### PR TITLE
CBAPI-3379: Add Device Facet API to CBC SDK

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ autoclass_content = 'both'
 # options for sphinx generation
 copybutton_prompt_text = ">>> "
 
+
 def setup(app):
     """Setup Sphinx."""
     app.add_css_file('css/custom.css')

--- a/src/cbc_sdk/platform/__init__.py
+++ b/src/cbc_sdk/platform/__init__.py
@@ -5,7 +5,7 @@ from cbc_sdk.platform.base import PlatformModel
 from cbc_sdk.platform.alerts import (BaseAlert, WatchlistAlert, CBAnalyticsAlert, DeviceControlAlert,
                                      Workflow, WorkflowStatus)
 
-from cbc_sdk.platform.devices import Device, DeviceSearchQuery
+from cbc_sdk.platform.devices import Device, DeviceFacet, DeviceSearchQuery
 
 from cbc_sdk.platform.events import Event, EventFacet
 

--- a/src/cbc_sdk/platform/devices.py
+++ b/src/cbc_sdk/platform/devices.py
@@ -293,8 +293,15 @@ class DeviceFacet(UnrefreshableModel):
             """
             Set up a device query to find all devices that match this facet value.
 
+            Example:
+                >>> facets = api.select(Device).where('').facets(['policy_id'])
+                >>> for value in facets[0].values_:
+                ...     print(f"Policy ID = {value.id}:")
+                ...     for dev in value.query_devices():
+                ...         print(f"    {dev.name} ({dev.last_external_ip_address})")
+
             Returns:
-                DeviceQuery: The new DeviceQuery, which may have additional criteria added to it.
+                DeviceQuery: A new DeviceQuery set with the criteria, which may have additional criteria added to it.
             """
             query = self._cb.select(Device)
             if self._outer.field == 'policy_id':
@@ -755,6 +762,12 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
     def facets(self, fieldlist, max_rows=0):
         """
         Return information about the facets for all known evices, using the defined criteria.
+
+        Example:
+            >>> query = api.select(Device).where('')
+            >>> facets = query.facets(['policy_id', 'status', 'os', 'ad_group_id'])
+            >>> for f in facets:
+            ...     print(f"Field {f.field} - {len(f.values_)} distinct values")
 
         Required Permissions:
             device (READ)

--- a/src/cbc_sdk/platform/devices.py
+++ b/src/cbc_sdk/platform/devices.py
@@ -765,7 +765,6 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         result = resp.json()
         return [DeviceFacet(self._cb, None, item) for item in result['results']]
 
-
     def download(self):
         """
         Uses the query parameters that have been set to download all device listings in CSV format.

--- a/src/cbc_sdk/platform/devices.py
+++ b/src/cbc_sdk/platform/devices.py
@@ -13,11 +13,11 @@
 
 """Model and Query Classes for Platform Devices"""
 
-from cbc_sdk.errors import ApiError, ServerError
+from cbc_sdk.errors import ApiError, ServerError, NonQueryableModel
 from cbc_sdk.platform import PlatformModel
 from cbc_sdk.platform.vulnerability_assessment import Vulnerability, VulnerabilityQuery
-from cbc_sdk.base import (BaseQuery, QueryBuilder, QueryBuilderSupportMixin, CriteriaBuilderSupportMixin,
-                          IterableQueryMixin, AsyncQueryMixin)
+from cbc_sdk.base import (UnrefreshableModel, BaseQuery, QueryBuilder, QueryBuilderSupportMixin,
+                          CriteriaBuilderSupportMixin, IterableQueryMixin, AsyncQueryMixin)
 
 import time
 
@@ -72,6 +72,9 @@ class Device(PlatformModel):
         """
         Rereads the device data from the server.
 
+        Required Permissions:
+            device (READ)
+
         Returns:
             bool: True if refresh was successful, False if not.
         """
@@ -85,6 +88,9 @@ class Device(PlatformModel):
         """
         Retrieve a Live Response session object for this Device.
 
+        Required Permissions:
+            org.liveresponse.session (CREATE)
+
         Returns:
             LiveResponseSession: Live Response session for the Device.
 
@@ -96,6 +102,9 @@ class Device(PlatformModel):
     def background_scan(self, flag):
         """
         Set the background scan option for this device.
+
+        Required Permissions:
+            device.bg-scan (EXECUTE)
 
         Args:
             flag (bool): True to turn background scan on, False to turn it off.
@@ -109,6 +118,9 @@ class Device(PlatformModel):
         """
         Set the bypass option for this device.
 
+        Required Permissions:
+            device.bypass (EXECUTE)
+
         Args:
             flag (bool): True to enable bypass, False to disable it.
 
@@ -121,6 +133,9 @@ class Device(PlatformModel):
         """
         Delete this sensor device.
 
+        Required Permissions:
+            device.deregistered (DELETE)
+
         Returns:
             str: The JSON output from the request.
         """
@@ -130,6 +145,9 @@ class Device(PlatformModel):
         """
         Uninstall this sensor device.
 
+        Required Permissions:
+            device.uninstall (EXECUTE)
+
         Returns:
             str: The JSON output from the request.
         """
@@ -138,6 +156,9 @@ class Device(PlatformModel):
     def quarantine(self, flag):
         """
         Set the quarantine option for this device.
+
+        Required Permissions:
+            device.quarantine (EXECUTE)
 
         Args:
             flag (bool): True to enable quarantine, False to disable it.
@@ -151,6 +172,9 @@ class Device(PlatformModel):
         """
         Set the current policy for this device.
 
+        Required Permissions:
+            device.policy (UPDATE)
+
         Args:
             policy_id (int): ID of the policy to set for the devices.
 
@@ -163,6 +187,9 @@ class Device(PlatformModel):
         """
         Update the sensor version for this device.
 
+        Required Permissions:
+            org.kits (EXECUTE)
+
         Args:
             sensor_version (dict): New version properties for the sensor.
 
@@ -172,7 +199,12 @@ class Device(PlatformModel):
         return self._cb.device_update_sensor_version([self._model_unique_id], sensor_version)
 
     def vulnerability_refresh(self):
-        """Perform an action on a specific device. Only REFRESH is supported."""
+        """
+        Perform an action on a specific device. Only REFRESH is supported.
+
+        Required Permissions:
+            vulnerabilityAssessment.data (EXECUTE)
+        """
         request = {"action_type": 'REFRESH'}
         url = "/vulnerability/assessment/api/v1/orgs/{}".format(self._cb.credentials.org_key)
 
@@ -189,6 +221,9 @@ class Device(PlatformModel):
     def get_vulnerability_summary(self, category=None):
         """
         Get the vulnerabilities associated with this device
+
+        Required Permissions:
+            vulnerabilityAssessment.data (READ)
 
         Args:
             category (string): (optional) vulnerabilty category (OS, APP)
@@ -220,6 +255,77 @@ class Device(PlatformModel):
         return VulnerabilityQuery(Vulnerability, self._cb, self)
 
 
+class DeviceFacet(UnrefreshableModel):
+    """Represents a device field in a facet search."""
+    urlobject = "/appservices/v6/orgs/{0}/devices/_facet"
+    primary_key = "id"
+    swagger_meta_file = "platform/models/device_facet.yaml"
+
+    def __init__(self, cb, model_unique_id, initial_data=None):
+        """
+        Initialize the DeviceFacet object.
+
+        Args:
+            cb (BaseAPI): Reference to API object used to communicate with the server.
+            model_unique_id (str): Not used.
+            initial_data (dict): Initial data used to populate the facet.
+        """
+        super(DeviceFacet, self).__init__(cb, model_unique_id, initial_data, force_init=False, full_doc=True)
+        self._values = [DeviceFacet.DeviceFacetValue(cb, item['id'], item) for item in initial_data['values']]
+
+    class DeviceFacetValue(UnrefreshableModel):
+        """Represents a value of a particular field."""
+        def __init__(self, cb, model_unique_id, initial_data):
+            """
+            Initialize the DeviceFacetValue object.
+
+            Args:
+                cb (BaseAPI): Reference to API object used to communicate with the server.
+                model_unique_id (str): Value ID.
+                initial_data (dict): Initial data used to populate the facet value.
+            """
+            super(DeviceFacet.DeviceFacetValue, self).__init__(cb, model_unique_id, initial_data, force_init=False,
+                                                               full_doc=True)
+
+    @classmethod
+    def _query_implementation(cls, cb, **kwargs):
+        """
+        Returns the appropriate query object for the Device type.
+
+        Args:
+            cb (BaseAPI): Reference to API object used to communicate with the server.
+            **kwargs (dict): Not used, retained for compatibility.
+
+        Returns:
+            DeviceFacetQuery: The query object for this alert type.
+        """
+        raise NonQueryableModel("use facets() on DeviceQuery to get DeviceFacet")
+
+    def _subobject(self, name):
+        """
+        Returns the "subobject value" of the given attribute.
+
+        Args:
+            name (str): Name of the subobject value to be returned.
+
+        Returns:
+            Any: Subobject value for the attribute, or None if there is none.
+        """
+        if name == 'values':
+            return self._values
+        return super(DeviceFacet, self)._subobject(name)
+
+    @property
+    def values_(self):
+        """
+        Return the list of facet values for this facet.
+
+        Returns:
+            list[DeviceFacetValue]: The list of values for this facet.
+        """
+        return self._values
+
+
 ############################################
 # Device Queries
 
@@ -234,6 +340,7 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
     VALID_PRIORITIES = ["LOW", "MEDIUM", "HIGH", "MISSION_CRITICAL"]
     VALID_DIRECTIONS = ["ASC", "DESC"]
     VALID_DEPLOYMENT_TYPES = ["ENDPOINT", "WORKLOAD"]
+    VALID_FACET_FIELDS = ["policy_id", "status", "os", "ad_group_id"]
 
     def __init__(self, doc_class, cb):
         """
@@ -533,6 +640,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         """
         Returns the number of results from the run of this query.
 
+        Required Permissions:
+            device (READ)
+
         Returns:
             int: The number of results from the run of this query.
         """
@@ -554,6 +664,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         Performs the query and returns the results of the query in an iterable fashion.
 
         Device v6 API uses base 1 instead of 0.
+
+        Required Permissions:
+            device (READ)
 
         Args:
             from_row (int): The row to start the query at (default 1).
@@ -593,6 +706,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         """
         Executed in the background to run an asynchronous query. Must be implemented in any inheriting classes.
 
+        Required Permissions:
+            device (READ)
+
         Args:
             context (object): The context returned by _init_async_query. May be None.
 
@@ -616,12 +732,49 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
             output += [self._doc_class(self._cb, item["id"], item) for item in results]
         return output
 
+    def facets(self, fieldlist, max_rows=0):
+        """
+        Return information about the facets for all known evices, using the defined criteria.
+
+        Required Permissions:
+            device (READ)
+
+        Args:
+            fieldlist (list[str]): List of facet field names. Valid names are "policy_id", "status", "os",
+                                   and "ad_group_id".
+            max_rows (int): The maximum number of rows to return. 0 means return all rows.
+
+        Returns:
+            list[DeviceFacet]: A list of facet information.
+        """
+        if not fieldlist:
+            raise ApiError("At least one term field must be specified")
+        if not all((field in DeviceSearchQuery.VALID_FACET_FIELDS) for field in fieldlist):
+            raise ApiError("One or more invalid term field names")
+        request = self._build_request(-1, -1)
+        if 'rows' in request:
+            del request['rows']
+        if 'sort' in request:
+            del request['sort']
+        terms = {'fields': fieldlist}
+        if max_rows > 0:
+            terms['rows'] = max_rows
+        request['terms'] = terms
+        url = self._build_url("/_facet")
+        resp = self._cb.post_object(url, body=request)
+        result = resp.json()
+        return [DeviceFacet(self._cb, None, item) for item in result['results']]
+
+
     def download(self):
         """
         Uses the query parameters that have been set to download all device listings in CSV format.
 
         Example:
             >>> cb.select(Device).set_status(["ALL"]).download()
+
+        Required Permissions:
+            device (READ)
 
         Returns:
             str: The CSV raw data as returned from the server.
@@ -655,6 +808,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         """
         Perform a bulk action on all devices matching the current search criteria.
 
+        Required Permissions:
+            Dependent on the action_type.
+
         Args:
             action_type (str): The action type to be performed.
             options (dict): Any options for the bulk device action.
@@ -671,6 +827,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         """
         Set the background scan option for the specified devices.
 
+        Required Permissions:
+            device.bg-scan (EXECUTE)
+
         Args:
             scan (bool): True to turn background scan on, False to turn it off.
 
@@ -682,6 +841,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
     def bypass(self, enable):
         """
         Set the bypass option for the specified devices.
+
+        Required Permissions:
+            device.bypass (EXECUTE)
 
         Args:
             enable (bool): True to enable bypass, False to disable it.
@@ -695,6 +857,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         """
         Delete the specified sensor devices.
 
+        Required Permissions:
+            device.deregistered (DELETE)
+
         Returns:
             str: The JSON output from the request.
         """
@@ -704,6 +869,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         """
         Uninstall the specified sensor devices.
 
+        Required Permissions:
+            device.uninstall (EXECUTE)
+
         Returns:
             str: The JSON output from the request.
         """
@@ -712,6 +880,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
     def quarantine(self, enable):
         """
         Set the quarantine option for the specified devices.
+
+        Required Permissions:
+            device.quarantine (EXECUTE)
 
         Args:
             enable (bool): True to enable quarantine, False to disable it.
@@ -725,6 +896,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         """
         Set the current policy for the specified devices.
 
+        Required Permissions:
+            device.policy (UPDATE)
+
         Args:
             policy_id (int): ID of the policy to set for the devices.
 
@@ -736,6 +910,9 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
     def update_sensor_version(self, sensor_version):
         """
         Update the sensor version for the specified devices.
+
+        Required Permissions:
+            org.kits (EXECUTE)
 
         Args:
             sensor_version (dict): New version properties for the sensor.

--- a/src/cbc_sdk/platform/models/device_facet.yaml
+++ b/src/cbc_sdk/platform/models/device_facet.yaml
@@ -1,0 +1,19 @@
+type: object
+properties:
+  field:
+    type: string
+    description: Name of the field being faceted
+  values:
+    type: array
+    description: The values of the faceted field.
+    items:
+      total:
+        type: integer
+        format: int64
+        description: Number of devices with this particular facet value
+      id:
+        type: string
+        description: ID of the facet value
+      name:
+        type: string
+        description: Name of the facet value

--- a/src/tests/unit/fixtures/platform/mock_devices.py
+++ b/src/tests/unit/fixtures/platform/mock_devices.py
@@ -273,3 +273,63 @@ POST_DEVICE_SEARCH_RESP = {
     ],
     "num_found": 1
 }
+
+FACET_RESPONSE = {
+    "results": [
+        {
+            "field": "policy_id",
+            "values": [
+                {
+                    "total": 788,
+                    "id": "6525",
+                    "name": "6525"
+                },
+                {
+                    "total": 25,
+                    "id": "7691",
+                    "name": "7691"
+                },
+                {
+                    "total": 9,
+                    "id": "68727",
+                    "name": "68727"
+                },
+                {
+                    "total": 7,
+                    "id": "65066",
+                    "name": "65066"
+                },
+                {
+                    "total": 4,
+                    "id": "69390",
+                    "name": "69390"
+                },
+                {
+                    "total": 1,
+                    "id": "35704",
+                    "name": "35704"
+                },
+                {
+                    "total": 1,
+                    "id": "6527",
+                    "name": "6527"
+                },
+                {
+                    "total": 1,
+                    "id": "71498",
+                    "name": "71498"
+                },
+                {
+                    "total": 1,
+                    "id": "78483",
+                    "name": "78483"
+                },
+                {
+                    "total": 1,
+                    "id": "86029",
+                    "name": "86029"
+                }
+            ]
+        }
+    ]
+}

--- a/src/tests/unit/fixtures/platform/mock_devices.py
+++ b/src/tests/unit/fixtures/platform/mock_devices.py
@@ -333,3 +333,47 @@ FACET_RESPONSE = {
         }
     ]
 }
+
+FACET_INIT_1 = {
+    "field": "policy_id",
+    "values": [
+        {
+            "total": 9,
+            "id": "68727",
+            "name": "68727"
+        }
+    ]
+}
+
+FACET_INIT_2 = {
+    "field": "status",
+    "values": [
+        {
+            "total": 115,
+            "id": "ACTIVE",
+            "name": "ACTIVE"
+        }
+    ]
+}
+
+FACET_INIT_3 = {
+    "field": "os",
+    "values": [
+        {
+            "total": 81,
+            "id": "linux",
+            "name": "linux"
+        }
+    ]
+}
+
+FACET_INIT_4 = {
+    "field": "ad_group_id",
+    "values": [
+        {
+            "total": 2,
+            "id": "955",
+            "name": "955"
+        }
+    ]
+}

--- a/src/tests/unit/platform/test_devicev6_api.py
+++ b/src/tests/unit/platform/test_devicev6_api.py
@@ -15,262 +15,197 @@ import pytest
 from cbc_sdk.errors import ApiError, ServerError
 from cbc_sdk.platform import Device
 from cbc_sdk.rest_api import CBCloudAPI
-from tests.unit.fixtures.stubresponse import StubResponse, patch_cbc_sdk_api
+from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
+from tests.unit.fixtures.platform.mock_devices import FACET_RESPONSE
 
 
-def call_cbcloud_api():
-    """Call the CBCloudAPI object"""
-    return CBCloudAPI(url="https://example.com", token="ABCD/1234", org_key="Z100", ssl_verify=True)
+@pytest.fixture(scope="function")
+def cb():
+    """Create CBCloudAPI singleton"""
+    return CBCloudAPI(url="https://example.com",
+                      org_key="test",
+                      token="abcd/1234",
+                      ssl_verify=False)
 
 
-def test_get_device(monkeypatch):
+@pytest.fixture(scope="function")
+def cbcsdk_mock(monkeypatch, cb):
+    """Mocks CBC SDK for unit tests"""
+    return CBCSDKMock(monkeypatch, cb)
+
+# ==================================== UNIT TESTS BELOW ====================================
+
+
+def test_get_device(cbcsdk_mock):
     """Test simple retrieval of a Device object by ID."""
-    _was_called = False
-
-    def _get_device(url):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/devices/6023"
-        _was_called = True
-        return {"device_id": 6023, "organization_name": "thistestworks"}
-
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, GET=_get_device)
+    cbcsdk_mock.mock_request('GET', "/appservices/v6/orgs/test/devices/6023",
+                             {"device_id": 6023, "organization_name": "thistestworks"})
+    api = cbcsdk_mock.api
     rc = api.select(Device, 6023)
-    assert _was_called
     assert isinstance(rc, Device)
     assert rc.device_id == 6023
     assert rc.organization_name == "thistestworks"
 
 
-def test_device_background_scan(monkeypatch):
+def test_device_background_scan(cbcsdk_mock):
     """Test setting the background scan status of a device."""
-    _was_called = False
-
-    def _call_background_scan(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_bgscan(url, body, **kwargs):
         assert body == {"action_type": "BACKGROUND_SCAN", "device_id": [6023], "options": {"toggle": "ON"}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_call_background_scan)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_bgscan)
+    api = cbcsdk_mock.api
     api.device_background_scan([6023], True)
-    assert _was_called
 
 
-def test_device_bypass(monkeypatch):
+def test_device_bypass(cbcsdk_mock):
     """Test setting the bypass status of a device."""
-    _was_called = False
-
-    def _call_bypass(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_bypass(url, body, **kwargs):
         assert body == {"action_type": "BYPASS", "device_id": [6023], "options": {"toggle": "OFF"}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_call_bypass)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_bypass)
+    api = cbcsdk_mock.api
     api.device_bypass([6023], False)
-    assert _was_called
 
 
-def test_device_delete_sensor(monkeypatch):
+def test_device_delete_sensor(cbcsdk_mock):
     """Test deleting the sensor for a device."""
-    _was_called = False
-
-    def _call_delete_sensor(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_delete(url, body, **kwargs):
         assert body == {"action_type": "DELETE_SENSOR", "device_id": [6023]}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_call_delete_sensor)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_delete)
+    api = cbcsdk_mock.api
     api.device_delete_sensor([6023])
-    assert _was_called
 
 
-def test_device_uninstall_sensor(monkeypatch):
+def test_device_uninstall_sensor(cbcsdk_mock):
     """Test uninstalling the sensor for a device."""
-    _was_called = False
-
-    def _call_uninstall_sensor(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_uninstall(url, body, **kwargs):
         assert body == {"action_type": "UNINSTALL_SENSOR", "device_id": [6023]}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_call_uninstall_sensor)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_uninstall)
+    api = cbcsdk_mock.api
     api.device_uninstall_sensor([6023])
-    assert _was_called
 
 
-def test_device_quarantine(monkeypatch):
+def test_device_quarantine(cbcsdk_mock):
     """Test setting the quarantine status of a device."""
-    _was_called = False
-
-    def _call_quarantine(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_quarantine(url, body, **kwargs):
         assert body == {"action_type": "QUARANTINE", "device_id": [6023], "options": {"toggle": "ON"}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_call_quarantine)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_quarantine)
+    api = cbcsdk_mock.api
     api.device_quarantine([6023], True)
-    assert _was_called
 
 
-def test_device_update_policy(monkeypatch):
+def test_device_update_policy(cbcsdk_mock):
     """Test updating the policy of a device."""
-    _was_called = False
-
-    def _call_update_policy(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_update(url, body, **kwargs):
         assert body == {"action_type": "UPDATE_POLICY", "device_id": [6023], "options": {"policy_id": 8675309}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_call_update_policy)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_update)
+    api = cbcsdk_mock.api
     api.device_update_policy([6023], 8675309)
-    assert _was_called
 
 
-def test_device_update_policy_error(monkeypatch):
+def test_device_update_policy_error(cbcsdk_mock):
     """Test updating the policy of a device."""
-    _was_called = False
-
-    def _call_update_policy(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_update(url, body, **kwargs):
         assert body == {"action_type": "UPDATE_POLICY", "device_id": [6023], "options": {"policy_id": 8675309}}
-        _was_called = True
-        return StubResponse(None, 500)
+        return CBCSDKMock.StubResponse(None, scode=500)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_call_update_policy)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_update)
+    api = cbcsdk_mock.api
     with pytest.raises(ServerError):
         api.device_update_policy([6023], 8675309)
-        assert _was_called
 
 
-def test_device_update_sensor_version(monkeypatch):
+def test_device_update_sensor_version(cbcsdk_mock):
     """Test updating the sensor version of a device."""
-    _was_called = False
-
-    def _call_update_sensor_version(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_update(url, body, **kwargs):
         assert body == {"action_type": "UPDATE_SENSOR_VERSION", "device_id": [6023],
                         "options": {"sensor_version": {"RHEL": "2.3.4.5"}}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_call_update_sensor_version)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_update)
+    api = cbcsdk_mock.api
     api.device_update_sensor_version([6023], {"RHEL": "2.3.4.5"})
-    assert _was_called
 
 
-def test_query_device_with_all_bells_and_whistles(monkeypatch):
+def test_query_device_with_all_bells_and_whistles(cbcsdk_mock):
     """Test a device query with all options set."""
-    _was_called = False
-
-    def _run_query(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/devices/_search"
+    def on_query(url, body, **kwargs):
         assert body == {"query": "foobar",
                         "rows": 2,
                         "criteria": {"ad_group_id": [14, 25], "os": ["LINUX"], "policy_id": [8675309],
                                      "status": ["ALL"], "target_priority": ["HIGH"], "deployment_type": ["ENDPOINT"]},
                         "exclusions": {"sensor_version": ["0.1"]},
                         "sort": [{"field": "name", "order": "DESC"}]}
-        _was_called = True
-        return StubResponse({"results": [{"id": 6023, "organization_name": "thistestworks"}],
-                             "num_found": 1})
+        return {"results": [{"id": 6023, "organization_name": "thistestworks"}], "num_found": 1}
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_run_query)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/devices/_search", on_query)
+    api = cbcsdk_mock.api
     query = api.select(Device).where("foobar").set_ad_group_ids([14, 25]).set_os(["LINUX"]) \
         .set_policy_ids([8675309]).set_status(["ALL"]).set_target_priorities(["HIGH"]) \
         .set_exclude_sensor_versions(["0.1"]).sort_by("name", "DESC").set_deployment_type(["ENDPOINT"])
     d = query.one()
-    assert _was_called
     assert d.id == 6023
     assert d.organization_name == "thistestworks"
 
 
-def test_query_device_with_last_contact_time_as_start_end(monkeypatch):
+def test_query_device_with_last_contact_time_as_start_end(cbcsdk_mock):
     """Test a device query with last_contact_time specified as starting and ending times."""
-    _was_called = False
-
-    def _run_query(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/devices/_search"
+    def on_query(url, body, **kwargs):
         assert body == {"query": "foobar",
                         "rows": 2,
                         "criteria": {"last_contact_time": {"start": "2019-09-30T12:34:56",
                                                            "end": "2019-10-01T12:00:12"}}, "exclusions": {}}
-        _was_called = True
-        return StubResponse({"results": [{"id": 6023, "organization_name": "thistestworks"}],
-                             "num_found": 1})
+        return {"results": [{"id": 6023, "organization_name": "thistestworks"}], "num_found": 1}
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_run_query)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/devices/_search", on_query)
+    api = cbcsdk_mock.api
     query = api.select(Device).where("foobar") \
         .set_last_contact_time(start="2019-09-30T12:34:56", end="2019-10-01T12:00:12")
     d = query.one()
-    assert _was_called
     assert d.id == 6023
     assert d.organization_name == "thistestworks"
 
 
-def test_query_device_with_last_contact_time_as_range(monkeypatch):
+def test_query_device_with_last_contact_time_as_range(cbcsdk_mock):
     """Test a device query with last_contact_time specified as a range."""
-    _was_called = False
-
-    def _run_query(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/devices/_search"
+    def on_query(url, body, **kwargs):
         assert body == {
             "query": "foobar",
             "rows": 2,
             "criteria": {"last_contact_time": {"range": "-3w"}},
             "exclusions": {}
         }
-        _was_called = True
-        return StubResponse({"results": [{"id": 6023, "organization_name": "thistestworks"}],
-                             "num_found": 1})
+        return {"results": [{"id": 6023, "organization_name": "thistestworks"}], "num_found": 1}
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_run_query)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/devices/_search", on_query)
+    api = cbcsdk_mock.api
     query = api.select(Device).where("foobar").set_last_contact_time(range="-3w")
     d = query.one()
-    assert _was_called
     assert d.id == 6023
     assert d.organization_name == "thistestworks"
 
 
-def test_query_device_invalid_last_contact_time_combinations():
+def test_query_device_invalid_last_contact_time_combinations(cb):
     """Test handling of invalid value combinations for set_last_contact_time()."""
-    api = call_cbcloud_api()
     with pytest.raises(ApiError):
-        api.select(Device).set_last_contact_time()
+        cb.select(Device).set_last_contact_time()
     with pytest.raises(ApiError):
-        api.select(Device).set_last_contact_time(start="2019-09-30T12:34:56", end="2019-10-01T12:00:12",
-                                                 range="-3w")
+        cb.select(Device).set_last_contact_time(start="2019-09-30T12:34:56", end="2019-10-01T12:00:12",
+                                                range="-3w")
     with pytest.raises(ApiError):
-        api.select(Device).set_last_contact_time(start="2019-09-30T12:34:56", range="-3w")
+        cb.select(Device).set_last_contact_time(start="2019-09-30T12:34:56", range="-3w")
     with pytest.raises(ApiError):
-        api.select(Device).set_last_contact_time(end="2019-10-01T12:00:12", range="-3w")
+        cb.select(Device).set_last_contact_time(end="2019-10-01T12:00:12", range="-3w")
 
 
 @pytest.mark.parametrize("method, arg", [
@@ -281,191 +216,149 @@ def test_query_device_invalid_last_contact_time_combinations():
     ("set_target_priorities", ["Bogus"]),
     ("set_exclude_sensor_versions", [12703])
 ])
-def test_query_device_invalid_criteria_values(method, arg):
+def test_query_device_invalid_criteria_values(cb, method, arg):
     """Test setting invalid values for device query criteria."""
-    api = call_cbcloud_api()
-    query = api.select(Device)
+    query = cb.select(Device)
     meth = getattr(query, method, None)
     with pytest.raises(ApiError):
         meth(arg)
 
 
-def test_query_device_invalid_sort_direction():
+def test_query_device_invalid_sort_direction(cb):
     """Test an attempt to sort device query results in an invalid direction."""
-    api = call_cbcloud_api()
     with pytest.raises(ApiError):
-        api.select(Device).sort_by("policy_name", "BOGUS")
+        cb.select(Device).sort_by("policy_name", "BOGUS")
 
 
-def test_query_device_download(monkeypatch):
+def test_query_device_facet(cbcsdk_mock):
+    """Test the query faceting operation."""
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/devices/_facet", FACET_RESPONSE)
+    api = cbcsdk_mock.api
+    query = api.select(Device).where('')
+    facets = query.facets(['policy_id'])
+    assert len(facets) == 1
+    assert facets[0].field == 'policy_id'
+    assert len(facets[0].values_) == 10
+    with pytest.raises(ApiError):
+        query.facets(['notexist'])
+    with pytest.raises(ApiError):
+        query.facets([])
+
+
+def test_query_device_download(cbcsdk_mock):
     """Test downloading the results of a device query as CSV."""
-    _was_called = False
-
-    def _run_download(url, query_params, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/devices/_search/download"
+    def on_download(url, query_params, **kwargs):
         assert query_params == {"status": "ALL", "ad_group_id": "14,25", "policy_id": "8675309",
                                 "target_priority": "HIGH", "query_string": "foobar", "sort_field": "name",
                                 "sort_order": "DESC"}
-        _was_called = True
         return "123456789,123456789,123456789"
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, RAW_GET=_run_download)
+    cbcsdk_mock.mock_request('RAW_GET', "/appservices/v6/orgs/test/devices/_search/download", on_download)
+    api = cbcsdk_mock.api
     rc = api.select(Device).where("foobar").set_ad_group_ids([14, 25]).set_policy_ids([8675309]) \
         .set_status(["ALL"]).set_target_priorities(["HIGH"]).sort_by("name", "DESC").download()
-    assert _was_called
     assert rc == "123456789,123456789,123456789"
 
 
-def test_query_device_do_background_scan(monkeypatch):
+def test_query_device_do_background_scan(cbcsdk_mock):
     """Test setting the background scan status on devices matched by a query."""
-    _was_called = False
-
-    def _background_scan(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_bgscan(url, body, **kwargs):
         assert body == {"action_type": "BACKGROUND_SCAN",
                         "search": {"query": "foobar", "criteria": {}, "exclusions": {}}, "options": {"toggle": "ON"}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_background_scan)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_bgscan)
+    api = cbcsdk_mock.api
     api.select(Device).where("foobar").background_scan(True)
-    assert _was_called
 
 
-def test_query_device_do_bypass(monkeypatch):
+def test_query_device_do_bypass(cbcsdk_mock):
     """Test setting the bypass status on devices matched by a query."""
-    _was_called = False
-
-    def _bypass(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_bypass(url, body, **kwargs):
         assert body == {"action_type": "BYPASS",
                         "search": {"query": "foobar", "criteria": {}, "exclusions": {}}, "options": {"toggle": "OFF"}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_bypass)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_bypass)
+    api = cbcsdk_mock.api
     api.select(Device).where("foobar").bypass(False)
-    assert _was_called
 
 
-def test_query_device_do_delete_sensor(monkeypatch):
+def test_query_device_do_delete_sensor(cbcsdk_mock):
     """Test deleting the sensor on devices matched by a query."""
-    _was_called = False
-
-    def _delete_sensor(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_delete(url, body, **kwargs):
         assert body == {"action_type": "DELETE_SENSOR",
                         "search": {"query": "foobar", "criteria": {}, "exclusions": {}}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_delete_sensor)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_delete)
+    api = cbcsdk_mock.api
     api.select(Device).where("foobar").delete_sensor()
-    assert _was_called
 
 
-def test_query_device_do_uninstall_sensor(monkeypatch):
+def test_query_device_do_uninstall_sensor(cbcsdk_mock):
     """Test uninstalling the sensor on devices matched by a query."""
-    _was_called = False
-
-    def _uninstall_sensor(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_uninstall(url, body, **kwargs):
         assert body == {"action_type": "UNINSTALL_SENSOR",
                         "search": {"query": "foobar", "criteria": {}, "exclusions": {}}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_uninstall_sensor)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_uninstall)
+    api = cbcsdk_mock.api
     api.select(Device).where("foobar").uninstall_sensor()
-    assert _was_called
 
 
-def test_query_device_do_quarantine(monkeypatch):
+def test_query_device_do_quarantine(cbcsdk_mock):
     """Test setting the quarantine status on devices matched by a query."""
-    _was_called = False
-
-    def _quarantine(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_quarantine(url, body, **kwargs):
         assert body == {"action_type": "QUARANTINE",
                         "search": {"query": "foobar", "criteria": {}, "exclusions": {}}, "options": {"toggle": "ON"}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_quarantine)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_quarantine)
+    api = cbcsdk_mock.api
     api.select(Device).where("foobar").quarantine(True)
-    assert _was_called
 
 
-def test_query_device_do_update_policy(monkeypatch):
+def test_query_device_do_update_policy(cbcsdk_mock):
     """Test updating the policy on devices matched by a query."""
-    _was_called = False
-
-    def _update_policy(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_update(url, body, **kwargs):
         assert body == {"action_type": "UPDATE_POLICY",
                         "search": {"query": "foobar", "criteria": {}, "exclusions": {}},
                         "options": {"policy_id": 8675309}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_update_policy)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_update)
+    api = cbcsdk_mock.api
     api.select(Device).where("foobar").update_policy(8675309)
-    assert _was_called
 
 
-def test_query_device_do_update_sensor_version(monkeypatch):
+def test_query_device_do_update_sensor_version(cbcsdk_mock):
     """Test updating the sensor version on devices matched by a query."""
-    _was_called = False
-
-    def _update_sensor_version(url, body, **kwargs):
-        nonlocal _was_called
-        assert url == "/appservices/v6/orgs/Z100/device_actions"
+    def on_update(url, body, **kwargs):
         assert body == {"action_type": "UPDATE_SENSOR_VERSION",
                         "search": {"query": "foobar", "criteria": {}, "exclusions": {}},
                         "options": {"sensor_version": {"RHEL": "2.3.4.5"}}}
-        _was_called = True
-        return StubResponse(None, 204)
+        return CBCSDKMock.StubResponse(None, scode=204)
 
-    api = call_cbcloud_api()
-    patch_cbc_sdk_api(monkeypatch, api, POST=_update_sensor_version)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/device_actions", on_update)
+    api = cbcsdk_mock.api
     api.select(Device).where("foobar").update_sensor_version({"RHEL": "2.3.4.5"})
-    assert _was_called
 
 
-def test_query_deployment_type(monkeypatch):
+def test_query_deployment_type(cbcsdk_mock):
     """Test deployment type query with correct and incorrect params."""
-    api = call_cbcloud_api()
-
-    def _invalid_deployment_type():
-        with pytest.raises(ApiError):
-            api.select(Device).set_deployment_type(["BOGUS"])
-
-    _invalid_deployment_type()
-
-    def _valid_deployment_type(url, body, **kwargs):
-        assert url == "/appservices/v6/orgs/Z100/devices/_search"
+    def on_query(url, body, **kwargs):
         assert body == {"query": "",
                         "rows": 2,
                         "criteria": {"deployment_type": ["ENDPOINT"]},
                         "exclusions": {}}
-        return StubResponse({"results": [{"id": 6023, "deployment_type": ["ENDPOINT"]}],
-                             "num_found": 1})
+        return {"results": [{"id": 6023, "deployment_type": ["ENDPOINT"]}], "num_found": 1}
 
-    patch_cbc_sdk_api(monkeypatch, api, POST=_valid_deployment_type)
+    cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/devices/_search", on_query)
+    api = cbcsdk_mock.api
+    with pytest.raises(ApiError):
+        api.select(Device).set_deployment_type(["BOGUS"])
     query = api.select(Device).set_deployment_type(["ENDPOINT"])
     d = query.one()
     assert d.deployment_type[0] in ["ENDPOINT", "WORKLOAD"]

--- a/src/tests/unit/platform/test_devicev6_api.py
+++ b/src/tests/unit/platform/test_devicev6_api.py
@@ -13,10 +13,11 @@
 
 import pytest
 from cbc_sdk.errors import ApiError, ServerError
-from cbc_sdk.platform import Device
+from cbc_sdk.platform import Device, DeviceFacet
 from cbc_sdk.rest_api import CBCloudAPI
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
-from tests.unit.fixtures.platform.mock_devices import FACET_RESPONSE
+from tests.unit.fixtures.platform.mock_devices import (FACET_RESPONSE, FACET_INIT_1, FACET_INIT_2, FACET_INIT_3,
+                                                       FACET_INIT_4)
 
 
 @pytest.fixture(scope="function")
@@ -243,6 +244,20 @@ def test_query_device_facet(cbcsdk_mock):
         query.facets(['notexist'])
     with pytest.raises(ApiError):
         query.facets([])
+
+
+@pytest.mark.parametrize('init_facet, desired_criteria', [
+    (FACET_INIT_1, {'policy_id': [68727]}),
+    (FACET_INIT_2, {'status': ['ACTIVE']}),
+    (FACET_INIT_3, {'os': ['LINUX']}),
+    (FACET_INIT_4, {'ad_group_id': [955]})
+])
+def test_facet_generated_queries(cb, init_facet, desired_criteria):
+    """Test to make sure the query_devices() API generates queries with the correct criteria."""
+    facet = DeviceFacet(cb, None, init_facet)
+    query = facet.values_[0].query_devices()
+    request = query._build_request(-1, -1)
+    assert request['criteria'] == desired_criteria
 
 
 def test_query_device_download(cbcsdk_mock):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3379

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added the facets() function to DeviceSearchQuery, which performs query faceting.  The facet values have an extra method of their own, query_devices(), which starts a search query for all devices matching that facet.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been updated and augmented to cover the new functionality. Coverage on that source file is at 94%. A UAT test for facets has also been added and proven to work against PROD02.