### PR TITLE
CBAPI-3336: Allow Get/Set Ignore Status Even If Report is Part of a Feed

### DIFF
--- a/src/cbc_sdk/enterprise_edr/threat_intelligence.py
+++ b/src/cbc_sdk/enterprise_edr/threat_intelligence.py
@@ -1229,13 +1229,11 @@ class Report(FeedModel):
     def ignored(self):
         """Returns the ignore status for this report.
 
-        Only watchlist reports have an ignore status.
-
         Returns:
             (bool): True if this Report is ignored, False otherwise.
 
         Raises:
-            InvalidObjectError: If `id` is missing or this Report is not from a Watchlist.
+            InvalidObjectError: If `id` is missing or feed ID is missing.
 
         Example:
 
@@ -1244,12 +1242,16 @@ class Report(FeedModel):
         """
         if not self.id:
             raise InvalidObjectError("missing Report ID")
-        if not self._from_watchlist:
-            raise InvalidObjectError("ignore status only applies to watchlist reports")
+        if self._from_watchlist:
+            send_id = self.id
+        else:
+            if not self._feed_id:
+                raise InvalidObjectError("missing Feed ID")
+            send_id = f"{self._feed_id}-{self.id}"
 
         url = "/threathunter/watchlistmgr/v3/orgs/{}/reports/{}/ignore".format(
             self._cb.credentials.org_key,
-            self.id
+            send_id
         )
         resp = self._cb.get_object(url)
         return resp["ignored"]
@@ -1257,40 +1259,42 @@ class Report(FeedModel):
     def ignore(self):
         """Sets the ignore status on this report.
 
-        Only watchlist reports have an ignore status.
-
         Raises:
-            InvalidObjectError: If `id` is missing or this Report is not from a Watchlist.
+            InvalidObjectError: If `id` is missing or feed ID is missing.
         """
         if not self.id:
             raise InvalidObjectError("missing Report ID")
-
-        if not self._from_watchlist:
-            raise InvalidObjectError("ignoring only applies to watchlist reports")
+        if self._from_watchlist:
+            send_id = self.id
+        else:
+            if not self._feed_id:
+                raise InvalidObjectError("missing Feed ID")
+            send_id = f"{self._feed_id}-{self.id}"
 
         url = "/threathunter/watchlistmgr/v3/orgs/{}/reports/{}/ignore".format(
             self._cb.credentials.org_key,
-            self.id
+            send_id
         )
         self._cb.put_object(url, None)
 
     def unignore(self):
         """Removes the ignore status on this report.
 
-        Only watchlist reports have an ignore status.
-
         Raises:
-            InvalidObjectError: If `id` is missing or this Report is not from a Watchlist.
+            InvalidObjectError: If `id` is missing or feed ID is missing.
         """
         if not self.id:
             raise InvalidObjectError("missing Report ID")
-
-        if not self._from_watchlist:
-            raise InvalidObjectError("ignoring only applies to watchlist reports")
+        if self._from_watchlist:
+            send_id = self.id
+        else:
+            if not self._feed_id:
+                raise InvalidObjectError("missing Feed ID")
+            send_id = f"{self._feed_id}-{self.id}"
 
         url = "/threathunter/watchlistmgr/v3/orgs/{}/reports/{}/ignore".format(
             self._cb.credentials.org_key,
-            self.id
+            send_id
         )
         self._cb.delete_object(url)
 

--- a/src/cbc_sdk/enterprise_edr/threat_intelligence.py
+++ b/src/cbc_sdk/enterprise_edr/threat_intelligence.py
@@ -1242,12 +1242,12 @@ class Report(FeedModel):
         """
         if not self.id:
             raise InvalidObjectError("missing Report ID")
-        if self._from_watchlist:
+        if self._feed_id:
+            send_id = f"{self._feed_id}-{self.id}"
+        elif self._from_watchlist:
             send_id = self.id
         else:
-            if not self._feed_id:
-                raise InvalidObjectError("missing Feed ID")
-            send_id = f"{self._feed_id}-{self.id}"
+            raise InvalidObjectError("missing Feed ID")
 
         url = "/threathunter/watchlistmgr/v3/orgs/{}/reports/{}/ignore".format(
             self._cb.credentials.org_key,
@@ -1264,12 +1264,12 @@ class Report(FeedModel):
         """
         if not self.id:
             raise InvalidObjectError("missing Report ID")
-        if self._from_watchlist:
+        if self._feed_id:
+            send_id = f"{self._feed_id}-{self.id}"
+        elif self._from_watchlist:
             send_id = self.id
         else:
-            if not self._feed_id:
-                raise InvalidObjectError("missing Feed ID")
-            send_id = f"{self._feed_id}-{self.id}"
+            raise InvalidObjectError("missing Feed ID")
 
         url = "/threathunter/watchlistmgr/v3/orgs/{}/reports/{}/ignore".format(
             self._cb.credentials.org_key,
@@ -1285,12 +1285,12 @@ class Report(FeedModel):
         """
         if not self.id:
             raise InvalidObjectError("missing Report ID")
-        if self._from_watchlist:
+        if self._feed_id:
+            send_id = f"{self._feed_id}-{self.id}"
+        elif self._from_watchlist:
             send_id = self.id
         else:
-            if not self._feed_id:
-                raise InvalidObjectError("missing Feed ID")
-            send_id = f"{self._feed_id}-{self.id}"
+            raise InvalidObjectError("missing Feed ID")
 
         url = "/threathunter/watchlistmgr/v3/orgs/{}/reports/{}/ignore".format(
             self._cb.credentials.org_key,

--- a/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
+++ b/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
@@ -496,7 +496,7 @@ def test_report_builder_save_watchlist(cbcsdk_mock):
     (REPORT_INIT, None, True, True, "69e2a8d0-bc36-4970-9834-8687efe1aff7", does_not_raise(), True),
     (REPORT_INIT, None, False, False, "", pytest.raises(InvalidObjectError), True),
     (REPORT_BUILT_VIA_BUILDER, None, True, False, "", pytest.raises(InvalidObjectError), True),
-    (REPORT_INIT2, "abcdefgh", True, True, "Compound", does_not_raise(), True),
+    (REPORT_INIT2, "abcdefgh", True, True, "abcdefgh-Compound", does_not_raise(), True),
     (REPORT_INIT2, "abcdefgh", False, True, "abcdefgh-Compound", does_not_raise(), True)
 ])
 def test_report_get_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request, url_id, expectation, result):
@@ -514,7 +514,7 @@ def test_report_get_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request,
     (REPORT_INIT, None, True, True, "69e2a8d0-bc36-4970-9834-8687efe1aff7", does_not_raise()),
     (REPORT_INIT, None, False, False, "", pytest.raises(InvalidObjectError)),
     (REPORT_BUILT_VIA_BUILDER, None, True, False, "", pytest.raises(InvalidObjectError)),
-    (REPORT_INIT2, "abcdefgh", True, True, "Compound", does_not_raise()),
+    (REPORT_INIT2, "abcdefgh", True, True, "abcdefgh-Compound", does_not_raise()),
     (REPORT_INIT2, "abcdefgh", False, True, "abcdefgh-Compound", does_not_raise())
 ])
 def test_report_set_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request, url_id, expectation):
@@ -532,7 +532,7 @@ def test_report_set_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request,
     (REPORT_INIT, None, True, True, "69e2a8d0-bc36-4970-9834-8687efe1aff7", does_not_raise()),
     (REPORT_INIT, None, False, False, "", pytest.raises(InvalidObjectError)),
     (REPORT_BUILT_VIA_BUILDER, None, True, False, "", pytest.raises(InvalidObjectError)),
-    (REPORT_INIT2, "abcdefgh", True, True, "Compound", does_not_raise()),
+    (REPORT_INIT2, "abcdefgh", True, True, "abcdefgh-Compound", does_not_raise()),
     (REPORT_INIT2, "abcdefgh", False, True, "abcdefgh-Compound", does_not_raise())
 ])
 def test_report_clear_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request, url_id, expectation):

--- a/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
+++ b/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
@@ -22,6 +22,7 @@ from tests.unit.fixtures.enterprise_edr.mock_threatintel import (WATCHLIST_GET_R
                                                                  IOC_GET_IGNORED,
                                                                  REPORT_BUILT_VIA_BUILDER,
                                                                  REPORT_INIT,
+                                                                 REPORT_INIT2,
                                                                  REPORT_GET_IGNORED,
                                                                  REPORT_GET_SEVERITY,
                                                                  REPORT_UPDATE_AFTER_ADD_IOC,
@@ -491,48 +492,53 @@ def test_report_builder_save_watchlist(cbcsdk_mock):
     assert report._info['id'] == "AaBbCcDdEeFfGg"
 
 
-@pytest.mark.parametrize("init_data, feed, watchlist, do_request, expectation, result", [
-    (REPORT_INIT, None, True, True, does_not_raise(), True),
-    (REPORT_INIT, None, False, False, pytest.raises(InvalidObjectError), True),
-    (REPORT_BUILT_VIA_BUILDER, None, True, False, pytest.raises(InvalidObjectError), True)
+@pytest.mark.parametrize("init_data, feed, watchlist, do_request, url_id, expectation, result", [
+    (REPORT_INIT, None, True, True, "69e2a8d0-bc36-4970-9834-8687efe1aff7", does_not_raise(), True),
+    (REPORT_INIT, None, False, False, "", pytest.raises(InvalidObjectError), True),
+    (REPORT_BUILT_VIA_BUILDER, None, True, False, "", pytest.raises(InvalidObjectError), True),
+    (REPORT_INIT2, "abcdefgh", True, True, "Compound", does_not_raise(), True),
+    (REPORT_INIT2, "abcdefgh", False, True, "abcdefgh-Compound", does_not_raise(), True)
 ])
-def test_report_get_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request, expectation, result):
+def test_report_get_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request, url_id, expectation, result):
     """Tests the operation of the report.ignored() method."""
     if do_request:
-        cbcsdk_mock.mock_request("GET", "/threathunter/watchlistmgr/v3/orgs/test/reports/"
-                                        "69e2a8d0-bc36-4970-9834-8687efe1aff7/ignore", REPORT_GET_IGNORED)
+        cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/reports/{url_id}/ignore",
+                                 REPORT_GET_IGNORED)
     api = cbcsdk_mock.api
     report = Report(api, None, init_data, feed, watchlist)
     with expectation:
         assert report.ignored == result
 
 
-@pytest.mark.parametrize("init_data, feed, watchlist, do_request, expectation", [
-    (REPORT_INIT, None, True, True, does_not_raise()),
-    (REPORT_INIT, None, False, False, pytest.raises(InvalidObjectError)),
-    (REPORT_BUILT_VIA_BUILDER, None, True, False, pytest.raises(InvalidObjectError))
+@pytest.mark.parametrize("init_data, feed, watchlist, do_request, url_id, expectation", [
+    (REPORT_INIT, None, True, True, "69e2a8d0-bc36-4970-9834-8687efe1aff7", does_not_raise()),
+    (REPORT_INIT, None, False, False, "", pytest.raises(InvalidObjectError)),
+    (REPORT_BUILT_VIA_BUILDER, None, True, False, "", pytest.raises(InvalidObjectError)),
+    (REPORT_INIT2, "abcdefgh", True, True, "Compound", does_not_raise()),
+    (REPORT_INIT2, "abcdefgh", False, True, "abcdefgh-Compound", does_not_raise())
 ])
-def test_report_set_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request, expectation):
+def test_report_set_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request, url_id, expectation):
     """Tests the operation of the report.ignore() method."""
     if do_request:
-        cbcsdk_mock.mock_request("PUT", "/threathunter/watchlistmgr/v3/orgs/test/reports/"
-                                        "69e2a8d0-bc36-4970-9834-8687efe1aff7/ignore", REPORT_GET_IGNORED)
+        cbcsdk_mock.mock_request("PUT", f"/threathunter/watchlistmgr/v3/orgs/test/reports/{url_id}/ignore",
+                                 REPORT_GET_IGNORED)
     api = cbcsdk_mock.api
     report = Report(api, None, init_data, feed, watchlist)
     with expectation:
         report.ignore()
 
 
-@pytest.mark.parametrize("init_data, feed, watchlist, do_request, expectation", [
-    (REPORT_INIT, None, True, True, does_not_raise()),
-    (REPORT_INIT, None, False, False, pytest.raises(InvalidObjectError)),
-    (REPORT_BUILT_VIA_BUILDER, None, True, False, pytest.raises(InvalidObjectError))
+@pytest.mark.parametrize("init_data, feed, watchlist, do_request, url_id, expectation", [
+    (REPORT_INIT, None, True, True, "69e2a8d0-bc36-4970-9834-8687efe1aff7", does_not_raise()),
+    (REPORT_INIT, None, False, False, "", pytest.raises(InvalidObjectError)),
+    (REPORT_BUILT_VIA_BUILDER, None, True, False, "", pytest.raises(InvalidObjectError)),
+    (REPORT_INIT2, "abcdefgh", True, True, "Compound", does_not_raise()),
+    (REPORT_INIT2, "abcdefgh", False, True, "abcdefgh-Compound", does_not_raise())
 ])
-def test_report_clear_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request, expectation):
+def test_report_clear_ignored(cbcsdk_mock, init_data, feed, watchlist, do_request, url_id, expectation):
     """Tests the operation of the report.unignore() method."""
     if do_request:
-        cbcsdk_mock.mock_request("DELETE", "/threathunter/watchlistmgr/v3/orgs/test/reports/"
-                                           "69e2a8d0-bc36-4970-9834-8687efe1aff7/ignore",
+        cbcsdk_mock.mock_request("DELETE", f"/threathunter/watchlistmgr/v3/orgs/test/reports/{url_id}/ignore",
                                  CBCSDKMock.StubResponse(None, 204))
     api = cbcsdk_mock.api
     report = Report(api, None, init_data, feed, watchlist)

--- a/src/tests/unit/fixtures/enterprise_edr/mock_threatintel.py
+++ b/src/tests/unit/fixtures/enterprise_edr/mock_threatintel.py
@@ -1056,6 +1056,31 @@ REPORT_INIT = {
     "visibility": "visible"
 }
 
+REPORT_INIT2 = {
+    "id": "Compound",
+    "title": "ReportTitle",
+    "description": "The report description",
+    "timestamp": 1234567890,
+    "severity": 5,
+    "link": "https://example.com",
+    "tags": ["Alpha", "Bravo"],
+    "iocs_v2": [
+        {
+            "id": "foo",
+            "match_type": "equality",
+            "field": "process_name",
+            "values": ["evil.exe"],
+        },
+        {
+            "id": "bar",
+            "match_type": "equality",
+            "field": "netconn_ipv4",
+            "values": ["10.29.99.1"],
+        }
+    ],
+    "visibility": "visible"
+}
+
 REPORT_GET_IGNORED = {
     "ignored": True
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3386, also GitHub #246 

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Changed the way the "ignore" API is called to use a "feed id-report id" syntax for the report if the report is part of a feed.  Tests have shown that this syntax works even if the feed in question is _not_ subscribed to by any watchlist.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been added to test the new code paths and the means of generating the feed ID sent to the server. All added code is covered.  Tests have also been run using the following script to query and set the ignore status of a report in a feed that is not subscribed to by any watchlist.

```
#!/usr/bin/env python

import sys
from cbc_sdk.helpers import build_cli_parser, get_cb_cloud_object
from cbc_sdk.enterprise_edr import Watchlist, Feed

parser = build_cli_parser("Exercise ignore check for a report")
parser.add_argument("feed_id", type=str, help='The feed ID the report is in')
parser.add_argument("report_id", type=str, help='The ID of the report for the exercise')

args = parser.parse_args()
cb = get_cb_cloud_object(args)

feed = cb.select(Feed, args.feed_id)
target_list = [report for report in feed.reports if report.id == args.report_id]
if not target_list:
    print(f"Report {args.report_id} not found in feed {args.feed_id}")
    sys.exit(1)
target = target_list[0]
state = target.ignored
print(f"Initial ignore state is {state}")
if not state:
    target.ignore()
    print(f"Next state: {target.ignored}")
target.unignore()
print(f"Next state: {target.ignored}")
if state:
    target.ignore()
    print(f"Next state: {target.ignored}")
if target.ignored != state:
    print("ERROR: final state mismatch")
    sys.exit(1)
print("Done.")
sys.exit(0)
```