### PR TITLE
[DO NOT MERGE] Remove unneeded quotes in Watchlist guide

### DIFF
--- a/docs/watchlists-feeds-reports.rst
+++ b/docs/watchlists-feeds-reports.rst
@@ -65,7 +65,7 @@ report associated with a watchlist, you must look in the watchlist's ``reports``
 ::
 
     >>> from cbc_sdk.enterprise_edr import Watchlist, Report, IOC_V2
-    >>> watchlist = api.select('Watchlist', 'R4cMgFIhRaakgk749MRr6Q')
+    >>> watchlist = api.select(Watchlist, 'R4cMgFIhRaakgk749MRr6Q')
     >>> report_list = [report for report in watchlist.reports where report.id == '47474d40-1f94-4995-b6d9-1d1eea3528b3']
     >>> report = report_list[0]
     >>> report.append_iocs([IOC_V2.create_query(api, 'evil-connect', 'netconn_ipv4:10.8.16.4')])

--- a/docs/watchlists-feeds-reports.rst
+++ b/docs/watchlists-feeds-reports.rst
@@ -66,7 +66,7 @@ report associated with a watchlist, you must look in the watchlist's ``reports``
 
     >>> from cbc_sdk.enterprise_edr import Watchlist, Report, IOC_V2
     >>> watchlist = api.select(Watchlist, 'R4cMgFIhRaakgk749MRr6Q')
-    >>> report_list = [report for report in watchlist.reports where report.id == '47474d40-1f94-4995-b6d9-1d1eea3528b3']
+    >>> report_list = [report for report in watchlist.reports if report.id == '47474d40-1f94-4995-b6d9-1d1eea3528b3']
     >>> report = report_list[0]
     >>> report.append_iocs([IOC_V2.create_query(api, 'evil-connect', 'netconn_ipv4:10.8.16.4')])
     >>> report.save_watchlist()

--- a/examples/enterprise_edr/which_watchlists.py
+++ b/examples/enterprise_edr/which_watchlists.py
@@ -1,0 +1,33 @@
+import sys
+from cbc_sdk.enterprise_edr import Feed, Report, Watchlist, WatchlistQuery
+from cbc_sdk.helpers import eprint, build_cli_parser, get_cb_cloud_object
+import json
+
+from cbc_sdk import CBCloudAPI
+api = CBCloudAPI(profile='default')
+
+# >>> from cbc_sdk.enterprise_edr import Report, IOC_V2
+# >>> builder = Report.create(api, "Unsigned Browsers", "Unsigned processes impersonating browsers", 5)
+# >>> builder.add_tag("compliance").add_tag("unsigned_browsers")
+# >>> builder.add_ioc(IOC_V2.create_query(api, "unsigned-chrome",
+# ...                 "process_name:chrome.exe NOT process_publisher_state:FILE_SIGNATURE_STATE_SIGNED"))
+# >>> report = builder.build()
+# >>> report.save_watchlist()
+
+watchlists = WatchlistQuery(Watchlist, api)
+
+# watchlist = watchlists[2]
+# print(">>> " + watchlist.name)
+
+for watchlist in watchlists:
+    for report_id in watchlist.report_ids:
+        if report_id == "GUmF3BmITp2lLYA7YKKLeA":
+            print(watchlist.name)
+            print(watchlist.reports)
+
+            # report = Report.get(api, report_id)
+            # print(">>> Report named " + report.name)
+
+            # report = watchlist.reports where report.id
+            
+            # report_list = [report for report in watchlist.reports where report.id == report_id]

--- a/examples/platform/list_process.py
+++ b/examples/platform/list_process.py
@@ -1,0 +1,9 @@
+from cbc_sdk import CBCloudAPI
+from cbc_sdk.platform import Device
+
+device_id = 9301703
+
+cb = CBCloudAPI()
+live_response = cb.select(Device, device_id).lr_session()
+
+print(live_response.list_processes())


### PR DESCRIPTION
## Pull request checklist

## Pull Request Description

I think the api.select takes Watchlist as an object not a string

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How Has This Been Tested?

I walked the example code myself and received a **TypeError: 'str' object is not callable** when running the line in question