### PR TITLE
Enhance reputation_override_uat.py

### DIFF
--- a/src/tests/uat/reputation_override_uat.py
+++ b/src/tests/uat/reputation_override_uat.py
@@ -26,11 +26,10 @@ Reputation Override:
 """
 
 # Standard library imports
+import pytest
 import sys
 
 # Internal library imports
-import pytest
-
 from cbc_sdk.helpers import build_cli_parser, get_cb_cloud_object
 from cbc_sdk.platform import ReputationOverride
 from cbc_sdk.errors import ObjectNotFoundError

--- a/src/tests/uat/reputation_override_uat.py
+++ b/src/tests/uat/reputation_override_uat.py
@@ -29,6 +29,8 @@ Reputation Override:
 import sys
 
 # Internal library imports
+import pytest
+
 from cbc_sdk.helpers import build_cli_parser, get_cb_cloud_object
 from cbc_sdk.platform import ReputationOverride
 from cbc_sdk.errors import ObjectNotFoundError
@@ -132,20 +134,10 @@ def main():
 
     ReputationOverride.bulk_delete(cb, [it_tool_override.id, cert_override.id])
 
-    isDeleted = True
-    try:
+    with pytest.raises(ObjectNotFoundError):
         cb.select(ReputationOverride, it_tool_override.id)
-        isDeleted = False
-    except ObjectNotFoundError:
-        pass
-
-    try:
+    with pytest.raises(ObjectNotFoundError):
         cb.select(ReputationOverride, cert_override.id)
-        isDeleted = False
-    except ObjectNotFoundError:
-        pass
-
-    assert isDeleted
     print('Bulk Delete Reputation Overrides .............OK')
 
 

--- a/src/tests/uat/reputation_override_uat.py
+++ b/src/tests/uat/reputation_override_uat.py
@@ -59,7 +59,7 @@ def main():
                         .where("foo*") \
                         .set_override_list("BLACK_LIST") \
                         .set_override_type("SHA256") \
-                        .sort_by("create_time", "asc") \
+                        .sort_by("create_time", "desc") \
                         .first()
 
     assert sha256_override.sha256_hash == "af62e6b3d475879c4234fe7bd8ba67ff6544ce6510131a069aaac75aa92aee7a"
@@ -103,7 +103,7 @@ def main():
     it_tool_override = cb.select(ReputationOverride) \
                          .set_override_list("WHITE_LIST") \
                          .set_override_type("IT_TOOL") \
-                         .sort_by("create_time", "asc") \
+                         .sort_by("create_time", "desc") \
                          .first()
 
     assert it_tool_override.path == "C://tools//*.exe"
@@ -122,7 +122,7 @@ def main():
     cert_override = cb.select(ReputationOverride) \
                       .set_override_list("WHITE_LIST") \
                       .set_override_type("CERT") \
-                      .sort_by("create_time", "asc") \
+                      .sort_by("create_time", "desc") \
                       .first()
 
     assert cert_override.signed_by == "VMware Inc."
@@ -132,19 +132,20 @@ def main():
 
     ReputationOverride.bulk_delete(cb, [it_tool_override.id, cert_override.id])
 
-    delete_query = cb.select(ReputationOverride) \
-                     .set_override_list("WHITE_LIST") \
-                     .set_override_type("IT_TOOL") \
-                     .sort_by("create_time", "asc")
+    isDeleted = True
+    try:
+        cb.select(ReputationOverride, it_tool_override.id)
+        isDeleted = False
+    except ObjectNotFoundError:
+        pass
 
-    assert len(delete_query) == 0
+    try:
+        cb.select(ReputationOverride, cert_override.id)
+        isDeleted = False
+    except ObjectNotFoundError:
+        pass
 
-    delete_query = cb.select(ReputationOverride) \
-                     .set_override_list("WHITE_LIST") \
-                     .set_override_type("CERT") \
-                     .sort_by("create_time", "asc")
-
-    assert len(delete_query) == 0
+    assert isDeleted
     print('Bulk Delete Reputation Overrides .............OK')
 
 


### PR DESCRIPTION
Fix reputation_override_uat.py to work as expected when there are additional IT_TOOL and CERT reputation overrides for the same organisation

## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [ ] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-2542

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Currently the test works only on fresh environment. It fails if there are other reputation overrides of type IT_TOOLS or CERT in the organisation. The proposed solution resolves this issue.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
The test passes successfully when performed on non-fresh environment.
