### PR TITLE
Disable keyring for non darwin systems

### DIFF
--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -4,8 +4,7 @@ MAINTAINER cb-developer-network@vmware.com
 COPY . /app
 WORKDIR /app
 
-RUN dnf install -y redhat-rpm-config gcc libffi-devel python3-devel openssl-devel cargo
-RUN pip3 install setuptools-rust
+RUN dnf install -y redhat-rpm-config gcc libffi-devel python3-devel openssl-devel
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 RUN pip3 install .

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ protobuf
 schema
 solrq
 validators
-keyring
+keyring;platform_system=='Darwin'
 
 # Dev dependencies
 pytest==5.4.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'schema',
     'solrq',
     'validators',
-    "keyring"
+    "keyring;platform_system=='Darwin'"
 ]
 
 tests_requires = [

--- a/src/cbc_sdk/credential_providers/__init__.py
+++ b/src/cbc_sdk/credential_providers/__init__.py
@@ -3,4 +3,9 @@ from __future__ import absolute_import
 from .file_credential_provider import FileCredentialProvider
 from .environ_credential_provider import EnvironCredentialProvider
 from .registry_credential_provider import RegistryCredentialProvider
-from .keychain_credential_provider import KeychainCredentialProvider
+
+import platform
+
+# Only import if macOS
+if platform.system() == 'Darwin':
+    from .keychain_credential_provider import KeychainCredentialProvider

--- a/src/tests/unit/credential_providers/test_keychain.py
+++ b/src/tests/unit/credential_providers/test_keychain.py
@@ -13,7 +13,11 @@
 
 import sys
 import pytest
-from cbc_sdk.credential_providers.keychain_credential_provider import KeychainCredentialProvider
+import platform
+
+if platform.system() == 'Darwin':
+    from cbc_sdk.credential_providers.keychain_credential_provider import KeychainCredentialProvider
+
 from cbc_sdk.errors import CredentialError
 
 INVALID_JSON = """{\nurl: "http://example.test/",\n"token" : "TTTTT/TTTTT",\n"org_key": "TT123TT",
@@ -24,6 +28,7 @@ VALID_JSON = """{\n"url": "http://example.test/",\n"token" : "TTTTT/TTTTT",\n"or
     \n"proxy": "proxy.example",\n"ignore_system_proxy": true,\n"integration": "test"\n} """
 
 
+@pytest.mark.skipif(platform.system() != 'Darwin', reason="only run on mac os")
 def test_breaks_not_on_macos(monkeypatch):
     """Test that creating the KeychainCredentialProvider breaks if we're not on macOS."""
     monkeypatch.setattr(sys, "platform", "linux")
@@ -31,6 +36,7 @@ def test_breaks_not_on_macos(monkeypatch):
         KeychainCredentialProvider("test", "test")
 
 
+@pytest.mark.skipif(platform.system() != 'Darwin', reason="only run on mac os")
 def test_password_parser(monkeypatch):
     """Test that checks if the password is parsed correctly."""
     monkeypatch.setattr(sys, "platform", "darwin")
@@ -48,6 +54,7 @@ def test_password_parser(monkeypatch):
     assert parsed["integration"] == "test"
 
 
+@pytest.mark.skipif(platform.system() != 'Darwin', reason="only run on mac os")
 def test_password_parser_invalid_json(monkeypatch):
     """Test that checks if the password is parsed correctly."""
     monkeypatch.setattr(sys, "platform", "darwin")
@@ -55,6 +62,7 @@ def test_password_parser_invalid_json(monkeypatch):
         KeychainCredentialProvider("test", "test")._parse_credentials(INVALID_JSON)
 
 
+@pytest.mark.skipif(platform.system() != 'Darwin', reason="only run on mac os")
 def test_get_credentials_valid(monkeypatch):
     """Tests if it parses the Credential data correctly."""
     monkeypatch.setattr(sys, "platform", "darwin")
@@ -72,6 +80,7 @@ def test_get_credentials_valid(monkeypatch):
     assert keychain_provider.integration == "test"
 
 
+@pytest.mark.skipif(platform.system() != 'Darwin', reason="only run on mac os")
 def test_get_credentials_invalid(monkeypatch):
     """Tests if it raises the CredentialError with the given invalid json."""
     monkeypatch.setattr(sys, "platform", "darwin")
@@ -80,6 +89,7 @@ def test_get_credentials_invalid(monkeypatch):
         KeychainCredentialProvider("test", "test").get_credentials()
 
 
+@pytest.mark.skipif(platform.system() != 'Darwin', reason="only run on mac os")
 def test_get_credentials_none_found(monkeypatch):
     """Tests if it raises the CredentialError if credentials are not found."""
     monkeypatch.setattr(sys, "platform", "darwin")


### PR DESCRIPTION
Sample way to disable a package for a specific operating system

I see support for non macOS key rings so I'd like the decision to be made as a team if this is something we want to expand support beyond macOS however it would require the rust packages to be added for red hat linux users which may be small.

https://pypi.org/project/keyring/