### PR TITLE
add a note about resolving "No module" errors when doing Sphinx doc build

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ make html
 
 The documentation is built in `docs/_build/html`.
 
+**N.B.:** If your documentation pages appear to generate incorrectly, check to see if you received the warning message
+`No module named 'cbc_sdk'`.  If so, set your `PYTHONPATH` to include the `src/` subdirectory of the SDK project
+directory before running `make html`, or the equivalent command `sphinx-build -M html . _build`.
+
 #### Using Docker
 
 Build the documentation by running:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
N/A

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added a note in the section of the `README.md` on generating the docs that, if the docs appear to generate incorrectly and the warnings indicate that Sphinx can't find the `cbc_sdk` module, setting the `PYTHONPATH` beforehand will resolve this. I stumbled into this particular trap myself, so I'm ensuring that I've documented the way out.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
`README.md` update only, no code changes.