### PR TITLE
Add full CredentialValue support to BaseAPI constructor

### DIFF
--- a/src/cbc_sdk/connection.py
+++ b/src/cbc_sdk/connection.py
@@ -362,17 +362,10 @@ class BaseAPI(object):
         integration_name = kwargs.pop("integration_name", None)
         self.credential_provider = kwargs.pop("credential_provider", None)
 
-        url, token, org_key = kwargs.pop("url", None), kwargs.pop("token", None), kwargs.pop("org_key", None)
+        url, token = kwargs.get("url", None), kwargs.get("token", None)
         if url and token:
-            if org_key:
-                credentials = {"url": url, "token": token, "org_key": org_key}
-            else:
-                credentials = {"url": url, "token": token}
-
-            for k in ("ssl_verify",):
-                if k in kwargs:
-                    credentials[k] = kwargs.pop(k)
-            self.credentials = Credentials(credentials)
+            self.credentials = Credentials(kwargs)
+            self.credentials.integration = integration_name
             self.credential_profile_name = None
         else:
             credential_file = kwargs.pop("credential_file", None)

--- a/src/tests/uat/proxy_test.py
+++ b/src/tests/uat/proxy_test.py
@@ -40,6 +40,8 @@ The following tinyproxy.conf file will allow all traffic to be accepted at port 
     # BasicAuth user password
 """
 
+import sys
+
 from cbc_sdk import CBCloudAPI
 from cbc_sdk.platform import Device
 
@@ -48,7 +50,17 @@ token = ''
 org_key = ''
 proxy = ''
 
-cb = CBCloudAPI(url=url, token=token, org_key=org_key, proxy=proxy, ssl_verify=False)
 
-assert type(cb.select(Device).first()) is Device
-print(f"Successfully fetched Device using proxy: {proxy}")
+def main():
+    """Script entry point"""
+    cb = CBCloudAPI(url=url, token=token, org_key=org_key, proxy=proxy, ssl_verify=False)
+
+    assert type(cb.select(Device).first()) is Device
+    print(f"Successfully fetched Device using proxy: {proxy}")
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")

--- a/src/tests/uat/proxy_test.py
+++ b/src/tests/uat/proxy_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# *******************************************************
+# Copyright (c) VMware, Inc. 2020-2021. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+# *******************************************************
+# *
+# * DISCLAIMER. THIS PROGRAM IS PROVIDED TO YOU "AS IS" WITHOUT
+# * WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER ORAL OR WRITTEN,
+# * EXPRESS OR IMPLIED. THE AUTHOR SPECIFICALLY DISCLAIMS ANY IMPLIED
+# * WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
+# * NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
+
+"""
+The following script verifies that an API call to a Carbon Black Cloud instance is able to route through a proxy.
+
+To execute, ensure have the following:
+* Carbon Black Cloud URL
+* API Token ({api_secret_key}/{api_id})
+* Organization Key
+* Proxy URL
+
+If you don't have a proxy configured consider setting up a proxy server using tinyproxy
+
+The following tinyproxy.conf file will allow all traffic to be accepted at port 8080
+
+    User nobody
+    Group nobody
+    Port 8080
+    Timeout 600
+    DefaultErrorFile "/usr/local/share/tinyproxy/default.html"
+    StatFile "/usr/local/share/tinyproxy/stats.html"
+    LogLevel Info
+    MaxClients 100
+    ViaProxyName "tinyproxy"
+
+    #
+    # Optional Authentication
+    # Proxy URL with authentication http://user:password@0.0.0.0:8080
+    #
+    # BasicAuth user password
+"""
+
+from cbc_sdk import CBCloudAPI
+from cbc_sdk.platform import Device
+
+url = ''
+token = ''
+org_key = ''
+proxy = ''
+
+cb = CBCloudAPI(url=url, token=token, org_key=org_key, proxy=proxy, ssl_verify=False)
+
+assert type(cb.select(Device).first()) is Device
+print(f"Successfully fetched Device using proxy: {proxy}")

--- a/src/tests/unit/test_base_api.py
+++ b/src/tests/unit/test_base_api.py
@@ -92,6 +92,30 @@ def test_BaseAPI_init_external_credential_provider_with_integration():
     assert sut.session.token_header['User-Agent'].startswith('Anthrax')
 
 
+def test_BaseAPI_all_options():
+    """Test initializing BaseAPI with all options."""
+    sut = BaseAPI(url='https://example.com',
+                  token='ABCDEFGHIJKLM',
+                  org_key='A1B2C3D4',
+                  integration_name='Anthrax',
+                  proxy='https://proxy.io:8080',
+                  ssl_verify=True,
+                  ssl_verify_hostname=True,
+                  ssl_force_tls_1_2=True)
+    assert sut.credentials.url == 'https://example.com'
+    assert sut.credentials.token == 'ABCDEFGHIJKLM'
+    assert sut.credentials.org_key == 'A1B2C3D4'
+    assert sut.credentials.integration == 'Anthrax'
+    assert sut.credentials.proxy == 'https://proxy.io:8080'
+    assert sut.credentials.ssl_verify is True
+    assert sut.credentials.ssl_verify_hostname is True
+    assert sut.credentials.ssl_force_tls_1_2 is True
+    assert sut.credential_profile_name is None
+    assert sut.session.server == 'https://example.com'
+    assert sut.session.token == 'ABCDEFGHIJKLM'
+    assert sut.session.token_header['User-Agent'].startswith('Anthrax')
+
+
 def test_BaseAPI_init_credential_provider_raises_error():
     """Test initializing the credentials when the provider raises an error."""
     creds = Credentials({'url': 'https://example.com', 'token': 'ABCDEFGHIJKLM', 'org_key': 'A1B2C3D4'})


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
CBAPI-2480

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
A few CredentialValue properties where not being loaded from the BaseAPI kwargs. Instead of popping all the values off, the kwargs can be passed through to the Credential object.

Added a basic UAT test for proxy testing

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Manual and unit tests