### PR TITLE
EA-20291 Fix Exception: `link should be valid url`

### DIFF
--- a/examples/enterprise_edr/threat_intelligence/stix_taxii.py
+++ b/examples/enterprise_edr/threat_intelligence/stix_taxii.py
@@ -7,6 +7,7 @@ import urllib3
 import copy
 import yaml
 import os
+from urllib.parse import urlparse
 from cabby.exceptions import NoURIProvidedError, ClientException
 from requests.exceptions import ConnectionError
 from cbc_sdk.errors import ApiError
@@ -367,7 +368,7 @@ class StixTaxii():
                     title=title,
                     description=description)
                 for ioc_key, ioc_val in ioc_dict.items():
-                    result.attach_ioc_v2(values=ioc_val, field=ioc_key, link=link)
+                    result.attach_ioc_v2(values=ioc_val, field=ioc_key, link=urlparse(link).netloc)
             except handled_exceptions as e:
                 logging.warning(f"Problem in report formatting: {e}")
                 result = self.result(

--- a/src/cbc_sdk/enterprise_edr/threat_intelligence.py
+++ b/src/cbc_sdk/enterprise_edr/threat_intelligence.py
@@ -1668,15 +1668,15 @@ class IOC_V2(FeedModel):
 
     def validate(self):
         """
-        Checks to ensure this IOC contains valid data.
+        Checks to ensure this IOC contains valid FQDN.
 
         Raises:
             InvalidObjectError: If the IOC contains invalid data.
         """
         super(IOC_V2, self).validate()
 
-        if self.link and not validators.url(self.link):
-            raise InvalidObjectError("link should be a valid URL")
+        if self.link and not validators.domain(self.link):
+            raise InvalidObjectError("link should be a valid domain URL (FQDN)")
 
     @property
     def ignored(self):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
EA-20291


## Pull Request Description
Sometimes the STIX feed might give just the netloc of a URI, sometimes a full URL and that depends on the feed. Since that we are parsing it into an `IOC_V2.link ` where the field must be `netconn_domain` (targetting FQDN) the fix is to remove the `validation.url` and replace it with `validation.domain` instead while validating the IOC. On the other hand, we should pass the netloc part of the URI instead of the whole URI while attaching the IOC to the Report.


## Does this introduce a breaking change?
- [x] No

## How Has This Been Tested?
Manually with STIX_v1.2 XML Files and with 2 STIX Feeds (1 confidential and 1 open-source).
