### PR TITLE
CBAPI-3298: Vulnerabilities SDK - Add code to handle printing

### DIFF
--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -591,6 +591,25 @@ class NewBaseModel(object, metaclass=CbMetaModel):
             string_value = string_value[:NewBaseModel.MAX_VALUE_WIDTH - 3] + "..."
         return string_value
 
+    @classmethod
+    def _str_name_field_len(cls, attributes):
+        """
+        Given an attribute dictionary, returns the maximum length of its "name" field.
+
+        Args:
+            attributes (dict): A dictionary to check.
+
+        Returns:
+            int: The maximum length of any key in the dictionary.
+        """
+        attr_names = []
+        for attr in attributes:
+            if isinstance(attr, str):
+                attr_names.append(attr)
+            elif isinstance(attr, dict):
+                attr_names.extend(attr.keys())
+        return max([len(s) for s in attr_names])
+
     def _str_attr_line(self, name, value, name_field_len, top_level=True):
         """
         Returns the representation of a single attribute within an object (which may be multiple lines).
@@ -645,7 +664,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
             lines.append('')
         elif isinstance(value, dict) and top_level:
             # append the dict elements
-            lines.append(format_str.format(status, name.rjust(name_field_len), '{'))
+            lines.append(format_str.format(status, name.rjust(name_field_len), '[dict] {'))
             lines.extend([f"{' ' * (spacing + 4)}{sub_line}" for sub_line in self._str_dict_lines(value, False)])
             lines.append(f"{' ' * spacing}{'}'}")
         else:
@@ -673,13 +692,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
             attributes = d
 
         # Compute the name field length.
-        attr_names = []
-        for attr in attributes:
-            if isinstance(attr, str):
-                attr_names.append(attr)
-            elif isinstance(attr, dict):
-                attr_names.extend(attr.keys())
-        name_field_len = max([len(s) for s in attr_names])
+        name_field_len = self._str_name_field_len(attributes)
 
         for attr in attributes:
             # typical case, where the info dictionary value for this `attr` is a string

--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -643,7 +643,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
             lines.extend([f"{' ' * spacing}{sub_line}"
                           for sub_line in self._str_dict_lines(subobject_value._info, False)])
             lines.append('')
-        elif isinstance(value, dict):
+        elif isinstance(value, dict) and top_level:
             # append the dict elements
             lines.append(format_str.format(status, name.rjust(name_field_len), '{'))
             lines.extend([f"{' ' * (spacing + 4)}{sub_line}" for sub_line in self._str_dict_lines(value, False)])

--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -368,7 +368,6 @@ class NewBaseModel(object, metaclass=CbMetaModel):
         """
         self._cb = cb
         self._last_refresh_time = 0
-        self._max_name_len = 0
 
         if initial_data is not None:
             self._info = initial_data
@@ -592,30 +591,14 @@ class NewBaseModel(object, metaclass=CbMetaModel):
             string_value = string_value[:NewBaseModel.MAX_VALUE_WIDTH - 3] + "..."
         return string_value
 
-    def _str_max_name_len(self):
-        """
-        Returns the maximum length of the attribute names for this object.
-
-        Returns:
-            int: The maximum length of the attribute names for this object.
-        """
-        if self._max_name_len == 0:
-            attr_names = []
-            for attr in self._info:
-                if isinstance(attr, str):
-                    attr_names.append(attr)
-                elif isinstance(attr, dict):
-                    attr_names.extend(attr.keys())
-            self._max_name_len = max([len(s) for s in attr_names])
-        return self._max_name_len
-
-    def _str_attr_line(self, name, value, top_level=True):
+    def _str_attr_line(self, name, value, name_field_len, top_level=True):
         """
         Returns the representation of a single attribute within an object (which may be multiple lines).
 
         Args:
             name (str): The name of this attribute.
             value (Any): The value of this attribute.
+            name_field_len (int): Size of the name field for this line.
             top_level (bool): True if this is a "top level" object being rendered as lines of text.
 
         Returns:
@@ -631,13 +614,13 @@ class NewBaseModel(object, metaclass=CbMetaModel):
             else:
                 status = "(*)"
         subobject_value = self._subobject(name) if top_level else None
-        spacing = self._str_max_name_len() + (6 if top_level else 2)  # (status + space) + name + colon + space
+        spacing = name_field_len + (6 if top_level else 2)  # (status + space) + name + colon + space
         if isinstance(value, list):
             # this is a list - render the first three items, then [...] if we have more
             target = value if subobject_value is None else subobject_value
             list_header = f"[list:{len(target)} {'item' if len(target) == 1 else 'items'}]" \
                           f"{':' if len(target) > 0 else ''}"
-            lines.append(format_str.format(status, name.rjust(self._str_max_name_len()), list_header))
+            lines.append(format_str.format(status, name.rjust(name_field_len), list_header))
             for index, item in enumerate(target):
                 if index >= NewBaseModel.MAX_LIST_ITEM_RENDER:
                     # punt the rest of the list
@@ -647,27 +630,35 @@ class NewBaseModel(object, metaclass=CbMetaModel):
                     # render the item as a subobject
                     lines.append((' ' * spacing) + sub_format_str.format('', f"[{index}]",
                                                                          f"[{item.__class__.__name__} object]:"))
-                    lines.extend([f"{' ' * (spacing + 5)}{sub_line}" for sub_line in item._str_attr_lines(False)])
+                    lines.extend([f"{' ' * (spacing + 5)}{sub_line}"
+                                  for sub_line in self._str_dict_lines(item._info, False)])
                     lines.append('')
                 else:
                     # render item normally
                     lines.append((' ' * spacing) + sub_format_str.format('', f"[{index}]", self._str_stringize(item)))
         elif subobject_value is not None:
             # this is a subobject
-            lines.append(format_str.format(status, name.rjust(self._str_max_name_len()),
+            lines.append(format_str.format(status, name.rjust(name_field_len),
                                            f"[{subobject_value.__class__.__name__} object]:"))
-            lines.extend([f"{' ' * spacing}{sub_line}" for sub_line in subobject_value._str_attr_lines(False)])
+            lines.extend([f"{' ' * spacing}{sub_line}"
+                          for sub_line in self._str_dict_lines(subobject_value._info, False)])
             lines.append('')
+        elif isinstance(value, dict):
+            # append the dict elements
+            lines.append(format_str.format(status, name.rjust(name_field_len), '{'))
+            lines.extend([f"{' ' * (spacing + 4)}{sub_line}" for sub_line in self._str_dict_lines(value, False)])
+            lines.append(f"{' ' * spacing}{'}'}")
         else:
             # ordinary case
-            lines.append(format_str.format(status, name.rjust(self._str_max_name_len()), self._str_stringize(value)))
+            lines.append(format_str.format(status, name.rjust(name_field_len), self._str_stringize(value)))
         return lines
 
-    def _str_attr_lines(self, top_level=True):
+    def _str_dict_lines(self, d, top_level=True):
         """
-        Returns the representation of all attributes within this object.
+        Returns the representation of all attributes within a dictionary.
 
         Args:
+            d (dict): The dictionary from which the attributes are to be rendered.
             top_level (bool): True if this is a "top level" object being rendered as lines of text.
 
         Returns:
@@ -676,20 +667,29 @@ class NewBaseModel(object, metaclass=CbMetaModel):
         # for dictionaries that can be sorted, sort them
         lines = []
         try:
-            attributes = sorted(self._info)
+            attributes = sorted(d)
         # dictionaries containing dictionaries cannot be sorted, so leave as is
         except:
-            attributes = self._info
+            attributes = d
+
+        # Compute the name field length.
+        attr_names = []
+        for attr in attributes:
+            if isinstance(attr, str):
+                attr_names.append(attr)
+            elif isinstance(attr, dict):
+                attr_names.extend(attr.keys())
+        name_field_len = max([len(s) for s in attr_names])
 
         for attr in attributes:
             # typical case, where the info dictionary value for this `attr` is a string
             if isinstance(attr, str):
-                lines.extend(self._str_attr_line(attr, self._info[attr], top_level))
+                lines.extend(self._str_attr_line(attr, d[attr], name_field_len, top_level))
             # edge case (seen in Facet searches) where the info dictionary value for this `attr` is a dictionary
             elif isinstance(attr, dict):
                 # go through each attribute in the `attr` dictionary
                 for att in attr:
-                    lines.extend(self._str_attr_line(att, attr[att], top_level))
+                    lines.extend(self._str_attr_line(att, attr[att], name_field_len, top_level))
 
         return lines
 
@@ -711,7 +711,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
         lines.append('')
 
         # add the attribute lines
-        lines.extend(self._str_attr_lines())
+        lines.extend(self._str_dict_lines(self._info))
 
         return "\n".join(lines)
 

--- a/src/tests/unit/base/test_base_models.py
+++ b/src/tests/unit/base/test_base_models.py
@@ -3,7 +3,7 @@
 import pytest
 import logging
 from cbc_sdk.base import MutableBaseModel, NewBaseModel
-from cbc_sdk.endpoint_standard import Policy, Event, Recommendation
+from cbc_sdk.endpoint_standard import Policy, Event
 from cbc_sdk.platform import Process
 from cbc_sdk.rest_api import CBCloudAPI
 from cbc_sdk.errors import ServerError, InvalidObjectError, ApiError
@@ -14,7 +14,6 @@ from tests.unit.fixtures.endpoint_standard.mock_events import EVENT_GET_SPECIFIC
 from tests.unit.fixtures.endpoint_standard.mock_policy import (POLICY_GET_SPECIFIC_RESP, POLICY_GET_RESP,
                                                                POLICY_UPDATE_RESP, POLICY_GET_RESP_1,
                                                                POLICY_GET_RESP_2, POLICY_POST_RESP)
-from tests.unit.fixtures.endpoint_standard.mock_recommendation import ACTION_INIT
 from tests.unit.fixtures.enterprise_edr.mock_threatintel import FEED_GET_SPECIFIC_RESP
 from tests.unit.fixtures.platform.mock_process import (GET_PROCESS_VALIDATION_RESP,
                                                        POST_PROCESS_SEARCH_JOB_RESP,

--- a/src/tests/unit/base/test_base_models.py
+++ b/src/tests/unit/base/test_base_models.py
@@ -460,15 +460,6 @@ def test_str_stringize():
         == 'If this had been an actual emergency, we would ...'
 
 
-def test_str_max_name_len(cb):
-    """Test the _str_max_name_len() method"""
-    recommendation = Recommendation(cb, ACTION_INIT['recommendation_id'], ACTION_INIT)
-    assert recommendation._str_max_name_len() == 17
-    assert recommendation.workflow_._str_max_name_len() == 11
-    assert recommendation.impact_._str_max_name_len() == 16
-    assert recommendation.new_rule_._str_max_name_len() == 13
-
-
 def test_str_attr_line(cb):
     """Test the _str_attr_line method"""
     subobject_data = {
@@ -490,6 +481,7 @@ def test_str_attr_line(cb):
         "objlong": "If this had been an actual emergency, we would all be dead by now",
         "objlist": [1, 2, 3, 5, 8, 13],
         "empty": [],
+        "objdict": {"a": 1, "b": 2, "c": 3},
         "mini_me": subobject_data,
         "List1": [listobj_data],
         "List2": [listobj_data, listobj2_data]
@@ -502,63 +494,76 @@ def test_str_attr_line(cb):
     my_object._my_subobjects["List1"] = [my_listobj]
     my_object._my_subobjects["List2"] = [my_listobj, my_listobj2]
     # Test rendering of basic data (subobject mode)
-    rendering = my_object._str_attr_line('objint', object_data['objint'], False)
+    name_field_len = my_object._str_name_field_len(object_data)
+    rendering = my_object._str_attr_line('objint', object_data['objint'], name_field_len, False)
     assert len(rendering) == 1
     assert rendering[0] == '   objint: 105'
-    rendering = my_object._str_attr_line('objstring', object_data['objstring'], False)
+    rendering = my_object._str_attr_line('objstring', object_data['objstring'], name_field_len, False)
     assert len(rendering) == 1
     assert rendering[0] == 'objstring: KMFMS'
-    rendering = my_object._str_attr_line('objlong', object_data['objlong'], False)
+    rendering = my_object._str_attr_line('objlong', object_data['objlong'], name_field_len, False)
     assert len(rendering) == 1
     assert rendering[0] == '  objlong: If this had been an actual emergency, we would ...'
     # Test rendering of list data (subobject mode)
-    rendering = my_object._str_attr_line('objlist', object_data['objlist'], False)
+    rendering = my_object._str_attr_line('objlist', object_data['objlist'], name_field_len, False)
     assert len(rendering) == 5
     assert rendering[0] == '  objlist: [list:6 items]:'
     assert rendering[1] == '           [0]: 1'
     assert rendering[2] == '           [1]: 2'
     assert rendering[3] == '           [2]: 3'
     assert rendering[4] == '           [...]'
-    rendering = my_object._str_attr_line('empty', object_data['empty'], False)
+    rendering = my_object._str_attr_line('empty', object_data['empty'], name_field_len, False)
     assert len(rendering) == 1
     assert rendering[0] == '    empty: [list:0 items]'
+    # Test rendering of dict data (subobject mode)
+    rendering = my_object._str_attr_line('objdict', object_data['objdict'], name_field_len, False)
+    assert len(rendering) == 1
+    assert rendering[0].startswith('  objdict: {')
     # Test rendering of subobject data (subobject mode)
-    rendering = my_object._str_attr_line('mini_me', object_data['mini_me'], False)
+    rendering = my_object._str_attr_line('mini_me', object_data['mini_me'], name_field_len, False)
     assert len(rendering) == 1
     assert rendering[0].startswith('  mini_me: {')
     # Test rendering of list-of-subobjects data (subobject mode)
-    rendering = my_object._str_attr_line('List1', object_data['List1'], False)
+    rendering = my_object._str_attr_line('List1', object_data['List1'], name_field_len, False)
     assert len(rendering) == 2
     assert rendering[0] == '    List1: [list:1 item]:'
     assert rendering[1].startswith('           [0]: {')
-    rendering = my_object._str_attr_line('List2', object_data['List2'], False)
+    rendering = my_object._str_attr_line('List2', object_data['List2'], name_field_len, False)
     assert len(rendering) == 3
     assert rendering[0] == '    List2: [list:2 items]:'
     assert rendering[1].startswith('           [0]: {')
     assert rendering[2].startswith('           [1]: {')
     # Test rendering of basic data (top-level mode)
-    rendering = my_object._str_attr_line('objint', object_data['objint'])
+    rendering = my_object._str_attr_line('objint', object_data['objint'], name_field_len)
     assert len(rendering) == 1
     assert rendering[0] == '       objint: 105'
-    rendering = my_object._str_attr_line('objstring', object_data['objstring'])
+    rendering = my_object._str_attr_line('objstring', object_data['objstring'], name_field_len)
     assert len(rendering) == 1
     assert rendering[0] == '    objstring: KMFMS'
-    rendering = my_object._str_attr_line('objlong', object_data['objlong'])
+    rendering = my_object._str_attr_line('objlong', object_data['objlong'], name_field_len)
     assert len(rendering) == 1
     assert rendering[0] == '      objlong: If this had been an actual emergency, we would ...'
     # Test rendering of list data (top-level mode)
-    rendering = my_object._str_attr_line('objlist', object_data['objlist'])
+    rendering = my_object._str_attr_line('objlist', object_data['objlist'], name_field_len)
     assert len(rendering) == 5
     assert rendering[0] == '      objlist: [list:6 items]:'
     assert rendering[1] == '               [0]: 1'
     assert rendering[2] == '               [1]: 2'
     assert rendering[3] == '               [2]: 3'
     assert rendering[4] == '               [...]'
-    rendering = my_object._str_attr_line('empty', object_data['empty'])
+    rendering = my_object._str_attr_line('empty', object_data['empty'], name_field_len)
     assert len(rendering) == 1
     assert rendering[0] == '        empty: [list:0 items]'
+    # Test rendering of dict data (top-level mode)
+    rendering = my_object._str_attr_line('objdict', object_data['objdict'], name_field_len)
+    assert len(rendering) == 5
+    assert rendering[0] == '      objdict: [dict] {'
+    assert rendering[1] == '                   a: 1'
+    assert rendering[2] == '                   b: 2'
+    assert rendering[3] == '                   c: 3'
+    assert rendering[4] == '               }'
     # Test rendering of subobject data (top-level mode) including lists in subobject
-    rendering = my_object._str_attr_line('mini_me', object_data['mini_me'])
+    rendering = my_object._str_attr_line('mini_me', object_data['mini_me'], name_field_len)
     assert len(rendering) == 10
     assert rendering[0] == '      mini_me: [TestBaseModel object]:'
     assert rendering[1] == '                     id: 4096'
@@ -571,13 +576,13 @@ def test_str_attr_line(cb):
     assert rendering[8] == '               sostring: Boom!'
     assert rendering[9] == ''
     # Test rendering of list-of-subobjects data (top-level mode)
-    rendering = my_object._str_attr_line('List1', object_data['List1'])
+    rendering = my_object._str_attr_line('List1', object_data['List1'], name_field_len)
     assert len(rendering) == 4
     assert rendering[0] == '        List1: [list:1 item]:'
     assert rendering[1] == '               [0]: [TestBaseModel object]:'
     assert rendering[2] == '                    id: 64'
     assert rendering[3] == ''
-    rendering = my_object._str_attr_line('List2', object_data['List2'])
+    rendering = my_object._str_attr_line('List2', object_data['List2'], name_field_len)
     assert len(rendering) == 7
     assert rendering[0] == '        List2: [list:2 items]:'
     assert rendering[1] == '               [0]: [TestBaseModel object]:'


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3298

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
The code that renders objects has been modified to handle dicts as attribute values of the top-level object being rendered, to improve the appearance of examples in the Vulnerability guide document.

Sample output (for a Vulnerability object):
```
Vulnerability object, bound to https://defense.conferdeploy.net.
-------------------------------------------------------------------------------

    affected_assets: [list:1 item]:
                     [0]: DESKTOP-ABCDEFG
           category: APP
             cve_id: CVE-1999-0794
       device_count: 1
            os_info: [dict] {
                            os_arch: 64-bit
                            os_name: Microsoft Windows 10 Pro
                            os_type: WINDOWS
                         os_version: 10.0.18363
                     }
      os_product_id: 37_282511
       product_info: [dict] {
                            arch:
                         product: Microsoft Office
                         release: None
                          vendor: Microsoft Corporation
                         version: 15.0.4693.1005
                     }
          vuln_info: [dict] {
                              active_internet_breach: False
                                          created_at: 1999-10-01T04:00:00Z
                                     cve_description: Microsoft Excel does not warn a user when a mac...
                                              cve_id: CVE-1999-0794
                              cvss_access_complexity: Low
                                  cvss_access_vector: Local access
                                 cvss_authentication: None required
                            cvss_availability_impact: Partial
                         cvss_confidentiality_impact: Partial
                               cvss_exploit_subscore: 3.9
                                cvss_impact_subscore: 6.4
                               cvss_integrity_impact: Partial
                                          cvss_score: 4.6
                            cvss_v3_exploit_subscore: None
                             cvss_v3_impact_subscore: None
                                       cvss_v3_score: None
                                      cvss_v3_vector: None
                                         cvss_vector: AV:L/AC:L/Au:N/C:P/I:P/A:P
                                  easily_exploitable: False
                                            fixed_by: None
                                 malware_exploitable: False
                                            nvd_link: https://nvd.nist.gov/vuln/detail/CVE-1999-0794
                                    risk_meter_score: 1.6
                                            severity: LOW
                                            solution: None
                     }
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
New format has been agreed upon by stakeholders. Unit testing covers all of the key rendering function, including the new case.