### PR TITLE
CBAPI-3328: SDK: Export Live Query Results - Line-by-Line Iteration

### DIFF
--- a/src/cbc_sdk/audit_remediation/base.py
+++ b/src/cbc_sdk/audit_remediation/base.py
@@ -1385,13 +1385,13 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
             livequery.manage(READ)
 
         Returns:
-            iterator: An iterator that can be used to get each line of CSV text in turn as a string.
+            iterable: An iterable that can be used to get each line of CSV text in turn as a string.
         """
         if self._run_id is None:
             raise ApiError("Can't retrieve results without a run ID")
         url = self._doc_class.urlobject.format(self._cb.credentials.org_key, self._run_id) + '?format=csv'
         request = self._build_request(0, -1)
-        return self._cb.post_and_get_lines(url, request, headers={'Accept': 'text/csv'})
+        yield from self._cb.post_and_get_lines(url, request, headers={'Accept': 'text/csv'})
 
     def export_zipped_csv(self, filename):
         """

--- a/src/cbc_sdk/audit_remediation/base.py
+++ b/src/cbc_sdk/audit_remediation/base.py
@@ -1377,6 +1377,22 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
         with io.open(filename, 'wb') as file:
             self.export_csv_as_stream(file)
 
+    def export_csv_as_lines(self):
+        """
+        Export the results from the run as CSV, returning the CSV data as iterated lines.
+
+        Required Permissions:
+            livequery.manage(READ)
+
+        Returns:
+            iterator: An iterator that can be used to get each line of CSV text in turn as a string.
+        """
+        if self._run_id is None:
+            raise ApiError("Can't retrieve results without a run ID")
+        url = self._doc_class.urlobject.format(self._cb.credentials.org_key, self._run_id) + '?format=csv'
+        request = self._build_request(0, -1)
+        return self._cb.post_and_get_lines(url, request, headers={'Accept': 'text/csv'})
+
     def export_zipped_csv(self, filename):
         """
         Export the results from the run as a zipped CSV, writing the zip data to the named file.

--- a/src/cbc_sdk/connection.py
+++ b/src/cbc_sdk/connection.py
@@ -542,7 +542,7 @@ class BaseAPI(object):
 
     def post_and_get_stream(self, uri, body, stream_output, **kwargs):
         """
-        Send a POST request  to the specified URI and stream the results back into the given stream object.
+        Send a POST request to the specified URI and stream the results back into the given stream object.
 
         Args:
             uri (str): The URI to send the POST request to.
@@ -560,6 +560,25 @@ class BaseAPI(object):
             for block in resp.iter_content(self.session.stream_buffer_size):
                 stream_output.write(block)
         return resp
+
+    def post_and_get_lines(self, uri, body, **kwargs):
+        """
+        Send a POST request to the specified URI and iterate over the response as lines of text.
+
+        Args:
+            uri (str): The URI to send the POST request to.
+            body (object): The data to be sent in the body of the POST request.
+            **kwargs (dict): Additional arguments for the HTTP POST.
+
+        Returns:
+            iterator: An iterator that can be used to get each line of text in turn as a string.
+        """
+        headers = kwargs.pop("headers", {})
+        headers["Content-Type"] = "application/json"
+        with self.session.http_request("POST", uri, headers=headers, data=json.dumps(body, sort_keys=True),
+                                       stream=True, **kwargs) as resp:
+            for line in resp.iter_lines(decode_unicode=True):
+                yield line
 
     @classmethod
     def _map_multipart_param(cls, table_entry, value):

--- a/src/cbc_sdk/connection.py
+++ b/src/cbc_sdk/connection.py
@@ -571,7 +571,7 @@ class BaseAPI(object):
             **kwargs (dict): Additional arguments for the HTTP POST.
 
         Returns:
-            iterator: An iterator that can be used to get each line of text in turn as a string.
+            iterable: An iterable that can be used to get each line of text in turn as a string.
         """
         headers = kwargs.pop("headers", {})
         headers["Content-Type"] = "application/json"

--- a/src/tests/unit/audit_remediation/test_audit_remediation_base.py
+++ b/src/tests/unit/audit_remediation/test_audit_remediation_base.py
@@ -309,6 +309,17 @@ def test_result_query_export_file(cbcsdk_mock):
         os.remove(tempfile)
 
 
+def test_result_query_export_lines(cbcsdk_mock):
+    """Tests exporting the results of a query as a list of lines."""
+    input = "AAA\r\nBBB\r\nCCC"
+    cbcsdk_mock.mock_request("POST_LINES", "/livequery/v1/orgs/test/runs/run_id/results/_search?format=csv",
+                             CBCSDKMock.StubResponse(input, 200, input, False))
+    api = cbcsdk_mock.api
+    result_query = api.select(Result).run_id("run_id")
+    output = result_query.export_csv_as_lines()
+    assert output == ["AAA", "BBB", "CCC"]
+
+
 def test_result_query_export_zip(cbcsdk_mock):
     """Tests exporting the results of a query as a zip file."""
     cbcsdk_mock.mock_request("POST_STREAM",
@@ -334,6 +345,8 @@ def test_result_query_exports_fail_without_run_id(cb):
         result_query.export_csv_as_string()
     with pytest.raises(ApiError):
         result_query.export_csv_as_file('blort.txt')
+    with pytest.raises(ApiError):
+        result_query.export_csv_as_lines()
     with pytest.raises(ApiError):
         result_query.export_zipped_csv('blort.zip')
 

--- a/src/tests/unit/audit_remediation/test_audit_remediation_base.py
+++ b/src/tests/unit/audit_remediation/test_audit_remediation_base.py
@@ -316,7 +316,7 @@ def test_result_query_export_lines(cbcsdk_mock):
                              CBCSDKMock.StubResponse(input, 200, input, False))
     api = cbcsdk_mock.api
     result_query = api.select(Result).run_id("run_id")
-    output = result_query.export_csv_as_lines()
+    output = list(result_query.export_csv_as_lines())
     assert output == ["AAA", "BBB", "CCC"]
 
 

--- a/src/tests/unit/audit_remediation/test_audit_remediation_base.py
+++ b/src/tests/unit/audit_remediation/test_audit_remediation_base.py
@@ -346,7 +346,7 @@ def test_result_query_exports_fail_without_run_id(cb):
     with pytest.raises(ApiError):
         result_query.export_csv_as_file('blort.txt')
     with pytest.raises(ApiError):
-        result_query.export_csv_as_lines()
+        list(result_query.export_csv_as_lines())
     with pytest.raises(ApiError):
         result_query.export_zipped_csv('blort.zip')
 

--- a/src/tests/unit/fixtures/stubresponse.py
+++ b/src/tests/unit/fixtures/stubresponse.py
@@ -51,7 +51,8 @@ class StubResponse(object):
 
     def iter_lines(self, **kwargs):
         """Create iterated lines from the 'content' parameter."""
-        return self.content.splitlines()
+        for line in self.content.splitlines():
+            yield line
 
 
 def _failing_get_object(url, parms=None, default=None):

--- a/src/tests/unit/fixtures/stubresponse.py
+++ b/src/tests/unit/fixtures/stubresponse.py
@@ -49,6 +49,10 @@ class StubResponse(object):
             return_list.append(part)
         return return_list
 
+    def iter_lines(self, **kwargs):
+        """Create iterated lines from the 'content' parameter."""
+        return self.content.splitlines()
+
 
 def _failing_get_object(url, parms=None, default=None):
     pytest.fail("GET called for %s when it shouldn't be" % url)

--- a/src/tests/unit/test_base_api.py
+++ b/src/tests/unit/test_base_api.py
@@ -294,6 +294,27 @@ def test_BaseAPI_post_and_get_stream(mox):
     mox.VerifyAll()
 
 
+def test_BaseAPI_post_and_get_lines(mox):
+    """Test the operation of post_and_get_lines."""
+    def validate_header(hdrs):
+        assert hdrs['Content-Type'] == 'application/json'
+        return True
+
+    def validate_data(data):
+        real_data = json.loads(data)
+        assert real_data == {'a': 1, 'b': 2}
+        return True
+
+    sut = BaseAPI(url='https://example.com', token='ABCDEFGH', org_key='A1B2C3D4')
+    mox.StubOutWithMock(sut.session, 'http_request')
+    sut.session.http_request('POST', '/path', headers=Func(validate_header), data=Func(validate_data), stream=True) \
+        .AndReturn(StubResponse(None, 200, "AAA\r\nBBB\r\nCCC"))
+    mox.ReplayAll()
+    output = list(sut.post_and_get_lines('/path', {'a': 1, 'b': 2}))
+    assert output == ["AAA", "BBB", "CCC"]
+    mox.VerifyAll()
+
+
 def test_BaseAPI_post_multipart(mox):
     """Test the operation of post_multipart."""
     def validate_header(hdrs):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3328

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added additional method to `ResultQuery`, `export_csv_as_lines()`, that returns the exported CSV as an iterator of lines.  By request of @avanbrunt-cb.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
New test script has been written that proves the download works against a live environment.  Test script (with internal data redacted) follows.
```
#!/usr/bin/env python

from cbc_sdk import CBCloudAPI
from cbc_sdk.audit_remediation import Run

api = CBCloudAPI(profile='[REDACTED]')
run = api.select(Run, '[REDACTED]')
for line in run.query_results().export_csv_as_lines():
    print(line)
```
Additional unit tests have been written for the new functionality.  All new code is covered.