### PR TITLE
CBAPI-2510: Add Permitted Roles API to SDK

### DIFF
--- a/src/cbc_sdk/platform/grants.py
+++ b/src/cbc_sdk/platform/grants.py
@@ -494,7 +494,7 @@ class Grant(MutableBaseModel):
             cb (CBCloudAPI): A reference to the CBCloudAPI object.
 
         Returns:
-            set: A set of string role URNs that we are permitted to manage (assign to users).
+            list: A list of string role URNs that we are permitted to manage (assign to users).
         """
         def _extractor(resp_data):
             """Pulls out all the lists of URN descriptors from the result."""
@@ -507,7 +507,7 @@ class Grant(MutableBaseModel):
                                                                                     token_split[1])
         data = list(_extractor(cb.get_object(url)))
         flat_data = [item for sublist in data for item in sublist]
-        return set([subitem['urn'] for subitem in flat_data if 'urn' in subitem])
+        return list(set([subitem['urn'] for subitem in flat_data if 'urn' in subitem]))
 
     @classmethod
     def create(cls, cb, template=None, **kwargs):

--- a/src/cbc_sdk/platform/grants.py
+++ b/src/cbc_sdk/platform/grants.py
@@ -500,8 +500,8 @@ class Grant(MutableBaseModel):
         def _extractor(resp_data):
             """Pulls out all the lists of URN descriptors from the result."""
             for d in resp_data.values():
-                for l in d.values():
-                    yield l
+                for ll in d.values():
+                    yield ll
 
         url = "/access/v3/orgs/{0}/users/{1}/roles/permitted?type=USER".format(cb.credentials.org_key, userid)
         data = list(_extractor(cb.get_object(url)))

--- a/src/cbc_sdk/platform/grants.py
+++ b/src/cbc_sdk/platform/grants.py
@@ -503,7 +503,7 @@ class Grant(MutableBaseModel):
                 for ll in d.values():
                     yield ll
 
-        url = "/access/v3/orgs/{0}/users/{1}/roles/permitted?type=USER".format(cb.credentials.org_key, userid)
+        url = "/access/v3/orgs/{0}/principals/{1}/roles/permitted".format(cb.credentials.org_key, userid)
         data = list(_extractor(cb.get_object(url)))
         flat_data = [item for sublist in data for item in sublist]
         return [subitem['urn'] for subitem in flat_data if 'urn' in subitem]

--- a/src/cbc_sdk/platform/grants.py
+++ b/src/cbc_sdk/platform/grants.py
@@ -486,6 +486,29 @@ class Grant(MutableBaseModel):
         self._refresh_if_needed(ret)
 
     @classmethod
+    def get_permitted_roles(cls, cb, userid):
+        """
+        Returns a list of all permitted roles that the specified user can have.
+
+        Args:
+            cb (CBCloudAPI): A reference to the CBCloudAPI object.
+            userid (int): ID of the user to get permitted roles for.
+
+        Returns:
+            list: A list of string role URNs that are permitted for the user.
+        """
+        def _extractor(resp_data):
+            """Pulls out all the lists of URN descriptors from the result."""
+            for d in resp_data.values():
+                for l in d.values():
+                    yield l
+
+        url = "/access/v3/orgs/{0}/users/{1}/roles/permitted?type=USER".format(cb.credentials.org_key, userid)
+        data = list(_extractor(cb.get_object(url)))
+        flat_data = [item for sublist in data for item in sublist]
+        return [subitem['urn'] for subitem in flat_data if 'urn' in subitem]
+
+    @classmethod
     def create(cls, cb, template=None, **kwargs):
         """
         Returns either a new Grant, or a GrantBuilder to begin the process of creating a new grant.

--- a/src/tests/unit/fixtures/platform/mock_grants.py
+++ b/src/tests/unit/fixtures/platform/mock_grants.py
@@ -261,7 +261,6 @@ QUERY_GRANT_RESP = {
     ]
 }
 
-
 DETAILS_GRANT1 = {
     "principal": "psc:user:test:3911",
     "expires": 0,
@@ -898,4 +897,56 @@ EXPECT_SET_EXPIRATION_2B = {
     "updated_by": "psc:user:FOO:BAR",
     "create_time": "2021-03-20T12:56:31.645Z",
     "update_time": "2021-03-20T12:56:31.645Z"
+}
+
+PERMITTED_ROLES_RESP = {
+    "additionalProp1": {
+        "additionalProp1": [
+            {
+                "urn": "psc:role::ALPHA",
+                "scoped": "psc:org:ABCD1234",
+                "name": "Support",
+                "desc": "The Alpha role.",
+                "disabled": False,
+                "capabilities": ["internal"],
+                "child_urn": "psc:role::ALPHA",
+                "created_by": "psc:user:ABCD1234:DEFG1234",
+                "updated_by": "psc:user:ABCD1234:DEFG1234",
+                "create_time": {},
+                "update_time": {}
+            }
+        ],
+        "additionalProp2": [
+            {
+                "urn": "psc:role::BRAVO",
+                "scoped": "psc:org:ABCD1234",
+                "name": "Support",
+                "desc": "The Bravo role.",
+                "disabled": False,
+                "capabilities": ["internal"],
+                "child_urn": "psc:role::BRAVO",
+                "created_by": "psc:user:ABCD1234:DEFG1234",
+                "updated_by": "psc:user:ABCD1234:DEFG1234",
+                "create_time": {},
+                "update_time": {}
+            }
+        ]
+    },
+    "additionalProp2": {
+        "additionalProp1": [
+            {
+                "urn": "psc:role::CHARLIE",
+                "scoped": "psc:org:ABCD1234",
+                "name": "Support",
+                "desc": "The Charlie role.",
+                "disabled": False,
+                "capabilities": ["internal"],
+                "child_urn": "psc:role::CHARLIE",
+                "created_by": "psc:user:ABCD1234:DEFG1234",
+                "updated_by": "psc:user:ABCD1234:DEFG1234",
+                "create_time": {},
+                "update_time": {}
+            }
+        ]
+    }
 }

--- a/src/tests/unit/fixtures/platform/mock_grants.py
+++ b/src/tests/unit/fixtures/platform/mock_grants.py
@@ -900,8 +900,8 @@ EXPECT_SET_EXPIRATION_2B = {
 }
 
 PERMITTED_ROLES_RESP = {
-    "additionalProp1": {
-        "additionalProp1": [
+    "results": {
+        "org1": [
             {
                 "urn": "psc:role::ALPHA",
                 "scoped": "psc:org:ABCD1234",
@@ -914,9 +914,7 @@ PERMITTED_ROLES_RESP = {
                 "updated_by": "psc:user:ABCD1234:DEFG1234",
                 "create_time": {},
                 "update_time": {}
-            }
-        ],
-        "additionalProp2": [
+            },
             {
                 "urn": "psc:role::BRAVO",
                 "scoped": "psc:org:ABCD1234",
@@ -930,10 +928,8 @@ PERMITTED_ROLES_RESP = {
                 "create_time": {},
                 "update_time": {}
             }
-        ]
-    },
-    "additionalProp2": {
-        "additionalProp1": [
+        ],
+        "org1:CHILDREN": [
             {
                 "urn": "psc:role::CHARLIE",
                 "scoped": "psc:org:ABCD1234",
@@ -942,6 +938,19 @@ PERMITTED_ROLES_RESP = {
                 "disabled": False,
                 "capabilities": ["internal"],
                 "child_urn": "psc:role::CHARLIE",
+                "created_by": "psc:user:ABCD1234:DEFG1234",
+                "updated_by": "psc:user:ABCD1234:DEFG1234",
+                "create_time": {},
+                "update_time": {}
+            },
+            {
+                "urn": "psc:role::BRAVO",
+                "scoped": "psc:org:ABCD1234",
+                "name": "Support",
+                "desc": "The Bravo role.",
+                "disabled": False,
+                "capabilities": ["internal"],
+                "child_urn": "psc:role::BRAVO",
                 "created_by": "psc:user:ABCD1234:DEFG1234",
                 "updated_by": "psc:user:ABCD1234:DEFG1234",
                 "create_time": {},

--- a/src/tests/unit/platform/test_grants.py
+++ b/src/tests/unit/platform/test_grants.py
@@ -381,7 +381,8 @@ def test_unsupported_query_profiles(cb):
 
 def test_get_permitted_roles(cbcsdk_mock):
     """Test the get_permitted_roles function."""
-    cbcsdk_mock.mock_request('GET', '/access/v3/orgs/test/principals/6023/roles/permitted', PERMITTED_ROLES_RESP)
+    cbcsdk_mock.mock_request('GET', '/access/v3/orgs/test/principals/1234/roles/permitted?type=USER',
+                             PERMITTED_ROLES_RESP)
     api = cbcsdk_mock.api
-    roles = Grant.get_permitted_roles(api, 6023)
-    assert roles == ["psc:role::ALPHA", "psc:role::BRAVO", "psc:role::CHARLIE"]
+    roles = Grant.get_permitted_roles(api)
+    assert roles == {"psc:role::ALPHA", "psc:role::BRAVO", "psc:role::CHARLIE"}

--- a/src/tests/unit/platform/test_grants.py
+++ b/src/tests/unit/platform/test_grants.py
@@ -10,7 +10,7 @@ from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from tests.unit.fixtures.platform.mock_grants import (GET_GRANT_RESP, PUT_GRANT_RESP, POST_GRANT_RESP,
                                                       POST_PROFILE_IN_GRANT_RESP, POST_PROFILE_IN_GRANT_RESP_2,
                                                       PUT_PROFILE_RESP, DELETE_PROFILE_RESP, DELETE_GRANT_RESP,
-                                                      QUERY_GRANT_RESP)
+                                                      QUERY_GRANT_RESP, PERMITTED_ROLES_RESP)
 
 logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
 
@@ -377,3 +377,11 @@ def test_unsupported_query_profiles(cb):
     """Make sure trying to do a direct query on Profile fails."""
     with pytest.raises(NonQueryableModel):
         cb.select(Grant.Profile)
+
+
+def test_get_permitted_roles(cbcsdk_mock):
+    """Test the get_permitted_roles function."""
+    cbcsdk_mock.mock_request('GET', '/access/v3/orgs/test/users/6023/roles/permitted?type=USER', PERMITTED_ROLES_RESP)
+    api = cbcsdk_mock.api
+    roles = Grant.get_permitted_roles(api, 6023)
+    assert roles == ["psc:role::ALPHA", "psc:role::BRAVO", "psc:role::CHARLIE"]

--- a/src/tests/unit/platform/test_grants.py
+++ b/src/tests/unit/platform/test_grants.py
@@ -381,7 +381,7 @@ def test_unsupported_query_profiles(cb):
 
 def test_get_permitted_roles(cbcsdk_mock):
     """Test the get_permitted_roles function."""
-    cbcsdk_mock.mock_request('GET', '/access/v3/orgs/test/users/6023/roles/permitted?type=USER', PERMITTED_ROLES_RESP)
+    cbcsdk_mock.mock_request('GET', '/access/v3/orgs/test/principals/6023/roles/permitted', PERMITTED_ROLES_RESP)
     api = cbcsdk_mock.api
     roles = Grant.get_permitted_roles(api, 6023)
     assert roles == ["psc:role::ALPHA", "psc:role::BRAVO", "psc:role::CHARLIE"]

--- a/src/tests/unit/platform/test_grants.py
+++ b/src/tests/unit/platform/test_grants.py
@@ -385,4 +385,4 @@ def test_get_permitted_roles(cbcsdk_mock):
                              PERMITTED_ROLES_RESP)
     api = cbcsdk_mock.api
     roles = Grant.get_permitted_roles(api)
-    assert roles == {"psc:role::ALPHA", "psc:role::BRAVO", "psc:role::CHARLIE"}
+    assert set(roles) == {"psc:role::ALPHA", "psc:role::BRAVO", "psc:role::CHARLIE"}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-2510

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added the get_permitted_roles API to the Grant class. This allows the user to fetch the roles that they are permitted to manage.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit test has been added for the new API. All added code is 100% covered. Coverage in grants.py remains at 99%.