### PR TITLE
Cbapi-2988: Resolve: EnrichedEvent search Error: TypeError: TimeoutError does not take keyword arguments

### DIFF
--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -22,7 +22,7 @@ from .utils import convert_from_cb, convert_to_cb
 import yaml
 import json
 import time
-from .errors import ApiError, ServerError, InvalidObjectError, MoreThanOneResultError, ObjectNotFoundError
+from .errors import ApiError, ServerError, InvalidObjectError, MoreThanOneResultError, ObjectNotFoundError, TimeoutError
 import logging
 from datetime import datetime
 from solrq import Q

--- a/src/cbc_sdk/endpoint_standard/base.py
+++ b/src/cbc_sdk/endpoint_standard/base.py
@@ -17,7 +17,7 @@ from cbc_sdk.base import (MutableBaseModel, UnrefreshableModel, CreatableModelMi
                           PaginatedQuery, QueryBuilder, QueryBuilderSupportMixin, IterableQueryMixin)
 from cbc_sdk.base import Query as BaseEventQuery
 from cbc_sdk.utils import convert_query_params
-from cbc_sdk.errors import ApiError
+from cbc_sdk.errors import ApiError, TimeoutError
 from cbc_sdk.platform.reputation import ReputationOverride
 from copy import deepcopy
 from pathlib import Path

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -14,7 +14,7 @@
 """Model and Query Classes for Platform Alerts and Workflows"""
 import time
 
-from cbc_sdk.errors import ApiError
+from cbc_sdk.errors import ApiError, TimeoutError
 from cbc_sdk.platform import PlatformModel
 from cbc_sdk.base import (BaseQuery,
                           UnrefreshableModel,

--- a/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events.py
+++ b/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events.py
@@ -5,7 +5,7 @@ import logging
 from cbc_sdk.endpoint_standard import EnrichedEvent
 from cbc_sdk.endpoint_standard.base import EnrichedEventQuery
 from cbc_sdk.rest_api import CBCloudAPI
-from cbc_sdk.errors import ApiError
+from cbc_sdk.errors import ApiError, TimeoutError
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from tests.unit.fixtures.endpoint_standard.mock_enriched_events import (
     GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_ZERO,

--- a/src/tests/unit/fixtures/endpoint_standard/mock_enriched_events.py
+++ b/src/tests/unit/fixtures/endpoint_standard/mock_enriched_events.py
@@ -169,8 +169,8 @@ GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_2 = {
 GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING = {
     "num_found": 808,
     "num_available": 1,
-    "contacted": 0,
-    "completed": 6,
+    "contacted": 6,
+    "completed": 0,
     "results": [],
 }
 

--- a/src/tests/unit/fixtures/endpoint_standard/mock_enriched_events_facet.py
+++ b/src/tests/unit/fixtures/endpoint_standard/mock_enriched_events_facet.py
@@ -52,5 +52,12 @@ GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_2 = {
     'num_found': 116,
     'contacted': 34,
     'completed': 34
+}
 
+GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING = {
+    'ranges': [],
+    'terms': [],
+    'num_found': 0,
+    'contacted': 34,
+    'completed': 0
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-2988

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Fixed imports in endpoint_standard/base.py, cbc_sdk/base.py, and platform/alerts.py to import the SDK TimeoutError rather than vanilla TimeoutError (which does not take keyword arguments).  Also added tests to make sure our TimeoutError is thrown properly where it ought to be.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
New unit tests have been added to make sure our TimeoutError is thrown properly where it ought to be.  Unit test has been tested by removing the new import and seeing that new test errors out.