### PR TITLE
CBAPI-2290: add easy way to add single approvals and blocks

### DIFF
--- a/docs/device-control.rst
+++ b/docs/device-control.rst
@@ -7,7 +7,7 @@ the blocking of such devices from access by your endpoints.
 Retrieving the List of Known USB Devices
 ----------------------------------------
 
-Using a query of the `USBDevice` object, you can see which USB devices have been used on any endpoint in your
+Using a query of the ``USBDevice`` object, you can see which USB devices have been used on any endpoint in your
 organization.
 
 ::
@@ -24,14 +24,14 @@ organization.
     PNY USB 2.0 FD 07189613DD84E242 UNAPPROVED
     USB Flash Disk FBI1305031200020 APPROVED
 
-Note that individual USB devices may be `APPROVED` or `UNAPPROVED`. USB devices which are `UNAPPROVED` cannot be read
-on any endpoint with a policy that blocks unknown USB devices.
+Note that individual USB devices may be ``APPROVED`` or ``UNAPPROVED``. USB devices which are ``UNAPPROVED`` cannot
+be read on any endpoint with a policy that blocks unknown USB devices.
 
 Approving A Specific Device
 ---------------------------
 
-We can create one or more approvals for a specific USB device by using the `USBDeviceApproval` object and its
-`bulk_create` method.  First, we'll get a list of all unapproved USB devices.
+We can create an approval for a USB device by using the device's ``approve()`` method.  First, we'll get a list of all
+unapproved USB devices.
 
 ::
 
@@ -47,20 +47,38 @@ We can create one or more approvals for a specific USB device by using the `USBD
     SanDisk Cruzer Dial 4C530000110722114075
     PNY USB 2.0 FD 07189613DD84E242
 
-Now we'll select one of these devices and create an approval for it.
+Now we'll select one of these devices and approve it.
 
 ::
 
     >>> usb = usb_list[1]
-    >>> from cbc_sdk.endpoint_standard import USBDeviceApproval
-    >>> my_approval = {'serial_number': usb.serial_number, 'vendor_id': usb.vendor_id, 'product_id': usb.product_id,
-    ...                'approval_name': 'Test1', 'notes': 'API testing'}
-    >>> output = USBDeviceApproval.bulk_create(api, [my_approval])
-    >>> print(output[0].approval_name)
+    >>> print(usb.status)
+    UNAPPROVED
+    >>> approval = usb.approve('Test1', 'API Testing')
+    >>> print(approval.approval_name)
     Test1
-    >>> print(output[0].notes)
-    API testing
-    >>> print(output[0].id)
-    7c034be7-7386-3ef3-877d-e712bda803d6
+    >>> print(approval.notes)
+    API Testing
+    >>> print(approval.serial_number)
+    4C530000110722114075
+    >>> print(approval.id)
+    1ffd0a16-28ad-3fba-981d-d1c29c2903da
+    >>> print(usb.status)
+    APPROVED
 
-The `bulk_create` method returns a list of `USBDeviceApproval` objects representing the approvals created.
+The ``approve()`` method creates a ``USBDeviceApproval`` representing that particular device's approval, and
+also reloads the ``USBDevice`` so its ``status`` reflects the fact that it's been approved.
+
+Removing A Device's Approval
+----------------------------
+
+Device approvals may be removed via the API as well. Starting from the end of the previous example:
+
+    >>> approval.delete()
+    >>> usb.refresh()
+    True
+    >>> print(usb.status)
+    UNAPPROVED
+
+The ``delete()`` method is what causes the approval to be removed.  We then use ``refresh()`` on the actual
+``USBDevice`` object to allow its ``status`` to be updated.

--- a/src/tests/unit/endpoint_standard/test_usb_device.py
+++ b/src/tests/unit/endpoint_standard/test_usb_device.py
@@ -15,11 +15,14 @@
 
 import pytest
 import logging
-from cbc_sdk.endpoint_standard import USBDevice
+from cbc_sdk.endpoint_standard import USBDevice, USBDeviceApproval
 from cbc_sdk.rest_api import CBCloudAPI
 from cbc_sdk.errors import ApiError
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from tests.unit.fixtures.endpoint_standard.mock_usb_devices import (USBDEVICE_GET_RESP, USBDEVICE_GET_ENDPOINTS_RESP,
+                                                                    USBDEVICE_GET_RESP_BEFORE_APPROVE,
+                                                                    USBDEVICE_APPROVE_RESP,
+                                                                    USBDEVICE_GET_RESP_AFTER_APPROVE,
                                                                     USBDEVICE_QUERY_RESP, USBDEVICE_FACET_RESP,
                                                                     USBDEVICE_GET_PRODUCTS_RESP)
 
@@ -62,6 +65,49 @@ def test_usb_get_and_get_endpoints(cbcsdk_mock):
     assert endpoints[1]["id"] == "50"
     assert endpoints[1]["endpoint_id"] == 7579317
     assert endpoints[1]["policy_id"] == 6997287
+
+
+def test_usb_get_and_approve(cbcsdk_mock):
+    """Tests getting a USB device by ID and approving it, checking the resulting USBDeviceApproval as well."""
+    approval_saved = False
+    get_calls = 0
+
+    def getter_func(url, query_parameters, default):
+        nonlocal approval_saved, get_calls
+        get_calls = get_calls + 1
+        if approval_saved:
+            return USBDEVICE_GET_RESP_AFTER_APPROVE
+        else:
+            return USBDEVICE_GET_RESP_BEFORE_APPROVE
+
+    def approval_call(url, body, **kwargs):
+        assert len(body) == 1
+        request = body[0]
+        assert request["vendor_id"] == "0x0781"
+        assert request['product_id'] == "0x5581"
+        assert request['serial_number'] == "4C531001331122115172"
+        assert request['approval_name'] == 'ApproveTest'
+        assert request['notes'] == 'Approval notes'
+        nonlocal approval_saved
+        approval_saved = True
+        return USBDEVICE_APPROVE_RESP
+
+    cbcsdk_mock.mock_request("GET", "/device_control/v3/orgs/test/devices/808", getter_func)
+    cbcsdk_mock.mock_request("POST", "/device_control/v3/orgs/test/approvals/_bulk", approval_call)
+    api = cbcsdk_mock.api
+    usb = USBDevice(api, "808")
+    assert usb.vendor_name == "SanDisk"
+    assert usb.product_name == "Ultra"
+    assert usb.status == 'UNAPPROVED'
+    approval = usb.approve('ApproveTest', 'Approval notes')
+    assert approval.id == "12703"
+    assert approval.vendor_id == usb.vendor_id
+    assert approval.product_id == usb.product_id
+    assert approval.serial_number == usb.serial_number
+    assert approval.approval_name == 'ApproveTest'
+    assert approval.notes == 'Approval notes'
+    assert usb.status == 'APPROVED'
+    assert get_calls == 2
 
 
 def test_usb_query_with_all_bells_and_whistles(cbcsdk_mock):

--- a/src/tests/unit/endpoint_standard/test_usb_device.py
+++ b/src/tests/unit/endpoint_standard/test_usb_device.py
@@ -15,7 +15,7 @@
 
 import pytest
 import logging
-from cbc_sdk.endpoint_standard import USBDevice, USBDeviceApproval
+from cbc_sdk.endpoint_standard import USBDevice
 from cbc_sdk.rest_api import CBCloudAPI
 from cbc_sdk.errors import ApiError
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock

--- a/src/tests/unit/endpoint_standard/test_usb_device_approval.py
+++ b/src/tests/unit/endpoint_standard/test_usb_device_approval.py
@@ -15,7 +15,7 @@
 
 import pytest
 import logging
-from cbc_sdk.endpoint_standard import USBDevice
+from cbc_sdk.endpoint_standard import USBDeviceApproval, USBDevice
 from cbc_sdk.rest_api import CBCloudAPI
 from cbc_sdk.errors import ApiError
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock

--- a/src/tests/unit/endpoint_standard/test_usb_device_approval.py
+++ b/src/tests/unit/endpoint_standard/test_usb_device_approval.py
@@ -15,7 +15,7 @@
 
 import pytest
 import logging
-from cbc_sdk.endpoint_standard import USBDeviceApproval, USBDevice
+from cbc_sdk.endpoint_standard import USBDevice
 from cbc_sdk.rest_api import CBCloudAPI
 from cbc_sdk.errors import ApiError
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock

--- a/src/tests/unit/endpoint_standard/test_usb_device_block.py
+++ b/src/tests/unit/endpoint_standard/test_usb_device_block.py
@@ -21,6 +21,7 @@ from cbc_sdk.errors import ServerError
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from tests.unit.fixtures.endpoint_standard.mock_usb_devices import (USBDEVICE_BLOCK_GET_RESP,
                                                                     USBDEVICE_BLOCK_GET_ALL_RESP,
+                                                                    USBDEVICE_BLOCK_CREATE_RESP,
                                                                     USBDEVICE_BLOCK_BULK_CREATE_RESP)
 
 
@@ -83,6 +84,15 @@ def test_block_get_all_async(cbcsdk_mock):
     block = results[0]
     assert block._model_unique_id == 55
     assert block.policy_id == "6997287"
+
+
+def test_block_create(cbcsdk_mock):
+    """Tests the create function."""
+    cbcsdk_mock.mock_request("POST", "/device_control/v3/orgs/test/blocks/_bulk", USBDEVICE_BLOCK_CREATE_RESP)
+    api = cbcsdk_mock.api
+    block = USBDeviceBlock.create(api, "9686969")
+    assert block._model_unique_id == 44
+    assert block.policy_id == "9686969"
 
 
 def test_block_bulk_create(cbcsdk_mock):

--- a/src/tests/unit/fixtures/endpoint_standard/mock_usb_devices.py
+++ b/src/tests/unit/fixtures/endpoint_standard/mock_usb_devices.py
@@ -111,6 +111,17 @@ USBDEVICE_BLOCK_GET_ALL_RESP = {
     ]
 }
 
+USBDEVICE_BLOCK_CREATE_RESP = {
+    "results": [
+        {
+            "created_at": "2020-11-12T16:24:46.226Z",
+            "id": 44,
+            "policy_id": "9686969",
+            "updated_at": "2020-11-12T16:24:46.226Z"
+        }
+    ]
+}
+
 USBDEVICE_BLOCK_BULK_CREATE_RESP = {
     "results": [
         {
@@ -173,6 +184,63 @@ USBDEVICE_GET_ENDPOINTS_RESP = {
             "updated_at": "2020-10-21T16:36:01Z"
         }
     ]
+}
+
+USBDEVICE_GET_RESP_BEFORE_APPROVE = {
+    "id": "808",
+    "first_seen": "2020-10-20T19:47:02Z",
+    "last_seen": "2020-10-21T18:00:59Z",
+    "vendor_name": "SanDisk",
+    "vendor_id": "0x0781",
+    "product_name": "Ultra",
+    "product_id": "0x5581",
+    "serial_number": "4C531001331122115172",
+    "last_endpoint_name": "DESKTOP-IL2ON7C",
+    "last_endpoint_id": 7590378,
+    "last_policy_id": 6997287,
+    "endpoint_count": 2,
+    "device_friendly_name": "SanDisk Ultra USB Device",
+    "device_name": "\\Device\\HarddiskVolume30",
+    "created_at": "2020-10-20T19:59:06Z",
+    "updated_at": "2020-10-21T18:00:59Z",
+    "status": "UNAPPROVED"
+}
+
+USBDEVICE_APPROVE_RESP = {
+    "results": [
+        {
+            "id": "12703",
+            "vendor_id": "0x0781",
+            "vendor_name": "SanDisk",
+            "product_id": "0x5581",
+            "product_name": "Ultra",
+            "serial_number": "4C531001331122115172",
+            "created_at": "2020-11-05T23:51:56.396425Z",
+            "updated_at": "2020-11-11T23:05:42.048625Z",
+            "notes": "Approval notes",
+            "approval_name": "ApproveTest"
+        },
+    ]
+}
+
+USBDEVICE_GET_RESP_AFTER_APPROVE = {
+    "id": "808",
+    "first_seen": "2020-10-20T19:47:02Z",
+    "last_seen": "2020-10-21T18:00:59Z",
+    "vendor_name": "SanDisk",
+    "vendor_id": "0x0781",
+    "product_name": "Ultra",
+    "product_id": "0x5581",
+    "serial_number": "4C531001331122115172",
+    "last_endpoint_name": "DESKTOP-IL2ON7C",
+    "last_endpoint_id": 7590378,
+    "last_policy_id": 6997287,
+    "endpoint_count": 2,
+    "device_friendly_name": "SanDisk Ultra USB Device",
+    "device_name": "\\Device\\HarddiskVolume30",
+    "created_at": "2020-10-20T19:59:06Z",
+    "updated_at": "2020-10-21T18:00:59Z",
+    "status": "APPROVED"
 }
 
 USBDEVICE_QUERY_RESP = {


### PR DESCRIPTION
Also added the create_from_usb_device method as a quick way to create
approvals from a USB device, and the approve() method on USBDevice that
creates and saves a new USBDeviceApproval all in one go.  The sample doc has
been updated to use the new approve() functionality and also show approval
deletion.

## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-2290

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added the following changes:
* Updated save() behavior on USBDeviceApproval to allow it to create a new object.
* USBDeviceApproval.create_from_usb_device() to create a USBDeviceApproval object from a USBDevice object.
* approve() method on USBDevice to create and save a new approval for a USBDevice all in one go. (Bruce's suggestion!)
* USBDeviceBlock.create() to create a single USB device block object.

The Device Control guide has also been rewritten to show off the new functionality.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
New unit tests have been added that cover the new functionality.  Functionality was also exercised in the process of creating the transcripts as shown in the device control guide.