### PR TITLE
CBAPI-2282: Update Alerts in SDK to include Device Control Alerts

### DIFF
--- a/docs/device-control.rst
+++ b/docs/device-control.rst
@@ -82,3 +82,34 @@ Device approvals may be removed via the API as well. Starting from the end of th
 
 The ``delete()`` method is what causes the approval to be removed.  We then use ``refresh()`` on the actual
 ``USBDevice`` object to allow its ``status`` to be updated.
+
+Device Control Alerts
+---------------------
+
+When an endpoint attempts to access a blocked USB device (the endpoint has USB device blocking configured and the USB
+device is not approved), a ``DeviceControlAlert`` is generated.  These alerts may be queried using the standard
+Platform API components.
+
+::
+
+    >>> from cbc_sdk import CBCloudAPI
+    >>> api = CBCloudAPI(profile='sample')
+    >>> from cbc_sdk.platform import DeviceControlAlert
+    >>> query = api.select(DeviceControlAlert).where('1')
+    >>> alerts_list = list(query)
+    >>> print(len(alerts_list))
+    7
+    >>> for alert in alerts_list:
+    ...   print(f"{alert.vendor_name} {alert.product_name} {alert.serial_number}")
+    ...
+    USB Flash Disk FBI1305031200020
+    USB Flash Disk FBI1305031200020
+    USB Flash Disk FBI1305031200020
+    USB Flash Disk FBI1305031200020
+    PNY USB 2.0 FD 07189613DD84E242
+    PNY USB 2.0 FD 07189613DD84E242
+    PNY USB 2.0 FD 07189613DD84E242
+
+There are a number of fields supported by ``DeviceControlAlert`` over and above the standard alert fields; see
+`the developer documentation <https://developer.carbonblack.com/reference/carbon-black-cloud/platform/latest/alerts-api/#device-control-alert>`_
+for details.

--- a/docs/device-control.rst
+++ b/docs/device-control.rst
@@ -97,8 +97,6 @@ Platform API components.
     >>> from cbc_sdk.platform import DeviceControlAlert
     >>> query = api.select(DeviceControlAlert).where('1')
     >>> alerts_list = list(query)
-    >>> print(len(alerts_list))
-    7
     >>> for alert in alerts_list:
     ...   print(f"{alert.vendor_name} {alert.product_name} {alert.serial_number}")
     ...

--- a/src/cbc_sdk/platform/__init__.py
+++ b/src/cbc_sdk/platform/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from cbc_sdk.platform.base import PlatformModel
 
-from cbc_sdk.platform.alerts import (BaseAlert, WatchlistAlert, CBAnalyticsAlert,
+from cbc_sdk.platform.alerts import (BaseAlert, WatchlistAlert, CBAnalyticsAlert, DeviceControlAlert,
                                      Workflow, WorkflowStatus)
 
 from cbc_sdk.platform.devices import Device, DeviceSearchQuery

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -202,6 +202,25 @@ class CBAnalyticsAlert(BaseAlert):
         return CBAnalyticsAlertSearchQuery(cls, cb)
 
 
+class DeviceControlAlert(BaseAlert):
+    """Represents Device Control alerts."""
+    urlobject = "/appservices/v6/orgs/{0}/alerts/devicecontrol"
+
+    @classmethod
+    def _query_implementation(cls, cb, **kwargs):
+        """
+        Returns the appropriate query object for this alert type.
+
+        Args:
+            cb (BaseAPI): Reference to API object used to communicate with the server.
+            **kwargs (dict): Not used, retained for compatibility.
+
+        Returns:
+            DeviceControlAlertSearchQuery: The query object for this alert type.
+        """
+        return DeviceControlAlertSearchQuery(cls, cb)
+
+
 class Workflow(UnrefreshableModel):
     """Represents the workflow associated with alerts."""
     swagger_meta_file = "platform/models/workflow.yaml"
@@ -314,7 +333,7 @@ class BaseAlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMix
     VALID_CATEGORIES = ["THREAT", "MONITORED", "INFO", "MINOR", "SERIOUS", "CRITICAL"]
     VALID_REPUTATIONS = ["KNOWN_MALWARE", "SUSPECT_MALWARE", "PUP", "NOT_LISTED", "ADAPTIVE_WHITE_LIST",
                          "COMMON_WHITE_LIST", "TRUSTED_WHITE_LIST", "COMPANY_BLACK_LIST"]
-    VALID_ALERT_TYPES = ["CB_ANALYTICS", "WATCHLIST"]
+    VALID_ALERT_TYPES = ["CB_ANALYTICS", "DEVICE_CONTROL", "WATCHLIST"]
     VALID_WORKFLOW_VALS = ["OPEN", "DISMISSED"]
     VALID_FACET_FIELDS = ["ALERT_TYPE", "CATEGORY", "REPUTATION", "WORKFLOW", "TAG", "POLICY_ID",
                           "POLICY_NAME", "DEVICE_ID", "DEVICE_NAME", "APPLICATION_HASH",
@@ -1122,4 +1141,124 @@ class CBAnalyticsAlertSearchQuery(BaseAlertSearchQuery):
                    for vector in vectors):
             raise ApiError("One or more invalid threat cause vectors")
         self._update_criteria("threat_cause_vector", vectors)
+        return self
+
+
+class DeviceControlAlertSearchQuery(BaseAlertSearchQuery):
+    """Represents a query that is used to locate DeviceControlAlert objects."""
+
+    def __init__(self, doc_class, cb):
+        """
+        Initialize the CBAnalyticsAlertSearchQuery.
+
+        Args:
+            doc_class (class): The model class that will be returned by this query.
+            cb (BaseAPI): Reference to API object used to communicate with the server.
+        """
+        super().__init__(doc_class, cb)
+        self._bulkupdate_url = "/appservices/v6/orgs/{0}/alerts/cbanalytics/devicecontrol/_criteria"
+
+    def set_external_device_friendly_names(self, names):
+        """
+        Restricts the alerts that this query is performed on to the specified external device friendly names.
+
+        Args:
+            names (list): List of external device friendly names to look for.
+
+        Returns:
+            DeviceControlAlertSearchQuery: This instance.
+        """
+        if not all(isinstance(n, str) for n in names):
+            raise ApiError("One or more invalid device name values")
+        self._update_criteria("external_device_friendly_name", names)
+        return self
+
+    def set_external_device_ids(self, ids):
+        """
+        Restricts the alerts that this query is performed on to the specified external device IDs.
+
+        Args:
+            ids (list): List of external device IDs to look for.
+
+        Returns:
+            DeviceControlAlertSearchQuery: This instance.
+        """
+        if not all(isinstance(n, str) for n in ids):
+            raise ApiError("One or more invalid device ID values")
+        self._update_criteria("external_device_id", ids)
+        return self
+
+    def set_product_ids(self, ids):
+        """
+        Restricts the alerts that this query is performed on to the specified product IDs.
+
+        Args:
+            ids (list): List of product IDs to look for.
+
+        Returns:
+            DeviceControlAlertSearchQuery: This instance.
+        """
+        if not all(isinstance(n, str) for n in ids):
+            raise ApiError("One or more invalid product ID values")
+        self._update_criteria("product_id", ids)
+        return self
+
+    def set_product_names(self, names):
+        """
+        Restricts the alerts that this query is performed on to the specified product names.
+
+        Args:
+            names (list): List of product names to look for.
+
+        Returns:
+            DeviceControlAlertSearchQuery: This instance.
+        """
+        if not all(isinstance(n, str) for n in names):
+            raise ApiError("One or more invalid product name values")
+        self._update_criteria("product_name", names)
+        return self
+
+    def set_serial_numbers(self, serial_numbers):
+        """
+        Restricts the alerts that this query is performed on to the specified serial numbers.
+
+        Args:
+            serial_numbers (list): List of serial numbers to look for.
+
+        Returns:
+            DeviceControlAlertSearchQuery: This instance.
+        """
+        if not all(isinstance(n, str) for n in serial_numbers):
+            raise ApiError("One or more invalid serial number values")
+        self._update_criteria("serial_number", serial_numbers)
+        return self
+
+    def set_vendor_ids(self, ids):
+        """
+        Restricts the alerts that this query is performed on to the specified vendor IDs.
+
+        Args:
+            ids (list): List of vendor IDs to look for.
+
+        Returns:
+            DeviceControlAlertSearchQuery: This instance.
+        """
+        if not all(isinstance(n, str) for n in ids):
+            raise ApiError("One or more invalid vendor ID values")
+        self._update_criteria("vendor_id", ids)
+        return self
+
+    def set_vendor_names(self, names):
+        """
+        Restricts the alerts that this query is performed on to the specified vendor names.
+
+        Args:
+            names (list): List of vendor names to look for.
+
+        Returns:
+            DeviceControlAlertSearchQuery: This instance.
+        """
+        if not all(isinstance(n, str) for n in names):
+            raise ApiError("One or more invalid vendor name values")
+        self._update_criteria("vendor_name", names)
         return self

--- a/src/cbc_sdk/platform/models/base_alert.yaml
+++ b/src/cbc_sdk/platform/models/base_alert.yaml
@@ -111,7 +111,7 @@ properties:
     description: Type of the alert
     enum:
     - CB_ANALYTICS
-    - VMWARE
+    - DEVICE_CONTROL
     - WATCHLIST
   workflow:
     description: User-updatable status of the alert


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-2282

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Updated CBC SDK to include DeviceControlAlert and DeviceControlAlertSearchQuery, as well as the valid alert type of DEVICE_CONTROL.  The "device control" guide document has been extended with mention of device control alerts as well.

This PR should also close GitHub issue #117.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
New unit tests have been added to test the DeviceControlAlertSearchQuery in the same manner as other alert search queries.  Transcript in the new section of the device control guide is copied from an actual run session searching for the DeviceControlAlert.