### PR TITLE
CBAPI-2597: Handle Macro-Operations for Users with No Grant

### DIFF
--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -896,15 +896,12 @@ class IterableQueryMixin:
         res = self[:2]
         if res is None:
             return None
+        label = str(self._query) if self._query else "<unspecified>"
         if len(res) == 0:
-            raise ObjectNotFoundError(
-                message="0 results for query {0:s}".format(self._query)
-            )
+            raise ObjectNotFoundError("query_uri", message="0 results for query {0:s}".format(label))
         if len(res) > 1:
             raise MoreThanOneResultError(
-                message="{0:d} results found for query {1:s}".format(
-                    len(self), self._query
-                ),
+                message="{0:d} results found for query {1:s}".format(len(self), label),
                 results=self.all()
             )
         return res[0]

--- a/src/cbc_sdk/platform/users.py
+++ b/src/cbc_sdk/platform/users.py
@@ -251,12 +251,9 @@ class User(MutableBaseModel):
         """
         return f"psc:org:{self._cb.credentials.org_key}"
 
-    def grant(self, create=False):
+    def grant(self):
         """
         Locates the access grant for this user.
-
-        Args:
-            create (bool): If True and the user does not already have a grant, attempt to create one.
 
         Returns:
             Grant: Access grant for this user, or None if the user has none.
@@ -265,10 +262,6 @@ class User(MutableBaseModel):
         try:
             return query.one()
         except ObjectNotFoundError:
-            if create:
-                template = {'principal': self.urn, 'org_ref': self.org_urn, 'roles': [],
-                            'principal_name': f"{self.first_name} {self.last_name}", 'profiles': []}
-                return Grant.create(self._cb, template)
             return None
 
     @classmethod

--- a/src/cbc_sdk/platform/users.py
+++ b/src/cbc_sdk/platform/users.py
@@ -357,7 +357,7 @@ class User(MutableBaseModel):
             users (list[User]): List of User objects specifying users to be disabled.
         """
         for user in users:
-            user.disable_all_access()
+            user._disable_all_access()
 
     @classmethod
     def bulk_delete(cls, users):
@@ -370,14 +370,32 @@ class User(MutableBaseModel):
         for user in users:
             user.delete()
 
-    def disable_all_access(self):
-        """Disables all access profiles held by ths user."""
+    def _disable_all_access(self):
+        """
+        Disables all access profiles held by ths user.
+
+        Returns:
+            bool: True if this user was a "legacy" user (no grant), False otherwise.
+        """
         grant = self.grant()
         if grant:
             for profile in grant.profiles_:
                 profile.set_disabled(True)
                 grant.touch()
             grant.save()
+            return False
+        else:
+            return True
+
+    def disable_all_access(self):
+        """
+        Disables all access profiles held by ths user.
+
+        Raises:
+            ApiError: If the user is a "legacy" user that has no grant.
+        """
+        if self._disable_all_access():
+            raise ApiError("legacy user has no grant")
 
     def change_role(self, role_urn, org=None):
         """
@@ -387,6 +405,9 @@ class User(MutableBaseModel):
             role_urn (str): URN of the role to be added.
             org (str): If specified, only profiles that match this organization will have the role added.  Organization
                        may be specified as either an org key or a URN.
+
+        Raises:
+            ApiError: If the user is a "legacy" user that has no grant.
         """
         my_org = None if org is None else normalize_org(org)
         grant = self.grant()
@@ -404,6 +425,8 @@ class User(MutableBaseModel):
                 grant.roles += [role_urn]
                 grant.touch()
             grant.save()
+        else:
+            raise ApiError("legacy user has no grant")
 
     def _internal_add_profiles(self, profile_templates):
         """
@@ -436,6 +459,9 @@ class User(MutableBaseModel):
 
         Args:
             profile_templates (list[dict]): List of profile templates to be disabled.  Must be normalized.
+
+        Returns:
+            bool: True if this user was a "legacy" user (no grant), False otherwise.
         """
         grant = self.grant()
         if grant:
@@ -446,6 +472,9 @@ class User(MutableBaseModel):
                         grant.touch()
                         break
             grant.save()
+            return False
+        else:
+            return True
 
     def _internal_set_profile_expiration(self, profile_templates, expiration_date):
         """
@@ -454,6 +483,9 @@ class User(MutableBaseModel):
         Args:
             profile_templates (list[dict]): List of profile templates to be reset.  Must be normalized.
             expiration_date (str): New expiration date, in ISO 8601 format.
+
+        Returns:
+            bool: True if this user was a "legacy" user (no grant), False otherwise.
         """
         grant = self.grant()
         if grant:
@@ -464,6 +496,9 @@ class User(MutableBaseModel):
                         grant.touch()
                         break
             grant.save()
+            return False
+        else:
+            return True
 
     def add_profiles(self, profile_templates):
         """
@@ -482,10 +517,14 @@ class User(MutableBaseModel):
 
         Args:
             profile_templates (list[dict]): List of profile templates to be disabled.
+
+        Raises:
+            ApiError: If the user is a "legacy" user that has no grant.
         """
         my_profiles = normalize_profile_list(profile_templates)
         if my_profiles:
-            self._internal_disable_profiles(my_profiles)
+            if self._internal_disable_profiles(my_profiles):
+                raise ApiError("legacy user has no grant")
 
     def set_profile_expiration(self, profile_templates, expiration_date):
         """
@@ -494,10 +533,14 @@ class User(MutableBaseModel):
         Args:
             profile_templates (list[dict]): List of profile templates to be reset.
             expiration_date (str): New expiration date, in ISO 8601 format.
+
+        Raises:
+            ApiError: If the user is a "legacy" user that has no grant.
         """
         my_profiles = normalize_profile_list(profile_templates)
         if my_profiles:
-            self._internal_set_profile_expiration(my_profiles, expiration_date)
+            if self._internal_set_profile_expiration(my_profiles, expiration_date):
+                raise ApiError("legacy user has no grant")
 
 
 """User Queries"""

--- a/src/tests/unit/fixtures/platform/mock_grants.py
+++ b/src/tests/unit/fixtures/platform/mock_grants.py
@@ -981,3 +981,58 @@ NEW_DETAILS_GRANT5 = {
     "create_time": "2021-03-20T12:56:31.645Z",
     "update_time": "2021-03-20T12:56:31.645Z"
 }
+
+EXPECT_NEW_GRANT_5A = {
+    "principal": "psc:user:test:3978",
+    'org_ref': 'psc:org:test',
+    'roles': [],
+    'principal_name': "Beckett Mariner",
+    'profiles': PROFILE_TEMPLATES_A
+}
+
+POST_GRANT_RESP_5A = {
+    "principal": "psc:user:test:3978",
+    "expires": 0,
+    "revoked": False,
+    "roles": [
+    ],
+    "profiles": [
+        {
+            "orgs": {
+                "allow": [
+                    "psc:org:test2"
+                ],
+            },
+            "roles": [
+                "psc:role::SECOPS_ROLE_MANAGER",
+                "psc:role:test:ALPHA_ROLE"
+            ],
+            "conditions": {
+                "expiration": 0,
+                "disabled": False
+            },
+            "can_manage": False
+        },
+        {
+            "orgs": {
+                "allow": [
+                    "psc:org:test_infinity"
+                ],
+            },
+            "roles": [
+                "psc:role::SECOPS_ROLE_MANAGER"
+            ],
+            "conditions": {
+                "expiration": 0,
+                "disabled": False
+            },
+            "can_manage": False
+        }
+    ],
+    "org_ref": "psc:org:test",
+    "principal_name": "Beckett Mariner",
+    "created_by": "psc:user:FOO:BAR",
+    "updated_by": "psc:user:FOO:BAR",
+    "create_time": "2021-03-20T12:56:31.645Z",
+    "update_time": "2021-03-20T12:56:31.645Z"
+}

--- a/src/tests/unit/fixtures/platform/mock_grants.py
+++ b/src/tests/unit/fixtures/platform/mock_grants.py
@@ -959,3 +959,25 @@ PERMITTED_ROLES_RESP = {
         ]
     }
 }
+
+EXPECT_CREATE_TEMPLATE5 = {
+    'principal': 'psc:user:test:3978',
+    'org_ref': 'psc:org:test',
+    'roles': [],
+    'principal_name': "Beckett Mariner",
+    'profiles': []
+}
+
+NEW_DETAILS_GRANT5 = {
+    "principal": "psc:user:test:3978",
+    "expires": 0,
+    "revoked": False,
+    "roles": [],
+    "profiles": [],
+    "org_ref": "psc:org:test",
+    "principal_name": "Beckett Mariner",
+    "created_by": "psc:user:FOO:BAR",
+    "updated_by": "psc:user:FOO:BAR",
+    "create_time": "2021-03-20T12:56:31.645Z",
+    "update_time": "2021-03-20T12:56:31.645Z"
+}

--- a/src/tests/unit/fixtures/platform/mock_grants.py
+++ b/src/tests/unit/fixtures/platform/mock_grants.py
@@ -960,28 +960,6 @@ PERMITTED_ROLES_RESP = {
     }
 }
 
-EXPECT_CREATE_TEMPLATE5 = {
-    'principal': 'psc:user:test:3978',
-    'org_ref': 'psc:org:test',
-    'roles': [],
-    'principal_name': "Beckett Mariner",
-    'profiles': []
-}
-
-NEW_DETAILS_GRANT5 = {
-    "principal": "psc:user:test:3978",
-    "expires": 0,
-    "revoked": False,
-    "roles": [],
-    "profiles": [],
-    "org_ref": "psc:org:test",
-    "principal_name": "Beckett Mariner",
-    "created_by": "psc:user:FOO:BAR",
-    "updated_by": "psc:user:FOO:BAR",
-    "create_time": "2021-03-20T12:56:31.645Z",
-    "update_time": "2021-03-20T12:56:31.645Z"
-}
-
 EXPECT_NEW_GRANT_5A = {
     "principal": "psc:user:test:3978",
     'org_ref': 'psc:org:test',

--- a/src/tests/unit/platform/test_users.py
+++ b/src/tests/unit/platform/test_users.py
@@ -3,6 +3,7 @@ import copy
 
 import pytest
 import logging
+from contextlib import ExitStack as does_not_raise
 from cbc_sdk.platform import User
 from cbc_sdk.rest_api import CBCloudAPI
 from cbc_sdk.errors import ApiError, ObjectNotFoundError, ServerError
@@ -473,12 +474,12 @@ def test_bulk_delete(cbcsdk_mock):
     assert deleted_users == set(id_list)
 
 
-@pytest.mark.parametrize('login_id, grant_get, expect_put', [
-    (3934, DETAILS_GRANT2, EXPECT_DISABLE_ALL_GRANT2),
-    (3911, DETAILS_GRANT1, None),
-    (3978, None, None)
+@pytest.mark.parametrize('login_id, grant_get, expect_put, except_context', [
+    (3934, DETAILS_GRANT2, EXPECT_DISABLE_ALL_GRANT2, does_not_raise()),
+    (3911, DETAILS_GRANT1, None, does_not_raise()),
+    (3978, None, None, pytest.raises(ApiError))
 ])
-def test_disable_all_access(cbcsdk_mock, login_id, grant_get, expect_put):
+def test_disable_all_access(cbcsdk_mock, login_id, grant_get, expect_put, except_context):
     """Tests the User.disable_all_access method"""
     put_was_called = False
 
@@ -494,27 +495,30 @@ def test_disable_all_access(cbcsdk_mock, login_id, grant_get, expect_put):
     cbcsdk_mock.mock_request('PUT', f'/access/v2/orgs/test/grants/psc:user:test:{login_id}', on_put)
     api = cbcsdk_mock.api
     user = api.select(User).user_ids([login_id]).one()
-    user.disable_all_access()
+    with except_context:
+        user.disable_all_access()
     if expect_put is None:
         assert not put_was_called
     else:
         assert put_was_called
 
 
-@pytest.mark.parametrize('user_email, user_loginid, grant_get, new_role, org, expect_put', [
+@pytest.mark.parametrize('user_email, user_loginid, grant_get, new_role, org, expect_put, except_context', [
     ('emercer@orville.planetary-union.net', 3911, DETAILS_GRANT1, 'psc:role:test:NEW_ROLE', None,
-     EXPECT_CHANGE_ROLE_GRANT1),
-    ('emercer@orville.planetary-union.net', 3911, DETAILS_GRANT1, 'psc:role:test:APP_SERVICE_ROLE', None, None),
+     EXPECT_CHANGE_ROLE_GRANT1, does_not_raise()),
+    ('emercer@orville.planetary-union.net', 3911, DETAILS_GRANT1, 'psc:role:test:APP_SERVICE_ROLE', None, None,
+     does_not_raise()),
     ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, 'psc:role:test:ALPHA_ROLE', None,
-     EXPECT_CHANGE_ROLE_GRANT2A),
+     EXPECT_CHANGE_ROLE_GRANT2A, does_not_raise()),
     ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, 'psc:role:test:ALPHA_ROLE', 'psc:org:test3',
-     EXPECT_CHANGE_ROLE_GRANT2B),
+     EXPECT_CHANGE_ROLE_GRANT2B, does_not_raise()),
     ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, 'psc:role:test:ALPHA_ROLE', 'test3',
-     EXPECT_CHANGE_ROLE_GRANT2B),
-    ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, 'psc:role::SECOPS_ROLE_MANAGER', None, None),
-    ("bmariner@cerritos.starfleet.mil", 3978, None, 'psc:role::SECOPS_ROLE_MANAGER', None, None)
+     EXPECT_CHANGE_ROLE_GRANT2B, does_not_raise()),
+    ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, 'psc:role::SECOPS_ROLE_MANAGER', None, None, does_not_raise()),
+    ("bmariner@cerritos.starfleet.mil", 3978, None, 'psc:role::SECOPS_ROLE_MANAGER', None, None,
+     pytest.raises(ApiError))
 ])
-def test_change_role(cbcsdk_mock, user_email, user_loginid, grant_get, new_role, org, expect_put):
+def test_change_role(cbcsdk_mock, user_email, user_loginid, grant_get, new_role, org, expect_put, except_context):
     """Tests the User.change_role method"""
     put_was_called = False
 
@@ -530,7 +534,8 @@ def test_change_role(cbcsdk_mock, user_email, user_loginid, grant_get, new_role,
     cbcsdk_mock.mock_request('PUT', f'/access/v2/orgs/test/grants/psc:user:test:{user_loginid}', on_put)
     api = cbcsdk_mock.api
     user = api.select(User).email_addresses([user_email]).one()
-    user.change_role(new_role, org)
+    with except_context:
+        user.change_role(new_role, org)
     if expect_put is None:
         assert not put_was_called
     else:
@@ -623,14 +628,14 @@ def test_add_profiles_with_new_grant(cbcsdk_mock):
     assert post_was_called
 
 
-@pytest.mark.parametrize('user_email, user_loginid, grant_get, profiles, expect_put', [
-    ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, [], None),
-    ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, PROFILE_TEMPLATES_B, EXPECT_DISABLE_2B),
-    ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, PROFILE_TEMPLATES_C, None),
-    ('emercer@orville.planetary-union.net', 3911, DETAILS_GRANT1, PROFILE_TEMPLATES_B, None),
-    ('bmariner@cerritos.starfleet.mil', 3978, None, PROFILE_TEMPLATES_B, None)
+@pytest.mark.parametrize('user_email, user_loginid, grant_get, profiles, expect_put, except_context', [
+    ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, [], None, does_not_raise()),
+    ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, PROFILE_TEMPLATES_B, EXPECT_DISABLE_2B, does_not_raise()),
+    ('mreynolds@browncoats.org', 3934, DETAILS_GRANT2, PROFILE_TEMPLATES_C, None, does_not_raise()),
+    ('emercer@orville.planetary-union.net', 3911, DETAILS_GRANT1, PROFILE_TEMPLATES_B, None, does_not_raise()),
+    ('bmariner@cerritos.starfleet.mil', 3978, None, PROFILE_TEMPLATES_B, None, pytest.raises(ApiError))
 ])
-def test_disable_profiles(cbcsdk_mock, user_email, user_loginid, grant_get, profiles, expect_put):
+def test_disable_profiles(cbcsdk_mock, user_email, user_loginid, grant_get, profiles, expect_put, except_context):
     """Test the User.disable_profiles method."""
     put_was_called = False
 
@@ -646,21 +651,22 @@ def test_disable_profiles(cbcsdk_mock, user_email, user_loginid, grant_get, prof
     cbcsdk_mock.mock_request('PUT', f'/access/v2/orgs/test/grants/psc:user:test:{user_loginid}', on_put)
     api = cbcsdk_mock.api
     user = api.select(User).email_addresses([user_email]).one()
-    user.disable_profiles(profiles)
+    with except_context:
+        user.disable_profiles(profiles)
     if expect_put is None:
         assert not put_was_called
     else:
         assert put_was_called
 
 
-@pytest.mark.parametrize('login_id, grant_get, profiles, expect_put', [
-    (3934, DETAILS_GRANT2, [], None),
-    (3934, DETAILS_GRANT2, PROFILE_TEMPLATES_B, EXPECT_SET_EXPIRATION_2B),
-    (3934, DETAILS_GRANT2, PROFILE_TEMPLATES_C, None),
-    (3911, DETAILS_GRANT1, PROFILE_TEMPLATES_B, None),
-    (3978, None, PROFILE_TEMPLATES_B, None),
+@pytest.mark.parametrize('login_id, grant_get, profiles, expect_put, except_context', [
+    (3934, DETAILS_GRANT2, [], None, does_not_raise()),
+    (3934, DETAILS_GRANT2, PROFILE_TEMPLATES_B, EXPECT_SET_EXPIRATION_2B, does_not_raise()),
+    (3934, DETAILS_GRANT2, PROFILE_TEMPLATES_C, None, does_not_raise()),
+    (3911, DETAILS_GRANT1, PROFILE_TEMPLATES_B, None, does_not_raise()),
+    (3978, None, PROFILE_TEMPLATES_B, None, pytest.raises(ApiError)),
 ])
-def test_set_profile_expiration(cbcsdk_mock, login_id, grant_get, profiles, expect_put):
+def test_set_profile_expiration(cbcsdk_mock, login_id, grant_get, profiles, expect_put, except_context):
     """Test the User.set_profile_expiration method."""
     put_was_called = False
 
@@ -676,7 +682,8 @@ def test_set_profile_expiration(cbcsdk_mock, login_id, grant_get, profiles, expe
     cbcsdk_mock.mock_request('PUT', f'/access/v2/orgs/test/grants/psc:user:test:{login_id}', on_put)
     api = cbcsdk_mock.api
     user = api.select(User).user_ids([login_id]).one()
-    user.set_profile_expiration(profiles, '20111031T12:34:56')
+    with except_context:
+        user.set_profile_expiration(profiles, '20111031T12:34:56')
     if expect_put is None:
         assert not put_was_called
     else:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-2597

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
I found a serious flaw in a lot of the macro-operations. They don't take into account that users might not _have_ grants.  ( _None_ of the users I can access from dev01 has a grant.)  This adds some defensive code to manage those cases.  For most of these, "user has no grant" becomes a no-op. For some things, like "add profiles," adding them to a user with no grant _creates_ a grant with the profiles to be added.  The grant() operation also offers an optional parameter to create a new grant for a user if they don't have one already.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been expanded to cover the no-grant cases, corresponding to the changes in the code.  Test coverage stands at 100% for users.py.