### PR TITLE
CBAPI-3055: Replace erroneous references to `integration_name` with `integration`

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -105,7 +105,7 @@ CBAPI, so older files can continue to be used.  This is an example of a credenti
     ssl_force_tls_1_2=1
     proxy=proxy.example
     ignore_system_proxy=on
-    integration_name=MyScript/0.9.0
+    integration=MyScript/0.9.0
 
     [production]
     url=http://example.com
@@ -117,7 +117,7 @@ CBAPI, so older files can continue to be used.  This is an example of a credenti
     ssl_force_tls_1_2=1
     proxy=proxy.example
     ignore_system_proxy=on
-    integration_name=MyApplication/1.3.1
+    integration=MyApplication/1.3.1
 
 Individual profiles or sections are delimited in the file by placing their name within square brackets: ``[profile_name]``.  Within
 each section, individual credential values are supplied in a ``keyword=value`` format.
@@ -191,7 +191,7 @@ be specified:
 +-------------------------+----------------+---------+
 |``proxy``                | ``REG_SZ``     |         |
 +-------------------------+----------------+---------+
-|``integration_name``     | ``REG_SZ``     |         |
+|``integration``          | ``REG_SZ``     |         |
 +-------------------------+----------------+---------+
 
 Unrecognized named values are ignored.
@@ -362,7 +362,7 @@ or :ref:`with Windows Registry <With Windows Registry>`, the credentials include
 |``proxy``                | If specified, this is the name of a proxy host to be |         |
 |                         | used in making the connection.                       |         |
 +-------------------------+------------------------------------------------------+---------+
-|``integration_name``     | The name of the integration to use these credentials.|         |
+|``integration``          | The name of the integration to use these credentials.|         |
 |                         | The string may optionally end with a slash character,|         |
 |                         | followed by the integration's version number.  Passed|         |
 |                         | as part of the ``User-Agent:`` HTTP header on all    |         |


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3055


## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
In the Authentication guide page, replaced reverences to the credential property "integration_name" with "integration." Note that the references to the keyword parameter to `CBCloudAPI` "integration_name" stay, because that's valid.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Documentation only, no code involved.