### PR TITLE
Limit livequery results to 10k cap to prevent 400 Bad Request

### DIFF
--- a/src/cbc_sdk/audit_remediation/base.py
+++ b/src/cbc_sdk/audit_remediation/base.py
@@ -23,6 +23,8 @@ import time
 
 log = logging.getLogger(__name__)
 
+MAX_RESULTS_LIMIT = 10000
+
 
 """Audit and Remediation Models"""
 
@@ -810,6 +812,8 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin):
             result = resp.json()
 
             self._total_results = result["num_found"]
+            if self._total_results > MAX_RESULTS_LIMIT:
+                self._total_results = MAX_RESULTS_LIMIT
             self._count_valid = True
 
             results = result.get("results", [])

--- a/src/tests/unit/audit_remediation/test_audit_remediation_base.py
+++ b/src/tests/unit/audit_remediation/test_audit_remediation_base.py
@@ -12,7 +12,8 @@ from tests.unit.fixtures.audit_remediation.mock_runs import (GET_RUN_RESP,
                                                              GET_RUN_RESULTS_RESP_2,
                                                              GET_DEVICE_SUMMARY_RESP_1,
                                                              GET_RESULTS_FACETS_RESP,
-                                                             POST_RUN_HISTORY_RESP)
+                                                             POST_RUN_HISTORY_RESP,
+                                                             GET_RUN_RESULTS_RESP_OVER_10k)
 
 log = logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
 
@@ -241,3 +242,15 @@ def test_result_query_no_run_id_exception(cbcsdk_mock):
     with pytest.raises(ApiError):
         results = [res for res in result_query._perform_query()]
     assert results is None
+
+
+def test_result_query_over_10k(cbcsdk_mock):
+    """Testing Result._count() and ._perform_query() raising ApiError when a run_id is not supplied."""
+    api = cbcsdk_mock.api
+    cbcsdk_mock.mock_request("POST",
+                             "/livequery/v1/orgs/test/runs/run_id/results/_search",
+                             GET_RUN_RESULTS_RESP_OVER_10k)
+    result_query = api.select(Result).run_id("run_id")
+
+    list(result_query._perform_query())
+    assert result_query._total_results == 10000

--- a/src/tests/unit/fixtures/audit_remediation/mock_runs.py
+++ b/src/tests/unit/fixtures/audit_remediation/mock_runs.py
@@ -833,3 +833,24 @@ POST_RUN_HISTORY_RESP = {
         }
     ]
 }
+
+GET_RUN_RESULTS_RESP_OVER_10k = {
+    "org_key": "A1B2C3D4E5",
+    "num_found": 10001,
+    "results": [
+        {
+            "id": "run_id",
+            "device": {
+                "id": 12345,
+                "name": "deviceName0",
+                "policy_id": 98765,
+                "policy_name": "device0policy",
+                "os": "WINDOWS"
+            },
+            "status": "not_matched",
+            "time_received": "2020-09-22T09:53:48.313Z",
+            "device_message": "",
+            "fields": {}
+        }
+    ]
+}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
CBAPI-2233

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Live query results returns 400 Bad Request when attempting to fetch more than 10k results

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Added a new unit test