### PR TITLE
Add supported behavior for file provider with default section

### DIFF
--- a/src/cbc_sdk/credential_providers/file_credential_provider.py
+++ b/src/cbc_sdk/credential_providers/file_credential_provider.py
@@ -125,8 +125,8 @@ class FileCredentialProvider(CredentialProvider):
         Raises:
             CredentialError: If there is any error retrieving the credentials.
         """
-        if not section:
-            raise CredentialError("Section must be specified")
+        if section is None:
+            section = 'default'
         if self._cached_credentials is None:
             new_creds = {}
             cred_files = [p for p in self._search_path if self._security_check(p)]

--- a/src/tests/unit/credential_providers/test_file.py
+++ b/src/tests/unit/credential_providers/test_file.py
@@ -156,8 +156,19 @@ def test_read_single_file():
         sut.get_credentials("notexist")
     with pytest.raises(CredentialError):
         sut.get_credentials("")
-    with pytest.raises(CredentialError):
-        sut.get_credentials()
+
+    # Default behavior for empty file credential behavior should use 'default' profile to match existing CBAPI behavior
+    creds = sut.get_credentials()
+    assert creds.url == "http://example.com"
+    assert creds.token == "ABCDEFGH"
+    assert creds.org_key == "A1B2C3D4"
+    assert not creds.ssl_verify
+    assert not creds.ssl_verify_hostname
+    assert creds.ssl_cert_file == "foo.certs"
+    assert creds.ssl_force_tls_1_2
+    assert creds.proxy == "proxy.example"
+    assert creds.ignore_system_proxy
+    assert creds.integration == "Covax"
 
 
 def test_read_multiple_files():


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
N/A

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
I remember being able to use `cb = CBCloudAPI()` which would use the default provide from the file credential provider in CBAPI. I've modified the FileCredentialProvider to use the `default` profile section

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Fixed an existing test around this functionality