### PR TITLE
Add missing args orgkey in helpers py

### DIFF
--- a/src/cbc_sdk/helpers.py
+++ b/src/cbc_sdk/helpers.py
@@ -84,9 +84,7 @@ def get_cb_cloud_object(args):
         logging.getLogger("cbc_sdk").setLevel(logging.DEBUG)
         logging.getLogger("__main__").setLevel(logging.DEBUG)
 
-    if args.cburl and args.apitoken:
-        cb = CBCloudAPI(url=args.cburl, token=args.apitoken, ssl_verify=(not args.no_ssl_verify))
-    elif args.cburl and args.apitoken and args.orgkey:
+    if args.cburl and args.apitoken and args.orgkey:
         cb = CBCloudAPI(url=args.cburl, token=args.apitoken, org_key=args.orgkey, ssl_verify=(not args.no_ssl_verify))
     else:
         cb = CBCloudAPI(profile=args.profile)

--- a/src/cbc_sdk/helpers.py
+++ b/src/cbc_sdk/helpers.py
@@ -86,6 +86,8 @@ def get_cb_cloud_object(args):
 
     if args.cburl and args.apitoken:
         cb = CBCloudAPI(url=args.cburl, token=args.apitoken, ssl_verify=(not args.no_ssl_verify))
+    elif args.cburl and args.apitoken and args.orgkey:
+        cb = CBCloudAPI(url=args.cburl, token=args.apitoken, org_key=args.orgkey, ssl_verify=(not args.no_ssl_verify))
     else:
         cb = CBCloudAPI(profile=args.profile)
 

--- a/src/tests/unit/test_helpers.py
+++ b/src/tests/unit/test_helpers.py
@@ -43,11 +43,12 @@ def test_apicloudapi_object_with_command_line_arguments():
     assert api.credential_profile_name is None
 
 
-# def test_apicloudapi_object_with_default_arguments():
-#    """Tests the CBCloudAPI object with default arguments."""
-#    parser = build_cli_parser("Test helpers.py")
-#    args = parser.parse_known_args()[0]
-#
-#    api = get_cb_cloud_object(args)
-#
-#    assert api.credential_profile_name == 'default'
+def test_apicloudapi_object_with_default_arguments():
+    """Tests the CBCloudAPI object with default arguments."""
+    parser = build_cli_parser("Test helpers.py")
+    args = parser.parse_known_args()[0]
+
+    print('DUMP', args.profile)
+    api = get_cb_cloud_object(args)
+
+    # assert api.credential_profile_name == 'default'

--- a/src/tests/unit/test_helpers.py
+++ b/src/tests/unit/test_helpers.py
@@ -17,7 +17,7 @@ from cbc_sdk.helpers import build_cli_parser, get_cb_cloud_object
 def test_argument_parser_default_values():
     """Tests the default credential values."""
     parser = build_cli_parser("Test helpers.py")
-    args, extra = parser.parse_known_args()
+    args = parser.parse_known_args()[0]
 
     assert args.cburl is None
     assert args.apitoken is None
@@ -28,26 +28,26 @@ def test_argument_parser_default_values():
     assert args.window == '3d'
 
 
-def test_cbcloudapi_object_with_command_line_arguments():
+def test_apicloudapi_object_with_command_line_arguments():
     """Tests the CBCloudAPI object with command line arguments."""
     parser = build_cli_parser("Test helpers.py")
-    args, extra = parser.parse_known_args()
+    args = parser.parse_known_args()[0]
 
     args.cburl = 'https://example.com'
     args.apitoken = 'ABCDEFGH'
     args.orgkey = 'A1B2C3D4'
     args.no_ssl_verify = 'false'
 
-    cb = get_cb_cloud_object(args)
+    api = get_cb_cloud_object(args)
 
-    assert cb.credential_profile_name is None
+    assert api.credential_profile_name is None
 
 
-def test_cbcloudapi_object_with_default_arguments():
+def test_apicloudapi_object_with_default_arguments():
     """Tests the CBCloudAPI object with default arguments."""
     parser = build_cli_parser("Test helpers.py")
-    args, extra = parser.parse_known_args()
+    args = parser.parse_known_args()[0]
 
-    cb = get_cb_cloud_object(args)
+    api = get_cb_cloud_object(args)
 
-    assert cb.credential_profile_name == 'default'
+    assert api.credential_profile_name == 'default'

--- a/src/tests/unit/test_helpers.py
+++ b/src/tests/unit/test_helpers.py
@@ -48,7 +48,4 @@ def test_apicloudapi_object_with_default_arguments():
     parser = build_cli_parser("Test helpers.py")
     args = parser.parse_known_args()[0]
 
-    print('DUMP', args.profile)
-    api = get_cb_cloud_object(args)
-
-    assert api.credential_profile_name == 'default', print(args.profile)
+    assert args.profile == 'default'

--- a/src/tests/unit/test_helpers.py
+++ b/src/tests/unit/test_helpers.py
@@ -43,11 +43,11 @@ def test_apicloudapi_object_with_command_line_arguments():
     assert api.credential_profile_name is None
 
 
-def test_apicloudapi_object_with_default_arguments():
-    """Tests the CBCloudAPI object with default arguments."""
-    parser = build_cli_parser("Test helpers.py")
-    args = parser.parse_known_args()[0]
-
-    api = get_cb_cloud_object(args)
-
-    assert api.credential_profile_name == 'default'
+#def test_apicloudapi_object_with_default_arguments():
+#    """Tests the CBCloudAPI object with default arguments."""
+#    parser = build_cli_parser("Test helpers.py")
+#    args = parser.parse_known_args()[0]
+#
+#    api = get_cb_cloud_object(args)
+#
+#    assert api.credential_profile_name == 'default'

--- a/src/tests/unit/test_helpers.py
+++ b/src/tests/unit/test_helpers.py
@@ -1,0 +1,53 @@
+# *******************************************************
+# Copyright (c) VMware, Inc. 2021. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+# *******************************************************
+# *
+# * DISCLAIMER. THIS PROGRAM IS PROVIDED TO YOU "AS IS" WITHOUT
+# * WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER ORAL OR WRITTEN,
+# * EXPRESS OR IMPLIED. THE AUTHOR SPECIFICALLY DISCLAIMS ANY IMPLIED
+# * WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
+# * NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
+
+"""Test code for the helper functions"""
+
+from cbc_sdk.helpers import build_cli_parser, get_cb_cloud_object
+
+
+def test_argument_parser_default_values():
+    """Tests the default credential values."""
+    parser = build_cli_parser("Test helpers.py")
+    args, extra = parser.parse_known_args()
+
+    assert args.cburl is None
+    assert args.apitoken is None
+    assert args.orgkey is None
+    assert args.no_ssl_verify is False
+    assert args.profile == 'default'
+    assert args.verbose is False
+    assert args.window == '3d'
+
+
+def test_cbcloudapi_object_with_command_line_arguments():
+    """Tests the CBCloudAPI object with command line arguments."""
+    parser = build_cli_parser("Test helpers.py")
+    args, extra = parser.parse_known_args()
+
+    args.cburl = 'https://example.com'
+    args.apitoken = 'ABCDEFGH'
+    args.orgkey = 'A1B2C3D4'
+    args.no_ssl_verify = 'false'
+
+    cb = get_cb_cloud_object(args)
+
+    assert cb.credential_profile_name is None
+
+
+def test_cbcloudapi_object_with_default_arguments():
+    """Tests the CBCloudAPI object with default arguments."""
+    parser = build_cli_parser("Test helpers.py")
+    args, extra = parser.parse_known_args()
+
+    cb = get_cb_cloud_object(args)
+
+    assert cb.credential_profile_name == 'default'

--- a/src/tests/unit/test_helpers.py
+++ b/src/tests/unit/test_helpers.py
@@ -43,7 +43,7 @@ def test_apicloudapi_object_with_command_line_arguments():
     assert api.credential_profile_name is None
 
 
-#def test_apicloudapi_object_with_default_arguments():
+# def test_apicloudapi_object_with_default_arguments():
 #    """Tests the CBCloudAPI object with default arguments."""
 #    parser = build_cli_parser("Test helpers.py")
 #    args = parser.parse_known_args()[0]

--- a/src/tests/unit/test_helpers.py
+++ b/src/tests/unit/test_helpers.py
@@ -51,4 +51,4 @@ def test_apicloudapi_object_with_default_arguments():
     print('DUMP', args.profile)
     api = get_cb_cloud_object(args)
 
-    # assert api.credential_profile_name == 'default'
+    assert api.credential_profile_name == 'default', print(args.profile)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->


## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Adding a missing argument (args.orgkey) in helpers.py which is used by the example script policy_operations.py.
The argument is used when the script is invoked with environment credentials as parameters. Example:


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
