### PR TITLE
CBAPI-3122: Delete User Grant Before Deleting User

### DIFF
--- a/bin/set-macos-keychain.py
+++ b/bin/set-macos-keychain.py
@@ -11,17 +11,15 @@
 # * WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
 # * NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
 
-__doc__ = """
+"""
 Helper script for adding an entry into macos's keychain.
 
 Use the script by simply invoking it without any system arguments to
 import your configuration from a file or manually by inputs.
 
-Invoke it with system arguments to create an entry without having to type the credentials
-manually.
+Invoke it with system arguments to create an entry without having to type the credentials manually.
 
 Examples:
-
     Using system arguments:
     $ ./set-macos-keychain.py -e CBC_SDK -a default -t <TOKEN> -k <ORG_KEY> -u <URL>
 

--- a/src/cbc_sdk/platform/users.py
+++ b/src/cbc_sdk/platform/users.py
@@ -553,6 +553,12 @@ class User(MutableBaseModel):
             if self._internal_set_profile_expiration(my_profiles, expiration_date):
                 raise ApiError("legacy user has no grant")
 
+    def delete(self):
+        """Delete this object."""
+        grant = self.grant()  # CBAPI-3122 - remove grant first if present
+        if grant:
+            grant.delete()
+        return self._delete_object()
 
 """User Queries"""
 

--- a/src/cbc_sdk/platform/users.py
+++ b/src/cbc_sdk/platform/users.py
@@ -560,6 +560,7 @@ class User(MutableBaseModel):
             grant.delete()
         return self._delete_object()
 
+
 """User Queries"""
 
 

--- a/src/tests/unit/fixtures/platform/mock_grants.py
+++ b/src/tests/unit/fixtures/platform/mock_grants.py
@@ -296,6 +296,23 @@ EXPECT_CHANGE_ROLE_GRANT1 = {
     "update_time": "2021-03-20T12:56:31.645Z"
 }
 
+EXPECT_DELETE_GRANT1 = {
+    "principal": "psc:user:test:3911",
+    "expires": 0,
+    "revoked": True,
+    "roles": [
+        "psc:role::SECOPS_ROLE_MANAGER",
+        "psc:role:test:APP_SERVICE_ROLE"
+    ],
+    "profiles": [],
+    "org_ref": "psc:org:test",
+    "principal_name": "Ed Mercer",
+    "created_by": "psc:user:FOO:BAR",
+    "updated_by": "psc:user:FOO:BAR",
+    "create_time": "2021-03-20T12:56:31.645Z",
+    "update_time": "2021-03-20T12:56:31.645Z"
+}
+
 DETAILS_GRANT2 = {
     "principal": "psc:user:test:3934",
     "expires": 0,

--- a/src/tests/unit/platform/test_users.py
+++ b/src/tests/unit/platform/test_users.py
@@ -13,7 +13,7 @@ from tests.unit.fixtures.platform.mock_users import (GET_USERS_RESP, GET_USERS_A
                                                      EXPECT_USER_ADD, EXPECT_USER_ADD_SMALL, EXPECT_USER_ADD_V1,
                                                      EXPECT_USER_ADD_V2, EXPECT_USER_ADD_BULK1, EXPECT_USER_ADD_BULK2,
                                                      USER_ADD_SUCCESS_RESP, USER_ADD_FAILURE_RESP)
-from tests.unit.fixtures.platform.mock_grants import (DETAILS_GRANT1, EXPECT_CHANGE_ROLE_GRANT1,
+from tests.unit.fixtures.platform.mock_grants import (DETAILS_GRANT1, EXPECT_CHANGE_ROLE_GRANT1, EXPECT_DELETE_GRANT1,
                                                       DETAILS_GRANT2, EXPECT_CHANGE_ROLE_GRANT2A,
                                                       EXPECT_CHANGE_ROLE_GRANT2B, EXPECT_DISABLE_ALL_GRANT2,
                                                       DETAILS_GRANT3, PROFILE_TEMPLATES_A, EXPECT_ADD_PROFILES_3A,
@@ -92,20 +92,6 @@ def test_get_and_modify_user(cbcsdk_mock):
     assert user.first_name == 'John'
     assert user.login_name == 'jsheridan@babylon5.com'
     assert user.email == 'jsheridan@zhadum.net'
-
-
-def test_get_and_delete_user(cbcsdk_mock):
-    """Tests retrieving and deleting a user."""
-    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/users', GET_USERS_RESP)
-    cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/users/3978', None)
-    api = cbcsdk_mock.api
-    user = api.select(User, 3978)
-    assert user.last_name == 'Mariner'
-    assert user.first_name == 'Beckett'
-    assert user.login_name == 'bmariner@cerritos.starfleet.mil'
-    assert user.email == 'bmariner@cerritos.starfleet.mil'
-    assert user.urn == 'psc:user:test:3978'
-    user.delete()
 
 
 def test_get_user_and_reset_googleauth(cbcsdk_mock):
@@ -269,6 +255,27 @@ def test_get_grant(cbcsdk_mock):
     assert grant.roles == ["psc:role::SECOPS_ROLE_MANAGER", "psc:role:test:APP_SERVICE_ROLE"]
 
 
+def test_delete_user_without_grant(cbcsdk_mock):
+    """Tests deleting a user that does not have a grant."""
+    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/users', GET_USERS_RESP)
+    cbcsdk_mock.mock_request('POST', '/access/v2/grants/_fetch', wrap_grant(None))
+    cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/users/3911', None)
+    api = cbcsdk_mock.api
+    user = api.select(User).user_ids([3911]).one()
+    user.delete()
+
+
+def test_delete_user_with_grant(cbcsdk_mock):
+    """Tests deleting a user that DOES have a grant."""
+    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/users', GET_USERS_RESP)
+    cbcsdk_mock.mock_request('POST', '/access/v2/grants/_fetch', wrap_grant(DETAILS_GRANT1))
+    cbcsdk_mock.mock_request('DELETE', '/access/v2/orgs/test/grants/psc:user:test:3911', EXPECT_DELETE_GRANT1)
+    cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/users/3911', None)
+    api = cbcsdk_mock.api
+    user = api.select(User).user_ids([3911]).one()
+    user.delete()
+
+
 def test_bulk_create(cbcsdk_mock):
     """Tests the User.bulk_create API."""
     count_posts = 0
@@ -428,7 +435,17 @@ def test_bulk_delete(cbcsdk_mock):
     def checkoff(userid):
         return lambda url, body: _checkoff(userid, url, body)
 
+    def get_grant(url, body, **kwargs):
+        assert len(body) == 1
+        assert body[0]['org_ref'] == 'psc:org:test'
+        rc = None
+        if body[0]['principal'] == 'psc:user:test:3911':
+            rc = DETAILS_GRANT1
+        return wrap_grant(rc)
+
     cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/users', GET_USERS_RESP)
+    cbcsdk_mock.mock_request('POST', '/access/v2/grants/_fetch', get_grant)
+    cbcsdk_mock.mock_request('DELETE', '/access/v2/orgs/test/grants/psc:user:test:3911', EXPECT_DELETE_GRANT1)
     cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/users/3911', checkoff(3911))
     cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/users/3934', checkoff(3934))
     api = cbcsdk_mock.api


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3122 (also GitHub #217)

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
The delete() method on User was failing if the user had an outstanding access grant.  We modify the delete() to check for an access grant on the user, and, if one exists, delete the grant before deleting the user.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
New unit tests have been written for the User.delete(), covering both the cases where the user has and does not have a grant. The test for User.bulk_delete() has also been updated.

The script 
[delete_user.py.txt](https://github.com/carbonblack/carbon-black-cloud-sdk-python/files/7376862/delete_user.py.txt) is a sample script that deletes a user from the command line given the user's E-mail address. The text log
[before-and-after.txt](https://github.com/carbonblack/carbon-black-cloud-sdk-python/files/7376863/before-and-after.txt) shows the output from that script both before and after the fix to User.delete() was applied.