### PR TITLE
CBAPI-3415: fixed rendering of empty dicts inside an object

### DIFF
--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -608,7 +608,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
                 attr_names.append(attr)
             elif isinstance(attr, dict):
                 attr_names.extend(attr.keys())
-        return max([len(s) for s in attr_names])
+        return max([len(s) for s in attr_names]) if attr_names else 0
 
     def _str_attr_line(self, name, value, name_field_len, top_level=True):
         """
@@ -665,7 +665,8 @@ class NewBaseModel(object, metaclass=CbMetaModel):
         elif isinstance(value, dict) and top_level:
             # append the dict elements
             lines.append(format_str.format(status, name.rjust(name_field_len), '[dict] {'))
-            lines.extend([f"{' ' * (spacing + 4)}{sub_line}" for sub_line in self._str_dict_lines(value, False)])
+            if len(value) > 0:
+                lines.extend([f"{' ' * (spacing + 4)}{sub_line}" for sub_line in self._str_dict_lines(value, False)])
             lines.append(f"{' ' * spacing}{'}'}")
         else:
             # ordinary case

--- a/src/tests/unit/base/test_base_models.py
+++ b/src/tests/unit/base/test_base_models.py
@@ -481,6 +481,7 @@ def test_str_attr_line(cb):
         "objlist": [1, 2, 3, 5, 8, 13],
         "empty": [],
         "objdict": {"a": 1, "b": 2, "c": 3},
+        "emptydict": {},
         "mini_me": subobject_data,
         "List1": [listobj_data],
         "List2": [listobj_data, listobj2_data]
@@ -518,6 +519,9 @@ def test_str_attr_line(cb):
     rendering = my_object._str_attr_line('objdict', object_data['objdict'], name_field_len, False)
     assert len(rendering) == 1
     assert rendering[0].startswith('  objdict: {')
+    rendering = my_object._str_attr_line('emptydict', object_data['emptydict'], name_field_len, False)
+    assert len(rendering) == 1
+    assert rendering[0].startswith('emptydict: {')
     # Test rendering of subobject data (subobject mode)
     rendering = my_object._str_attr_line('mini_me', object_data['mini_me'], name_field_len, False)
     assert len(rendering) == 1
@@ -561,6 +565,10 @@ def test_str_attr_line(cb):
     assert rendering[2] == '                   b: 2'
     assert rendering[3] == '                   c: 3'
     assert rendering[4] == '               }'
+    rendering = my_object._str_attr_line('emptydict', object_data['emptydict'], name_field_len)
+    assert len(rendering) == 2
+    assert rendering[0] == '    emptydict: [dict] {'
+    assert rendering[1] == '               }'
     # Test rendering of subobject data (top-level mode) including lists in subobject
     rendering = my_object._str_attr_line('mini_me', object_data['mini_me'], name_field_len)
     assert len(rendering) == 10


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3415

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Reported by Kylie: In some cases, printing a Result object would cause an exception.  This happened with Results that had no fields, and hence their "fields" field was an empty dict.  Enhancements have been made in the code to properly print an empty dict, and to keep this exception from ever being raised again.

With this fix in place, a Result object with an empty dict now prints as follows:
```
Result object, bound to https://defense.conferdeploy.net.
-------------------------------------------------------------------------------

            device: [dict] {
                                 id: [elided]
                               name: [elided]
                                 os: WINDOWS
                          policy_id: [elided]
                        policy_name: default
                    }
    device_message: 
            fields: [dict] {
                    }
                id: [elided]
            status: not_matched
     time_received: 2022-01-11T23:54:11.123Z
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Additional unit test code has been added to explicitly test rendering an empty dictionary as an object field.  Kylie's specific scenario was verified by creating and running the following snippet:
```
#!/usr/bin/env python

from cbc_sdk import CBCloudAPI
from cbc_sdk.audit_remediation import Result
api = CBCloudAPI(profile='prod02-super')
query = api.select(Result).run_id('[identifier elided]')
l = list(query)
for result in l:
    print(result)
```
