### PR TITLE
Pip modules normalized names use dash instead of underscore

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -7,8 +7,8 @@ authentication for it, and executing a simple example program that makes one API
 
 Installation
 ------------
-Make sure you are using Python 3.  Use the command ``pip install carbon_black_cloud_sdk`` to install the SDK and all its dependencies.
-(In some environments, the correct command will be ``pip3 install carbon_black_cloud_sdk`` to use Python 3.)
+Make sure you are using Python 3.  Use the command ``pip install carbon-black-cloud-sdk`` to install the SDK and all its dependencies.
+(In some environments, the correct command will be ``pip3 install carbon-black-cloud-sdk`` to use Python 3.)
 
 You can also access the SDK in development mode by cloning the GitHub repository, and then executing
 ``python setup.py develop`` (in some environments, ``python3 setup.py develop``) from the top-level directory.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ The example scripts must be retrieved locally before they can be run.  The easie
 is by cloning the repository. You may also retrieve individual examples by viewing them on GitHub in "raw" mode and
 using your browser's `Save As...` function to save a copy locally. 
 
-To run the example scripts, first set up the Carbon Black Cloud SDK with either the `pip install carbon_black_cloud_sdk` or `python setup.py develop`
+To run the example scripts, first set up the Carbon Black Cloud SDK with either the `pip install carbon-black-cloud-sdk` or `python setup.py develop`
 commands as detailed in the top-level `README.md` file.  You may also set your `PYTHONPATH` environment variable to
 point to the `{cbc_sdk}/src` directory, where `{cbc_sdk}` refers to the top-level directory where you have cloned
 the Carbon Black Cloud SDK repository.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def read(fname):
 
 
 setup(
-    name='carbon_black_cloud_sdk',
+    name='carbon-black-cloud-sdk',
     version=read('VERSION'),
     url='https://github.com/carbonblack/carbon-black-cloud-sdk-python',
     license='MIT',


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
It does not generate an issue correctly because the normalization is automatically applied by "pip" and "pypi"

## Pull Request Description
carbon_black_cloud_sdk -> carbon-black-cloud-sdk
See https://www.python.org/dev/peps/pep-0503/#normalized-names and https://pypi.org/project/carbon-black-cloud-sdk/

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
I did not test the change in setup.py, and obviously I cannot submit to pypi so I let you check if it runs fine :)