### PR TITLE
CBAPI-3296: Live Query Async with Jobs Service

### DIFF
--- a/src/cbc_sdk/audit_remediation/base.py
+++ b/src/cbc_sdk/audit_remediation/base.py
@@ -1413,6 +1413,8 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
         """
         Create an asynchronous job that exports the results from the run.
 
+        This is recommended if you are expecting a very large result set.
+
         Required Permissions:
             livequery.manage(READ), jobs.status(READ)
 

--- a/src/cbc_sdk/audit_remediation/base.py
+++ b/src/cbc_sdk/audit_remediation/base.py
@@ -1424,7 +1424,7 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
         url = self._doc_class.urlobject.format(self._cb.credentials.org_key, self._run_id) + '?format=csv&async=true'
         request = self._build_request(0, -1)
         response = self._cb.post_object(url, request)
-        ref_url = response.get('ref_url', None)
+        ref_url = response.json().get('ref_url', None)
         try:
             job_id = int(ref_url.rsplit('/', 1)[1]) if ref_url else -1
         except ValueError:

--- a/src/cbc_sdk/audit_remediation/base.py
+++ b/src/cbc_sdk/audit_remediation/base.py
@@ -1345,7 +1345,7 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
             url += '&download=true'
         request = self._build_request(0, -1)
         self._cb.api_request_stream('POST', url, output, data=request,
-                                     headers={'Accept': 'application/octet-stream' if compressed else 'text/csv'})
+                                    headers={'Accept': 'application/octet-stream' if compressed else 'text/csv'})
 
     def export_csv_as_string(self):
         """

--- a/src/cbc_sdk/audit_remediation/base.py
+++ b/src/cbc_sdk/audit_remediation/base.py
@@ -1344,7 +1344,7 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
         if compressed:
             url += '&download=true'
         request = self._build_request(0, -1)
-        self._cb.post_and_get_stream(url, request, output,
+        self._cb.api_request_stream('POST', url, output, data=request,
                                      headers={'Accept': 'application/octet-stream' if compressed else 'text/csv'})
 
     def export_csv_as_string(self):
@@ -1392,7 +1392,7 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
             raise ApiError("Can't retrieve results without a run ID")
         url = self._doc_class.urlobject.format(self._cb.credentials.org_key, self._run_id) + '?format=csv'
         request = self._build_request(0, -1)
-        yield from self._cb.post_and_get_lines(url, request, headers={'Accept': 'text/csv'})
+        yield from self._cb.api_request_iterate('POST', url, data=request, headers={'Accept': 'text/csv'})
 
     def export_zipped_csv(self, filename):
         """

--- a/src/cbc_sdk/platform/__init__.py
+++ b/src/cbc_sdk/platform/__init__.py
@@ -20,3 +20,5 @@ from cbc_sdk.platform.grants import Grant
 from cbc_sdk.platform.users import User
 
 from cbc_sdk.platform.vulnerability_assessment import Vulnerability
+
+from cbc_sdk.platform.jobs import Job

--- a/src/cbc_sdk/platform/jobs.py
+++ b/src/cbc_sdk/platform/jobs.py
@@ -128,6 +128,9 @@ class Job(NewBaseModel):
         """
         Export the results from the job, returning the data as iterated lines of text.
 
+        This is only intended for output that can reasonably be represented as lines of text, such as plain text or
+        CSV.  If a job outputs structured text like JSON or XML, this method should not be used.
+
         Required Permissions:
             jobs.status(READ)
 

--- a/src/cbc_sdk/platform/jobs.py
+++ b/src/cbc_sdk/platform/jobs.py
@@ -15,6 +15,7 @@
 
 import io
 import logging
+import time
 from cbc_sdk.base import NewBaseModel, BaseQuery, IterableQueryMixin, AsyncQueryMixin
 
 
@@ -81,7 +82,7 @@ class Job(NewBaseModel):
         url = self.urlobject_single.format(self._cb.credentials.org_key, self._model_unique_id) + "/progress"
         resp = self._cb.get_object(url)
         self._info['progress'] = resp
-        return resp['num_total'], resp['num_completed'], resp['message']
+        return resp['num_total'], resp['num_completed'], resp.get('message', None)
 
     def get_output_as_stream(self, output):
         """
@@ -134,7 +135,7 @@ class Job(NewBaseModel):
             iterable: An iterable that can be used to get each line of text in turn as a string.
         """
         url = self.urlobject_single.format(self._cb.credentials.org_key, self._model_unique_id) + '/download'
-        yield from self._cb.get_lines_data(self, url)
+        yield from self._cb.get_lines_data(url)
 
 
 class JobQuery(BaseQuery, IterableQueryMixin, AsyncQueryMixin):
@@ -150,6 +151,8 @@ class JobQuery(BaseQuery, IterableQueryMixin, AsyncQueryMixin):
         super(JobQuery, self).__init__(None)
         self._doc_class = doc_class
         self._cb = cb
+        self._total_results = -1
+        self._count_valid = False
 
     def _execute(self):
         """

--- a/src/cbc_sdk/platform/jobs.py
+++ b/src/cbc_sdk/platform/jobs.py
@@ -95,7 +95,7 @@ class Job(NewBaseModel):
             output (RawIOBase): Stream to write the CSV data from the request to.
         """
         url = self.urlobject_single.format(self._cb.credentials.org_key, self._model_unique_id) + '/download'
-        self._cb.get_stream_data(url, output)
+        self._cb.api_request_stream('GET', url, output)
 
     def get_output_as_string(self):
         """
@@ -138,7 +138,7 @@ class Job(NewBaseModel):
             iterable: An iterable that can be used to get each line of text in turn as a string.
         """
         url = self.urlobject_single.format(self._cb.credentials.org_key, self._model_unique_id) + '/download'
-        yield from self._cb.get_lines_data(url)
+        yield from self._cb.api_request_iterate('GET', url)
 
 
 class JobQuery(BaseQuery, IterableQueryMixin, AsyncQueryMixin):

--- a/src/cbc_sdk/platform/jobs.py
+++ b/src/cbc_sdk/platform/jobs.py
@@ -96,21 +96,15 @@ class Job(NewBaseModel):
             Job: This object.
         """
         progress_data = (1, 0, '')
-        sleep_time = 0.0
+        do_sleep = False
         while progress_data[1] < progress_data[0]:
-            if sleep_time > 0.0:
-                time.sleep(sleep_time)
+            if do_sleep:
+                time.sleep(0.5)
             try:
                 progress_data = self.get_progress()
             except ServerError:
                 progress_data = (1, 0, '')
-            # The sleep time starts at 0.1 seconds and doubles each time until it hits 1.6 seconds, providing a simple
-            # exponential backoff between progress calls.
-            if sleep_time > 0.0:
-                if sleep_time < 1.0:
-                    sleep_time *= 2.0
-            else:
-                sleep_time = 0.1
+            do_sleep = True
         return self
 
     def await_completion(self):

--- a/src/cbc_sdk/platform/jobs.py
+++ b/src/cbc_sdk/platform/jobs.py
@@ -104,6 +104,8 @@ class Job(NewBaseModel):
                 progress_data = self.get_progress()
             except ServerError:
                 progress_data = (1, 0, '')
+            # The sleep time starts at 0.1 seconds and doubles each time until it hits 1.6 seconds, providing a simple
+            # exponential backoff between progress calls.
             if sleep_time > 0.0:
                 if sleep_time < 1.0:
                     sleep_time *= 2.0
@@ -114,6 +116,9 @@ class Job(NewBaseModel):
     def await_completion(self):
         """
         Waits for this job to complete in an asynchronous fashion.
+
+        Returns a Future object which can be used to await results that are ready to fetch. This function call
+        does not block.
 
         Required Permissions:
             jobs.status(READ)

--- a/src/cbc_sdk/platform/jobs.py
+++ b/src/cbc_sdk/platform/jobs.py
@@ -97,12 +97,16 @@ class Job(NewBaseModel):
         """
         progress_data = (1, 0, '')
         do_sleep = False
+        errorcount = 0
         while progress_data[1] < progress_data[0]:
             if do_sleep:
                 time.sleep(0.5)
             try:
                 progress_data = self.get_progress()
             except ServerError:
+                errorcount += 1
+                if errorcount == 3:
+                    raise
                 progress_data = (1, 0, '')
             do_sleep = True
         return self

--- a/src/cbc_sdk/platform/jobs.py
+++ b/src/cbc_sdk/platform/jobs.py
@@ -115,7 +115,7 @@ class Job(NewBaseModel):
 
     def await_completion(self):
         """
-        Waits for this job to complete in an asynchronous fashion.
+        Create a Python Future to check for job completion and return results when available.
 
         Returns a Future object which can be used to await results that are ready to fetch. This function call
         does not block.

--- a/src/cbc_sdk/platform/jobs.py
+++ b/src/cbc_sdk/platform/jobs.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+# *******************************************************
+# Copyright (c) VMware, Inc. 2020. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+# *******************************************************
+# *
+# * DISCLAIMER. THIS PROGRAM IS PROVIDED TO YOU "AS IS" WITHOUT
+# * WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER ORAL OR WRITTEN,
+# * EXPRESS OR IMPLIED. THE AUTHOR SPECIFICALLY DISCLAIMS ANY IMPLIED
+# * WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
+# * NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
+
+"""Model and Query Classes for Jobs API"""
+
+import logging
+from cbc_sdk.base import NewBaseModel, BaseQuery, IterableQueryMixin, AsyncQueryMixin
+
+
+log = logging.getLogger(__name__)
+
+
+class Job(NewBaseModel):
+    urlobject = "/jobs/v1/orgs/{0}/jobs"
+    urlobject_single = "/jobs/v1/orgs/{0}/jobs/{1}"
+    primary_key = "id"
+    swagger_meta_file = "platform/models/job.yaml"
+
+    def __init__(self, cb, model_unique_id, initial_data=None):
+        super(Job, self).__init__(cb, model_unique_id, initial_data)
+        if model_unique_id is not None and initial_data is None:
+            self._refresh()
+        else:
+            self._full_init = True
+
+    @classmethod
+    def _query_implementation(cls, cb, **kwargs):
+        return JobQuery(cls, cb)
+
+    def _refresh(self):
+        url = self.urlobject_single.format(self._cb.credentials.org_key, self._model_unique_id)
+        resp = self._cb.get_object(url)
+        self._info = resp
+        self._full_init = True
+        self._last_refresh_time = time.time()
+        return True
+
+    def get_progress(self):
+        url = self.urlobject_single.format(self._cb.credentials.org_key, self._model_unique_id) + "/progress"
+        resp = self._cb.get_object(url)
+        self._info['progress'] = resp
+        return resp['num_total'], resp['num_completed'], resp['message']
+
+
+class JobQuery(BaseQuery, IterableQueryMixin, AsyncQueryMixin):
+    def __init__(self, doc_class, cb):
+        super(JobQuery, self).__init__(None)
+        self._doc_class = doc_class
+        self._cb = cb
+
+    def _execute(self):
+        """
+        Executes the query and returns the list of raw results.
+
+        Returns:
+            list[dict]: The raw results of the query, as a list of dicts.
+        """
+        rawdata = self._cb.get_object(Job.urlobject.format(self._cb.credentials.org_key))
+        return rawdata.get('results', [])
+
+    def _count(self):
+        """
+        Returns the number of results from the run of this query.
+
+        Returns:
+            int: The number of results from the run of this query.
+        """
+        if not self._count_valid:
+            return_data = self._execute()
+            self._total_results = len(return_data)
+            self._count_valid = True
+        return self._total_results
+
+    def _perform_query(self, from_row=0, max_rows=-1):
+        """
+        Performs the query and returns the results of the query in an iterable fashion.
+
+        Args:
+            from_row (int): Unused in this implementation, always 0.
+            max_rows (int): Unused in this implementation, always -1.
+
+        Returns:
+            Iterable: The iterated query.
+        """
+        return_data = self._execute()
+        self._total_results = len(return_data)
+        self._count_valid = True
+        for item in return_data:
+            yield Job(self._cb, item['id'], item)
+
+    def _run_async_query(self, context):
+        """
+        Executed in the background to run an asynchronous query.
+
+        Args:
+            context (object): Not used; always None.
+
+        Returns:
+            list[Job]: Result of the async query, as a list of Job objects.
+        """
+        return_data = self._execute()
+        output = [Job(self._cb, item['id'], item) for item in return_data]
+        self._total_results = len(output)
+        self._count_valid = True
+        return output

--- a/src/cbc_sdk/platform/models/job.yaml
+++ b/src/cbc_sdk/platform/models/job.yaml
@@ -1,0 +1,61 @@
+type: object
+properties:
+  connector_id:
+    type: string
+    description: Connector ID for the job
+  create_time:
+    type: string
+    format: date-time
+    description: Time this job was created
+  errors:
+    type: string
+    description: Errors for the job
+  id:
+    type: integer
+    format: int64
+    description: ID of the job
+  job_parameters:
+    type: object
+    description: Parameters that were used for this job
+  last_update_time:
+    type: string
+    format: date-time
+    description: Last time this job was updated
+  org_key:
+    type: string
+    description: Organization key of the org this job is being run against
+  owner_id:
+    type: integer
+    format: int64
+    description: ID of the job owner
+  progress:
+    type: object
+    properties:
+      num_total:
+        type: integer
+        format: int64
+        description: Number of items in total
+      num_completed:
+        type: integer
+        format: int64
+        description: Number of items completed
+      message:
+        type: string
+        description: Indicates the current progress of the job
+        enum:
+          - QUEUED
+          - IN_PROGRESS
+          - FINISHED
+  status:
+    type: string
+    description: Current job status
+    enum:
+      - CREATED
+      - FAILED
+      - COMPLETED
+  type:
+    type: string
+    description: Type of job this is
+    enum:
+      - event_export
+      - livequery_export

--- a/src/tests/unit/audit_remediation/test_audit_remediation_base.py
+++ b/src/tests/unit/audit_remediation/test_audit_remediation_base.py
@@ -290,7 +290,7 @@ def test_result_query_async(cbcsdk_mock):
 
 def test_result_query_export_string(cbcsdk_mock):
     """Tests exporting the results of a query as a string."""
-    cbcsdk_mock.mock_request("POST_STREAM", "/livequery/v1/orgs/test/runs/run_id/results/_search?format=csv",
+    cbcsdk_mock.mock_request("STREAM:POST", "/livequery/v1/orgs/test/runs/run_id/results/_search?format=csv",
                              CBCSDKMock.StubResponse("ThisIsFine", 200, "ThisIsFine", False))
     api = cbcsdk_mock.api
     result_query = api.select(Result).run_id("run_id")
@@ -300,7 +300,7 @@ def test_result_query_export_string(cbcsdk_mock):
 
 def test_result_query_export_file(cbcsdk_mock):
     """Tests exporting the results of a query as a file."""
-    cbcsdk_mock.mock_request("POST_STREAM", "/livequery/v1/orgs/test/runs/run_id/results/_search?format=csv",
+    cbcsdk_mock.mock_request("STREAM:POST", "/livequery/v1/orgs/test/runs/run_id/results/_search?format=csv",
                              CBCSDKMock.StubResponse("ThisIsFine", 200, "ThisIsFine", False))
     api = cbcsdk_mock.api
     result_query = api.select(Result).run_id("run_id")
@@ -336,7 +336,7 @@ def test_result_query_async_export(cbcsdk_mock, ref_url, func_raises, get_job):
 def test_result_query_export_lines(cbcsdk_mock):
     """Tests exporting the results of a query as a list of lines."""
     input = "AAA\r\nBBB\r\nCCC"
-    cbcsdk_mock.mock_request("POST_LINES", "/livequery/v1/orgs/test/runs/run_id/results/_search?format=csv",
+    cbcsdk_mock.mock_request("ITERATE:POST", "/livequery/v1/orgs/test/runs/run_id/results/_search?format=csv",
                              CBCSDKMock.StubResponse(input, 200, input, False))
     api = cbcsdk_mock.api
     result_query = api.select(Result).run_id("run_id")
@@ -346,7 +346,7 @@ def test_result_query_export_lines(cbcsdk_mock):
 
 def test_result_query_export_zip(cbcsdk_mock):
     """Tests exporting the results of a query as a zip file."""
-    cbcsdk_mock.mock_request("POST_STREAM",
+    cbcsdk_mock.mock_request("STREAM:POST",
                              "/livequery/v1/orgs/test/runs/run_id/results/_search?format=csv&download=true",
                              CBCSDKMock.StubResponse("ThisIsFine", 200, "ThisIsFine", False))
     api = cbcsdk_mock.api

--- a/src/tests/unit/fixtures/CBCSDKMock.py
+++ b/src/tests/unit/fixtures/CBCSDKMock.py
@@ -32,11 +32,9 @@ class CBCSDKMock:
         self._all_request_data = list()
         monkeypatch.setattr(api, "get_object", self._self_get_object())
         monkeypatch.setattr(api, "get_raw_data", self._self_get_raw_data())
-        monkeypatch.setattr(api, "get_stream_data", self._self_get_stream_data())
-        monkeypatch.setattr(api, "get_lines_data", self._self_get_lines_data())
+        monkeypatch.setattr(api, "api_request_stream", self._self_api_request_stream())
+        monkeypatch.setattr(api, "api_request_iterate", self._self_api_request_iterate())
         monkeypatch.setattr(api, "post_object", self._self_post_object())
-        monkeypatch.setattr(api, "post_and_get_stream", self._self_post_and_get_stream())
-        monkeypatch.setattr(api, "post_and_get_lines", self._self_post_and_get_lines())
         monkeypatch.setattr(api, "post_multipart", self._self_post_multipart())
         monkeypatch.setattr(api, "put_object", self._self_put_object())
         monkeypatch.setattr(api, "delete_object", self._self_delete_object())
@@ -96,8 +94,8 @@ class CBCSDKMock:
         Mocks the VERB + URL by defining the response for that particular request
 
         Args:
-            verb (str): HTTP verb supported [ GET, RAW_GET, GET_STREAM, GET_LINES, POST, POST_STREAM, POST_LINES,
-                                              POST_MULTIPART, PUT, DELETE ]
+            verb (str): HTTP verb supported [ GET, RAW_GET, POST, POST_MULTIPART, PUT, DELETE, STREAM:methodname,
+                                              ITERATE:methodname ]
             url (str): The full path of to be mocked with support for regex
             body (?): Any value or object to be returned as mocked response
 
@@ -149,13 +147,13 @@ class CBCSDKMock:
 
         return _get_raw_data
 
-    def _self_get_stream_data(self):
-        def _get_stream_data(url, stream_output, query_params=None, **kwargs):
-            self._capture_data(query_params)
-            matched = self.match_key(self.get_mock_key("GET_STREAM", url))
+    def _self_api_request_stream(self):
+        def _api_request_stream(method, uri, stream_output, **kwargs):
+            self._capture_data(kwargs)
+            matched = self.match_key(self.get_mock_key(f"STREAM:{method}", uri))
             if matched:
                 if callable(self.mocks[matched]):
-                    result = self.mocks[matched](url, query_params, **kwargs)
+                    result = self.mocks[matched](uri, kwargs.pop("data", {}), **kwargs)
                     return_data = self.StubResponse(result, 200, result, False)
                 elif self.mocks[matched] is Exception or self.mocks[matched] in Exception.__subclasses__():
                     raise self.mocks[matched]
@@ -164,17 +162,17 @@ class CBCSDKMock:
                 if return_data.status_code < 400:
                     stream_output.write(bytes(return_data.text, 'utf-8'))
                 return return_data
-            pytest.fail("GET called for %s when it shouldn't be" % url)
+            pytest.fail(f"{method} called for {uri} when it shouldn't be")
 
-        return _get_stream_data
+        return _api_request_stream
 
-    def _self_get_lines_data(self):
-        def _get_lines_data(url, query_params=None, **kwargs):
-            self._capture_data(query_params)
-            matched = self.match_key(self.get_mock_key("GET_LINES", url))
+    def _self_api_request_iterate(self):
+        def _api_request_iterate(method, uri, **kwargs):
+            self._capture_data(kwargs)
+            matched = self.match_key(self.get_mock_key(f"ITERATE:{method}", uri))
             if matched:
                 if callable(self.mocks[matched]):
-                    result = self.mocks[matched](url, query_params, **kwargs)
+                    result = self.mocks[matched](uri, kwargs.pop("data", {}), **kwargs)
                     return_data = self.StubResponse(result, 200, result, False)
                 elif self.mocks[matched] is Exception or self.mocks[matched] in Exception.__subclasses__():
                     raise self.mocks[matched]
@@ -182,9 +180,9 @@ class CBCSDKMock:
                     return_data = self.mocks[matched]
                 if return_data.status_code < 400:
                     return return_data.text.splitlines()
-            pytest.fail("GET called for %s when it shouldn't be" % url)
+            pytest.fail(f"{method} called for {uri} when it shouldn't be")
 
-        return _get_lines_data
+        return _api_request_iterate
 
     def _self_post_object(self):
         def _post_object(url, body, **kwargs):
@@ -200,43 +198,6 @@ class CBCSDKMock:
             pytest.fail("POST called for %s when it shouldn't be" % url)
 
         return _post_object
-
-    def _self_post_and_get_stream(self):
-        def _post_and_get_stream(url, body, stream_output, **kwargs):
-            self._capture_data(body)
-            matched = self.match_key(self.get_mock_key("POST_STREAM", url))
-            if matched:
-                if callable(self.mocks[matched]):
-                    result = self.mocks[matched](url, body, **kwargs)
-                    return_data = self.StubResponse(result, 200, result, False)
-                elif self.mocks[matched] is Exception or self.mocks[matched] in Exception.__subclasses__():
-                    raise self.mocks[matched]
-                else:
-                    return_data = self.mocks[matched]
-                if return_data.status_code < 400:
-                    stream_output.write(bytes(return_data.text, 'utf-8'))
-                return return_data
-            pytest.fail("POST called for %s when it shouldn't be" % url)
-
-        return _post_and_get_stream
-
-    def _self_post_and_get_lines(self):
-        def _post_and_get_lines(url, body, **kwargs):
-            self._capture_data(body)
-            matched = self.match_key(self.get_mock_key("POST_LINES", url))
-            if matched:
-                if callable(self.mocks[matched]):
-                    result = self.mocks[matched](url, body, **kwargs)
-                    return_data = self.StubResponse(result, 200, result, False)
-                elif self.mocks[matched] is Exception or self.mocks[matched] in Exception.__subclasses__():
-                    raise self.mocks[matched]
-                else:
-                    return_data = self.mocks[matched]
-                if return_data.status_code < 400:
-                    return return_data.text.splitlines()
-            pytest.fail("POST called for %s when it shouldn't be" % url)
-
-        return _post_and_get_lines
 
     def _self_post_multipart(self):
         def _post_multipart(url, param_table, **kwargs):

--- a/src/tests/unit/fixtures/CBCSDKMock.py
+++ b/src/tests/unit/fixtures/CBCSDKMock.py
@@ -96,7 +96,8 @@ class CBCSDKMock:
         Mocks the VERB + URL by defining the response for that particular request
 
         Args:
-            verb (str): HTTP verb supported [ GET, RAW_GET, POST, POST_STREAM, POST_LINES, POST_MULTIPART, PUT, DELETE ]
+            verb (str): HTTP verb supported [ GET, RAW_GET, GET_STREAM, GET_LINES, POST, POST_STREAM, POST_LINES,
+                                              POST_MULTIPART, PUT, DELETE ]
             url (str): The full path of to be mocked with support for regex
             body (?): Any value or object to be returned as mocked response
 

--- a/src/tests/unit/fixtures/platform/mock_jobs.py
+++ b/src/tests/unit/fixtures/platform/mock_jobs.py
@@ -55,3 +55,21 @@ PROGRESS_2 = {
     "num_completed": 16,
     "message": "Foo"
 }
+
+AWAIT_COMPLETION_PROGRESS = [
+    {
+        "num_total": 18,
+        "num_completed": 0,
+        "message": ""
+    },
+    {
+        "num_total": 18,
+        "num_completed": 10,
+        "message": ""
+    },
+    {
+        "num_total": 18,
+        "num_completed": 18,
+        "message": ""
+    },
+]

--- a/src/tests/unit/fixtures/platform/mock_jobs.py
+++ b/src/tests/unit/fixtures/platform/mock_jobs.py
@@ -1,0 +1,57 @@
+"""Mock responses for Job"""
+
+_JOB1 = {
+    "id": 12345,
+    "type": "livequery_export",
+    "job_parameters": {
+        "job_parameters": None
+    },
+    "connector_id": "ABCDEFGHIJ",
+    "org_key": "test",
+    "status": "COMPLETED",
+    "progress": {
+        "num_total": 18,
+        "num_completed": 18
+    },
+    "create_time": "2022-01-04T19:18:58.213Z",
+    "last_update_time": "2022-01-04T19:18:59.385Z"
+}
+
+
+_JOB2 = {
+    "id": 23456,
+    "type": "livequery_export",
+    "job_parameters": {
+        "job_parameters": None
+    },
+    "connector_id": "ABCDEFGHIJ",
+    "org_key": "test",
+    "status": "CREATED",
+    "progress": {
+        "num_total": 34,
+        "num_completed": 16
+    },
+    "create_time": "2022-01-04T19:18:58.213Z",
+    "last_update_time": "2022-01-04T19:18:59.385Z"
+}
+
+
+FIND_ALL_JOBS_RESP = {
+    "num_found": 2,
+    "results": [_JOB1, _JOB2]
+}
+
+JOB_DETAILS_1 = _JOB1
+
+JOB_DETAILS_2 = _JOB2
+
+PROGRESS_1 = {
+    "num_total": 18,
+    "num_completed": 18
+}
+
+PROGRESS_2 = {
+    "num_total": 34,
+    "num_completed": 16,
+    "message": "Foo"
+}

--- a/src/tests/unit/platform/test_jobs.py
+++ b/src/tests/unit/platform/test_jobs.py
@@ -6,10 +6,11 @@ import io
 import os
 from tempfile import mkstemp
 from cbc_sdk.platform import Job
+from cbc_sdk.errors import ServerError
 from cbc_sdk.rest_api import CBCloudAPI
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from tests.unit.fixtures.platform.mock_jobs import (FIND_ALL_JOBS_RESP, JOB_DETAILS_1, JOB_DETAILS_2, PROGRESS_1,
-                                                    PROGRESS_2)
+                                                    PROGRESS_2, AWAIT_COMPLETION_PROGRESS)
 
 
 logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
@@ -94,6 +95,32 @@ def test_load_job_and_get_progress(cbcsdk_mock, jobid, total, completed, msg, lo
     assert my_total == total
     assert my_completed == completed
     assert my_message == msg
+
+
+def test_job_await_completion(cbcsdk_mock):
+    """Test the functionality of await_completion()."""
+    first_time = True
+    pr_index = 0
+
+    def on_progress(url, query_params, default):
+        nonlocal first_time, pr_index
+        if first_time:
+            first_time = False
+            raise ServerError(400, "Not yet")
+        assert pr_index < len(AWAIT_COMPLETION_PROGRESS), "Too many progress calls made"
+        return_value = AWAIT_COMPLETION_PROGRESS[pr_index]
+        pr_index += 1
+        return return_value
+
+    cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs/12345', JOB_DETAILS_1)
+    cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs/12345/progress', on_progress)
+    api = cbcsdk_mock.api
+    job = api.select(Job, 12345)
+    future = job.await_completion()
+    result = future.result()
+    assert result is job
+    assert first_time is False
+    assert pr_index == len(AWAIT_COMPLETION_PROGRESS)
 
 
 def test_job_output_export_string(cbcsdk_mock):

--- a/src/tests/unit/platform/test_jobs.py
+++ b/src/tests/unit/platform/test_jobs.py
@@ -1,0 +1,134 @@
+"""Tests for the Job object of the CBC SDK"""
+
+import pytest
+import logging
+import io
+import os
+from tempfile import mkstemp
+from cbc_sdk.platform import Job
+from cbc_sdk.rest_api import CBCloudAPI
+from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
+from tests.unit.fixtures.platform.mock_jobs import (FIND_ALL_JOBS_RESP, JOB_DETAILS_1, JOB_DETAILS_2, PROGRESS_1,
+                                                    PROGRESS_2)
+
+
+logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
+
+
+@pytest.fixture(scope="function")
+def cb():
+    """Create CBCloudAPI singleton"""
+    return CBCloudAPI(url="https://example.com",
+                      org_key="test",
+                      token="abcd/1234",
+                      ssl_verify=False)
+
+
+@pytest.fixture(scope="function")
+def cbcsdk_mock(monkeypatch, cb):
+    """Mocks CBC SDK for unit tests"""
+    return CBCSDKMock(monkeypatch, cb)
+
+
+def new_tempfile():
+    """Create a temporary file and return the name of it."""
+    rc = mkstemp()
+    os.close(rc[0])
+    return rc[1]
+
+
+def file_contents(filename):
+    """Return a string containing the contents of the file."""
+    with io.open(filename, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+# ==================================== UNIT TESTS BELOW ====================================
+
+def test_get_jobs(cbcsdk_mock):
+    """Tests getting the list of all jobs."""
+    cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs', FIND_ALL_JOBS_RESP)
+    api = cbcsdk_mock.api
+    query = api.select(Job)
+    assert query._count() == 2
+    list_jobs = list(query)
+    assert len(list_jobs) == 2
+    assert list_jobs[0].id == 12345
+    assert list_jobs[0].status == 'COMPLETED'
+    assert list_jobs[0].progress['num_total'] == 18
+    assert list_jobs[0].progress['num_completed'] == 18
+    assert list_jobs[1].id == 23456
+    assert list_jobs[1].status == 'CREATED'
+    assert list_jobs[1].progress['num_total'] == 34
+    assert list_jobs[1].progress['num_completed'] == 16
+
+
+def test_get_jobs_async(cbcsdk_mock):
+    """Tests getting the list of all jobs in an asynchronous fashion."""
+    cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs', FIND_ALL_JOBS_RESP)
+    api = cbcsdk_mock.api
+    future = api.select(Job).execute_async()
+    list_jobs = future.result()
+    assert len(list_jobs) == 2
+    assert list_jobs[0].id == 12345
+    assert list_jobs[0].status == 'COMPLETED'
+    assert list_jobs[0].progress['num_total'] == 18
+    assert list_jobs[0].progress['num_completed'] == 18
+    assert list_jobs[1].id == 23456
+    assert list_jobs[1].status == 'CREATED'
+    assert list_jobs[1].progress['num_total'] == 34
+    assert list_jobs[1].progress['num_completed'] == 16
+
+
+@pytest.mark.parametrize("jobid, total, completed, msg, load_return, progress_return", [
+    (12345, 18, 18, None, JOB_DETAILS_1, PROGRESS_1),
+    (23456, 34, 16, 'Foo', JOB_DETAILS_2, PROGRESS_2)
+])
+def test_load_job_and_get_progress(cbcsdk_mock, jobid, total, completed, msg, load_return, progress_return):
+    """Tests loading a job by ID and getting its progress indicators."""
+    cbcsdk_mock.mock_request('GET', f'/jobs/v1/orgs/test/jobs/{jobid}', load_return)
+    cbcsdk_mock.mock_request('GET', f'/jobs/v1/orgs/test/jobs/{jobid}/progress', progress_return)
+    api = cbcsdk_mock.api
+    job = api.select(Job, jobid)
+    my_total, my_completed, my_message = job.get_progress()
+    assert my_total == total
+    assert my_completed == completed
+    assert my_message == msg
+
+
+def test_job_output_export_string(cbcsdk_mock):
+    """Tests exporting the results of a job as a string."""
+    cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs/12345', JOB_DETAILS_1)
+    cbcsdk_mock.mock_request('GET_STREAM', '/jobs/v1/orgs/test/jobs/12345/download',
+                             CBCSDKMock.StubResponse("ThisIsFine", 200, "ThisIsFine", False))
+    api = cbcsdk_mock.api
+    job = api.select(Job, 12345)
+    output = job.get_output_as_string()
+    assert output == "ThisIsFine"
+
+
+def test_job_output_export_file(cbcsdk_mock):
+    """Tests exporting the results of a job as a file."""
+    cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs/12345', JOB_DETAILS_1)
+    cbcsdk_mock.mock_request('GET_STREAM', '/jobs/v1/orgs/test/jobs/12345/download',
+                             CBCSDKMock.StubResponse("ThisIsFine", 200, "ThisIsFine", False))
+    api = cbcsdk_mock.api
+    job = api.select(Job, 12345)
+    tempfile = new_tempfile()
+    try:
+        job.get_output_as_file(tempfile)
+        assert file_contents(tempfile) == "ThisIsFine"
+    finally:
+        os.remove(tempfile)
+
+
+def test_job_output_export_lines(cbcsdk_mock):
+    """Tests exporting the results of a query as a list of lines."""
+    cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs/12345', JOB_DETAILS_1)
+    data = "AAA\r\nBBB\r\nCCC"
+    cbcsdk_mock.mock_request('GET_LINES', '/jobs/v1/orgs/test/jobs/12345/download',
+                             CBCSDKMock.StubResponse(data, 200, data, False))
+    api = cbcsdk_mock.api
+    job = api.select(Job, 12345)
+    output = list(job.get_output_as_lines())
+    assert output == ["AAA", "BBB", "CCC"]

--- a/src/tests/unit/platform/test_jobs.py
+++ b/src/tests/unit/platform/test_jobs.py
@@ -99,7 +99,7 @@ def test_load_job_and_get_progress(cbcsdk_mock, jobid, total, completed, msg, lo
 def test_job_output_export_string(cbcsdk_mock):
     """Tests exporting the results of a job as a string."""
     cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs/12345', JOB_DETAILS_1)
-    cbcsdk_mock.mock_request('GET_STREAM', '/jobs/v1/orgs/test/jobs/12345/download',
+    cbcsdk_mock.mock_request('STREAM:GET', '/jobs/v1/orgs/test/jobs/12345/download',
                              CBCSDKMock.StubResponse("ThisIsFine", 200, "ThisIsFine", False))
     api = cbcsdk_mock.api
     job = api.select(Job, 12345)
@@ -110,7 +110,7 @@ def test_job_output_export_string(cbcsdk_mock):
 def test_job_output_export_file(cbcsdk_mock):
     """Tests exporting the results of a job as a file."""
     cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs/12345', JOB_DETAILS_1)
-    cbcsdk_mock.mock_request('GET_STREAM', '/jobs/v1/orgs/test/jobs/12345/download',
+    cbcsdk_mock.mock_request('STREAM:GET', '/jobs/v1/orgs/test/jobs/12345/download',
                              CBCSDKMock.StubResponse("ThisIsFine", 200, "ThisIsFine", False))
     api = cbcsdk_mock.api
     job = api.select(Job, 12345)
@@ -126,7 +126,7 @@ def test_job_output_export_lines(cbcsdk_mock):
     """Tests exporting the results of a query as a list of lines."""
     cbcsdk_mock.mock_request('GET', '/jobs/v1/orgs/test/jobs/12345', JOB_DETAILS_1)
     data = "AAA\r\nBBB\r\nCCC"
-    cbcsdk_mock.mock_request('GET_LINES', '/jobs/v1/orgs/test/jobs/12345/download',
+    cbcsdk_mock.mock_request('ITERATE:GET', '/jobs/v1/orgs/test/jobs/12345/download',
                              CBCSDKMock.StubResponse(data, 200, data, False))
     api = cbcsdk_mock.api
     job = api.select(Job, 12345)

--- a/src/tests/unit/test_base_api.py
+++ b/src/tests/unit/test_base_api.py
@@ -257,6 +257,7 @@ def test_BaseAPI_get_raw_data_raises_from_returns(mox, response, errcode, prefix
     ({'a': 1, 'b': 2}, '/path?a=1&b=2')
 ])
 def test_BaseAPI_get_stream_data(mox, qparam, actual_path):
+    """Test the operation of get_stream_data."""
     sut = BaseAPI(url='https://example.com', token='ABCDEFGH', org_key='A1B2C3D4')
     mox.StubOutWithMock(sut.session, 'http_request')
     sut.session.http_request('GET', actual_path, headers=IgnoreArg(), stream=True) \
@@ -274,6 +275,7 @@ def test_BaseAPI_get_stream_data(mox, qparam, actual_path):
     ({'a': 1, 'b': 2}, '/path?a=1&b=2')
 ])
 def test_BaseAPI_get_lines_data(mox, qparam, actual_path):
+    """Test the operation of get_lines_data."""
     sut = BaseAPI(url='https://example.com', token='ABCDEFGH', org_key='A1B2C3D4')
     mox.StubOutWithMock(sut.session, 'http_request')
     sut.session.http_request('GET', actual_path, headers=IgnoreArg(), stream=True) \

--- a/src/tests/unit/test_base_api.py
+++ b/src/tests/unit/test_base_api.py
@@ -22,7 +22,7 @@ from cbc_sdk.errors import CredentialError, ServerError
 from cbc_sdk.credential_providers.default import default_provider_object
 from tests.unit.fixtures.mock_credentials import MockCredentialProvider
 from tests.unit.fixtures.stubresponse import StubResponse
-from mox import Func, IgnoreArg
+from mox import Func
 
 
 def test_BaseAPI_init_with_raw_credential_params():


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3296

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added support for retrieving results for a Live Query via an asynchronous job.  Includes adding support for the Job Service API to the Platform part of the SDK. Job results may be retrieved as stream output, file download, one big string, or an iterated list of lines, as with existing LiveQuery results support.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Job service has been run against PROD02 successfully. Unit tests have been added for all new code.  Coverage of new Jobs API is at 100%. No net loss of coverage in other portions of the SDK.  Test script run against PROD02 is as follows:
```
#!/usr/bin/env python

from cbc_sdk import CBCloudAPI
from cbc_sdk.audit_remediation import Run

api = CBCloudAPI(profile='prod02-super')
run = api.select(Run, 'uerrofnzcdgychxi9icquislzjhclswo')
job = run.query_results().async_export()
print(f"New job created with ID {job.id}")
future = job.await_completion()
for s in future.result().get_output_as_lines():
    print(s)
```
