### PR TITLE
CBAPI-3539: Update SDK to use watchlist manager v3 instead of v2 APIs

### DIFF
--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -827,7 +827,7 @@ class MutableBaseModel(NewBaseModel):
                 pass
             log.debug("Creating a new {0:s} object".format(self.__class__.__name__))
             http_method = self.__class__._new_object_http_method
-            ret = self._cb.api_json_request(http_method, self.urlobject,
+            ret = self._cb.api_json_request(http_method, self._build_api_request_uri(http_method=http_method),
                                             data=new_object_info)
         else:
             log.debug("Updating {0:s} with unique ID {1:s}".format(self.__class__.__name__, str(self._model_unique_id)))

--- a/src/cbc_sdk/enterprise_edr/threat_intelligence.py
+++ b/src/cbc_sdk/enterprise_edr/threat_intelligence.py
@@ -250,6 +250,21 @@ class Watchlist(FeedModel):
         """
         return WatchlistQuery(self, cb)
 
+    def _build_api_request_uri(self, http_method="GET"):
+        """
+        Returns the API request URI for this object.
+
+        Args:
+            http_method (str): Unused.
+
+        Returns:
+            str: The API request URI for this object.
+        """
+        if self._model_unique_id is not None:
+            return self.urlobject_single.format(self._cb.credentials.org_key, self._model_unique_id)
+        else:
+            return self.urlobject.format(self._cb.credentials.org_key)
+
     def save(self):
         """Saves this watchlist on the Enterprise EDR server.
 

--- a/src/cbc_sdk/enterprise_edr/threat_intelligence.py
+++ b/src/cbc_sdk/enterprise_edr/threat_intelligence.py
@@ -67,8 +67,8 @@ class FeedModel(UnrefreshableModel, CreatableModelMixin, MutableBaseModel):
 class Watchlist(FeedModel):
     """Represents an Enterprise EDR watchlist."""
     # NOTE(ww): Not documented.
-    urlobject = "/threathunter/watchlistmgr/v2/watchlist"
-    urlobject_single = "/threathunter/watchlistmgr/v2/watchlist/{}"
+    urlobject = "/threathunter/watchlistmgr/v3/orgs/{}/watchlists"
+    urlobject_single = "/threathunter/watchlistmgr/v3/orgs/{}/watchlists/{}"
     swagger_meta_file = "enterprise_edr/models/watchlist.yaml"
 
     def __init__(self, cb, model_unique_id=None, initial_data=None):
@@ -85,7 +85,7 @@ class Watchlist(FeedModel):
         if initial_data:
             item = initial_data
         elif model_unique_id:
-            item = cb.get_object(self.urlobject_single.format(model_unique_id))
+            item = cb.get_object(self.urlobject_single.format(cb.credentials.org_key, model_unique_id))
 
         feed_id = item.get("id")
 
@@ -1856,6 +1856,6 @@ class WatchlistQuery(SimpleQuery):
         """Return a list of all Watchlist objects."""
         log.debug("Fetching all watchlists")
 
-        resp = self._cb.get_object(self._doc_class.urlobject)
+        resp = self._cb.get_object(self._doc_class.urlobject.format(self._cb.credentials.org_key))
         results = resp.get("results", [])
         return [self._doc_class(self._cb, initial_data=item) for item in results]

--- a/src/tests/uat/watchlist_feed_uat.py
+++ b/src/tests/uat/watchlist_feed_uat.py
@@ -1,0 +1,191 @@
+# *******************************************************
+# Copyright (c) VMware, Inc. 2020-2021. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+# *******************************************************
+# *
+# * DISCLAIMER. THIS PROGRAM IS PROVIDED TO YOU "AS IS" WITHOUT
+# * WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER ORAL OR WRITTEN,
+# * EXPRESS OR IMPLIED. THE AUTHOR SPECIFICALLY DISCLAIMS ANY IMPLIED
+# * WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
+# * NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
+
+"""Test script for watchlists and feeds."""
+
+import sys
+from datetime import datetime
+from cbc_sdk.enterprise_edr import Report, IOC_V2, Watchlist, Feed
+from cbc_sdk.helpers import build_cli_parser, get_cb_cloud_object
+
+
+CURRENT_DATE = datetime.now().strftime("%Y-%m-%d")
+
+
+def create_report_in_watchlist(api):
+    """
+    Create_report_in_watchlist creates a report creates a watchlist and adds the report
+
+    The report is then set to ignore, then un-ignored
+    validation of correct behaviour is by review of the printed results
+    script executed successfully on release candidate 1.3.5
+    """
+    print("Testing create_report_in_watchlist...")
+    builder = Report.create(api, "SDK Test v36wl Unsigned Browsers",
+                            "Unsigned processes impersonating browsers", 5)
+    builder.add_tag("compliance").add_tag("unsigned_browsers")
+    builder.add_ioc(IOC_V2.create_query(api, "unsigned-chrome",
+                                        "process_name:chrome.exe "
+                                        "NOT process_publisher_state:FILE_SIGNATURE_STATE_SIGNED"))
+    watchlist_report = builder.build()
+    watchlist_report.save_watchlist()
+    print("Report:")
+    print(watchlist_report)
+    builder = Watchlist.create(api, f"SDK Testing {CURRENT_DATE} v36")
+    builder.set_description("Description for SDK testing").add_reports([watchlist_report])
+    watchlist = builder.build()
+    watchlist.save()
+    print("Watchlist:")
+    print(watchlist)
+    watchlist.enable_alerts()
+    print('ignore the watchlist report ')
+    watchlist_report.ignore()
+    print(f'watchlist_report ignored value: {watchlist_report.ignored}')
+    print('un-ignore the watchlist report ')
+    watchlist_report.unignore()
+    print(f'watchlist_report ignored value, should be ignored = False: {watchlist_report.ignored}')
+    print('create_report_in_watchlist.............................Check UI to validate')
+
+
+def create_report_in_feed(api):
+    """
+    Create_report_in_feed creates a report, creates a feed and adds the report to that feed.
+
+    The feed id is returned for later manipulation.
+    the report is then set to ignore, then un-ignored
+    validation of correct behaviour is by review of the printed results
+    script executed successfully on release candidate 1.3.5
+    """
+    print("Testing create_report_in_feed...")
+    report_builder = Report.create(api, "Report for Feed v36", "Feed - Unsigned processes impersonating browsers", 5)
+    report_builder.add_tag("compliance").add_tag("unsigned_browsers")
+    report_builder.add_ioc(IOC_V2.create_query(api, "unsigned-chrome",
+                                               "process_name:chrome.exe "
+                                               "NOT process_publisher_state:FILE_SIGNATURE_STATE_SIGNED"))
+    report_builder.set_visibility("visible")
+    report = report_builder.build()
+    print("Newly created report:")
+    print(report)
+    feed_builder = Feed.create(api, f'SDK Testing - Feed - {CURRENT_DATE} v36',
+                               'http://example.com/location',
+                               'Any signs of suspicious applications running on our endpoints', 'external_threat_intel')
+    feed_builder.set_source_label('Where the info is coming from')
+    feed_builder.add_reports([report])
+    feed = feed_builder.build()
+    feed.save()
+    print("Newly saved feed:")
+    print(feed)
+    for r in feed.reports:
+        print("Report in Feed")
+        print(r)
+        print(f'feed_report ignored value, should be ignored = False: {r.ignored}')
+
+    saved_report = feed.reports[0]
+    print("Working with this report:")
+    print(saved_report)
+    print(saved_report.ignored)
+
+    print('check ignoring the report while the feed is not in a watchlist')
+    saved_report.ignore()
+    print(f'feed_report ignored value: {saved_report.ignored}')
+    print('un-ignore the feed report ')
+    saved_report.unignore()
+    print(f'feed_report ignored value, should be ignored = False: {saved_report.ignored}')
+    print('create_report_in_feed.............................Check UI to validate')
+
+    return feed.id
+
+
+def add_feed_to_watchlist_and_ignore_report(api, feed_id):
+    """
+    Create_report_in_feed_in_watchlist expects to receive a feed_id of a feed
+
+    containing one report, typically created in the previous method create_report_in_feed
+    It subscribes that feed to a watchlist.
+    the report is then set to ignore, then un-ignored
+    validation of correct behaviour is by review of the printed results
+    script executed successfully on release candidate 1.3.5
+    """
+    print("Testing add_feed_to_watchlist_and_ignore_report...")
+    feed = api.select(Feed, feed_id)
+    print("newly retrieved feed")
+    print(feed)
+
+    print('check only one report and that the ignored status on it is false')
+    for r in feed.reports:
+        print(r)
+        print(r.ignored)
+
+    print('put the feed in a watchlist')
+    feed_watchlist = Watchlist.create_from_feed(feed, "SDK Testing - Watchlist for Feed - 202201265 v36 ",
+                                                "Subscription to the new feed")
+    watchlist = feed_watchlist.save()
+
+    print('re-select the feed and the report')
+    report_to_manipulate = watchlist.feed.reports[0]
+
+    print("Working with this report:")
+    print(report_to_manipulate)
+    print(f'ignored should be false: {report_to_manipulate.ignored}')
+
+    print('check ignoring the report while the feed is not in a watchlist')
+    report_to_manipulate.ignore()
+    print(f'report_to_manipulate ignored value: {report_to_manipulate.ignored}')
+    print('un-ignore the feed report ')
+    report_to_manipulate.unignore()
+    print(f'report_to_manipulate ignored value, should be ignored = False: {report_to_manipulate.ignored}')
+    print('add_feed_to_watchlist_and_ignore_report.............................Check UI to validate')
+
+
+def get_unsubscribed_feeds(api):
+    """Get any feeds that aren't subscibed to by a watchlist"""
+    feed_query = api.select(Feed)
+    all_feeds = {}
+    for feed in feed_query:
+        all_feeds[feed.id] = feed.name
+    print(f"Got {len(all_feeds)} feed name(s) from all feeds")
+    wl_query = api.select(Watchlist)
+    wl_classifs = [wl.classifier_ for wl in wl_query if wl.classifier_ is not None]
+    wl_feed_ids = [cl[1] for cl in wl_classifs if cl[0] == 'feed_id']
+    print(f"Got {len(wl_feed_ids)} feed ID(s) from watchlists")
+    result = [id for id in all_feeds.keys() if id not in wl_feed_ids]
+
+    print(f"Found {len(result)} feed(s)")
+    for id in result:
+        print(f"{id} - {all_feeds[id]}")
+
+
+def get_reports_in_a_feed(api, feed_id):
+    """Get all the reports within a feed"""
+    feed = api.select(Feed, feed_id)
+    print(f"[Reports for feed with ID:{feed_id}]")
+    for report in feed.reports:
+        print(f"{report.id} - {report.title}")
+
+
+def main():
+    """Entry function for testing"""
+    parser = build_cli_parser()
+    args = parser.parse_args()
+    api = get_cb_cloud_object(args)
+
+    create_report_in_watchlist(api)
+
+    feed_id = create_report_in_feed(api)
+    add_feed_to_watchlist_and_ignore_report(api, feed_id)
+    # get_unsubscribed_feeds(api)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")

--- a/src/tests/unit/base/test_base_models.py
+++ b/src/tests/unit/base/test_base_models.py
@@ -276,7 +276,7 @@ def test_update_object_mbm(cbcsdk_mock):
     # if primary_key hasn't been modified, we use the _change_object_http_method
     api = cbcsdk_mock.api
     cbcsdk_mock.mock_request("GET", "/integrationServices/v3/policy/30242", POLICY_GET_RESP_1)
-    cbcsdk_mock.mock_request("PATCH", "/integrationServices/v3/policy/30242", POLICY_UPDATE_RESP)
+    cbcsdk_mock.mock_request("PUT", "/integrationServices/v3/policy/30242", POLICY_UPDATE_RESP)
     policy = api.select(Policy, 30242)
     policy._set("name", "newFakeName")
     policy._set("testId", 1)
@@ -308,7 +308,7 @@ def test_update_entire_mbm(cbcsdk_mock):
         mutableBaseModelPolicy._model_unique_id = 30241
 
     mutableBaseModelPolicy.id = 30241
-    cbcsdk_mock.mock_request("PATCH", "/integrationServices/v3/policy", POLICY_POST_RESP)
+    cbcsdk_mock.mock_request("POST", "/integrationServices/v3/policy", POLICY_POST_RESP)
     assert mutableBaseModelPolicy._update_entire_object()
     assert mutableBaseModelPolicy.id == 30241
 
@@ -320,7 +320,7 @@ def test_patch_entire_mbm(cbcsdk_mock):
     cbcsdk_mock.mock_request("GET", "/integrationServices/v3/policy/30241", POLICY_GET_RESP)
     mutableBaseModelPolicy = Policy(api, 30242)
     mutableBaseModelPolicy.id = 30241
-    cbcsdk_mock.mock_request("PATCH", "/integrationServices/v3/policy", POLICY_POST_RESP)
+    cbcsdk_mock.mock_request("PUT", "/integrationServices/v3/policy", POLICY_POST_RESP)
     assert mutableBaseModelPolicy._patch_object()
     assert mutableBaseModelPolicy.id == 30241
 

--- a/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
+++ b/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
@@ -61,7 +61,7 @@ def cbcsdk_mock(monkeypatch, cb):
 
 def test_watchlist_query(cbcsdk_mock):
     """Testing Watchlist Querying"""
-    cbcsdk_mock.mock_request("GET", "/threathunter/watchlistmgr/v2/watchlist", WATCHLIST_GET_RESP)
+    cbcsdk_mock.mock_request("GET", "/threathunter/watchlistmgr/v3/orgs/test/watchlists", WATCHLIST_GET_RESP)
     api = cbcsdk_mock.api
     watchlist = api.select(Watchlist)
     results = [res for res in watchlist._perform_query()]
@@ -72,7 +72,8 @@ def test_watchlist_query(cbcsdk_mock):
 def test_watchlist_init(cbcsdk_mock):
     """Testing Watchlist.__init__()."""
     id = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}", WATCHLIST_GET_SPECIFIC_RESP)
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
+                             WATCHLIST_GET_SPECIFIC_RESP)
     watchlist = Watchlist(cbcsdk_mock.api, model_unique_id="watchlistId", initial_data=None)
     assert watchlist._model_unique_id == "watchlistId"
 
@@ -87,7 +88,7 @@ def test_watchlist_save(cbcsdk_mock):
     watchlist.save()
 
     # if Watchlist response is missing a required field per enterprise_edr.models.Watchlist, raise InvalidObjectError
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}",
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
                              WATCHLIST_GET_SPECIFIC_MISSING_FIELDS_RESP)
     watchlist = api.select(Watchlist, "watchlistId")
     with pytest.raises(InvalidObjectError):
@@ -99,14 +100,15 @@ def test_watchlist_save(cbcsdk_mock):
 def test_watchlist_update(cbcsdk_mock):
     """Testing Watchlist.update()."""
     id = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}", WATCHLIST_GET_SPECIFIC_RESP)
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
+                             WATCHLIST_GET_SPECIFIC_RESP)
     watchlist = Watchlist(cbcsdk_mock.api, model_unique_id="watchlistId", initial_data=None)
     assert "description" in watchlist._info
     assert "nonexistant_key" not in watchlist._info
     assert watchlist._info["description"] == "Existing description for the watchlist."
     cbcsdk_mock.mock_request("PUT", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
                              WATCHLIST_GET_SPECIFIC_RESP)
-    cbcsdk_mock.mock_request("PATCH", f"/threathunter/watchlistmgr/v2/watchlist/{id}",
+    cbcsdk_mock.mock_request("PATCH", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
                              WATCHLIST_GET_SPECIFIC_RESP)
     watchlist.update(description="My New Description", nonexistant_key="This Is Ignored")
     assert watchlist._info["description"] == "My New Description"
@@ -117,11 +119,12 @@ def test_watchlist_update_id(cbcsdk_mock):
     """Testing Watchlist.update()."""
     id = "watchlistId2"
     id2 = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}", WATCHLIST_GET_SPECIFIC_RESP_2)
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
+                             WATCHLIST_GET_SPECIFIC_RESP_2)
     watchlist = Watchlist(cbcsdk_mock.api, model_unique_id="watchlistId2", initial_data=None)
     assert "description" in watchlist._info
     assert "nonexistant_key" not in watchlist._info
-    cbcsdk_mock.mock_request("PATCH", "/threathunter/watchlistmgr/v2/watchlist",
+    cbcsdk_mock.mock_request("PATCH", "/threathunter/watchlistmgr/v3/orgs/test/watchlists",
                              WATCHLIST_GET_SPECIFIC_RESP)
     watchlist.id = id2
     result_repr = watchlist.__repr__()
@@ -140,7 +143,8 @@ def test_watchlist_update_invalid_object(cbcsdk_mock):
 def test_watchlist_update_api_error(cbcsdk_mock):
     """Testing Watchlist.update() raising ApiError when passing in "report_ids" with empty list."""
     id = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}", WATCHLIST_GET_SPECIFIC_RESP)
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
+                             WATCHLIST_GET_SPECIFIC_RESP)
     watchlist = Watchlist(cbcsdk_mock.api, model_unique_id="watchlistId", initial_data=None)
     cbcsdk_mock.mock_request("PUT", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
                              WATCHLIST_GET_SPECIFIC_RESP)
@@ -164,7 +168,8 @@ def test_watchlist_classifier_empty(cbcsdk_mock):
 def test_watchlist_delete(cbcsdk_mock):
     """Testing Watchlist.delete()."""
     id = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}", WATCHLIST_GET_SPECIFIC_RESP)
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
+                             WATCHLIST_GET_SPECIFIC_RESP)
     cbcsdk_mock.mock_request("DELETE", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}", None)
     watchlist = Watchlist(cbcsdk_mock.api, model_unique_id="watchlistId")
     watchlist.delete()
@@ -181,7 +186,8 @@ def test_enable_alerts(cbcsdk_mock):
     """Testing Watchlist.enable_alerts()."""
     api = cbcsdk_mock.api
     id = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}", WATCHLIST_GET_SPECIFIC_RESP)
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
+                             WATCHLIST_GET_SPECIFIC_RESP)
     watchlist = Watchlist(api, model_unique_id="watchlistId")
     cbcsdk_mock.mock_request("PUT", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}/alert", {"alert": True})
     watchlist.enable_alerts()
@@ -199,7 +205,8 @@ def test_disable_alerts(cbcsdk_mock):
     """Testing Watchlist.disable_alerts()."""
     api = cbcsdk_mock.api
     id = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}", WATCHLIST_GET_SPECIFIC_RESP)
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
+                             WATCHLIST_GET_SPECIFIC_RESP)
     watchlist = Watchlist(api, model_unique_id="watchlistId")
     cbcsdk_mock.mock_request("DELETE", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}/alert", None)
     watchlist.disable_alerts()
@@ -217,7 +224,8 @@ def test_watchlist_enable_tags(cbcsdk_mock):
     """Testing Watchlist.enable_tags()."""
     api = cbcsdk_mock.api
     id = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}", WATCHLIST_GET_SPECIFIC_RESP)
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
+                             WATCHLIST_GET_SPECIFIC_RESP)
     watchlist = Watchlist(api, model_unique_id="watchlistId")
     cbcsdk_mock.mock_request("PUT", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}/tag", {"tag": True})
     watchlist.enable_tags()
@@ -235,7 +243,8 @@ def test_watchlist_disable_tags(cbcsdk_mock):
     """Testing Watchlist.disable_tags()."""
     api = cbcsdk_mock.api
     id = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}", WATCHLIST_GET_SPECIFIC_RESP)
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
+                             WATCHLIST_GET_SPECIFIC_RESP)
     watchlist = Watchlist(api, model_unique_id="watchlistId")
     cbcsdk_mock.mock_request("DELETE", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}/tag", None)
     watchlist.disable_tags()
@@ -253,7 +262,7 @@ def test_watchlist_feed(cbcsdk_mock):
     """Testing Watchlist.feed property."""
     api = cbcsdk_mock.api
     id = "watchlistId"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}",
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
                              WATCHLIST_GET_SPECIFIC_RESP)
     watchlist = api.select(Watchlist, "watchlistId")
     cbcsdk_mock.mock_request("GET", "/threathunter/feedmgr/v2/orgs/test/feeds/feed_id_associated",
@@ -267,7 +276,7 @@ def test_watchlist_feed_missing_classifier(cbcsdk_mock):
     """Testing Watchlist.feed property."""
     api = cbcsdk_mock.api
     id = "watchlistMissingFieldsWithID"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}",
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
                              WATCHLIST_GET_SPECIFIC_MISSING_FIELDS_RESP)
     watchlist = api.select(Watchlist, "watchlistMissingFieldsWithID")
     assert not watchlist.classifier
@@ -278,7 +287,7 @@ def test_watchlist_feed_invalid_classifier(cbcsdk_mock):
     """Testing Watchlist.feed property when "classifier" is missing."""
     api = cbcsdk_mock.api
     id = "watchlistInvalidClassifier"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}",
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
                              WATCHLIST_GET_SPECIFIC_INVALID_CLASSIFIER_RESP)
     watchlist = api.select(Watchlist, "watchlistInvalidClassifier")
     assert watchlist.classifier
@@ -289,7 +298,7 @@ def test_watchlist_reports(cbcsdk_mock):
     """Testing Watchlist.reports property."""
     api = cbcsdk_mock.api
     id = "watchlistInvalidClassifier"
-    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v2/watchlist/{id}",
+    cbcsdk_mock.mock_request("GET", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
                              WATCHLIST_GET_SPECIFIC_RESP)
     watchlist = api.select(Watchlist, "watchlistInvalidClassifier")
     cbcsdk_mock.mock_request("GET", "/threathunter/watchlistmgr/v3/orgs/test/reports/reportId0",

--- a/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
+++ b/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
@@ -108,8 +108,6 @@ def test_watchlist_update(cbcsdk_mock):
     assert watchlist._info["description"] == "Existing description for the watchlist."
     cbcsdk_mock.mock_request("PUT", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
                              WATCHLIST_GET_SPECIFIC_RESP)
-    cbcsdk_mock.mock_request("PATCH", f"/threathunter/watchlistmgr/v3/orgs/test/watchlists/{id}",
-                             WATCHLIST_GET_SPECIFIC_RESP)
     watchlist.update(description="My New Description", nonexistant_key="This Is Ignored")
     assert watchlist._info["description"] == "My New Description"
     watchlist._update_object()
@@ -124,7 +122,7 @@ def test_watchlist_update_id(cbcsdk_mock):
     watchlist = Watchlist(cbcsdk_mock.api, model_unique_id="watchlistId2", initial_data=None)
     assert "description" in watchlist._info
     assert "nonexistant_key" not in watchlist._info
-    cbcsdk_mock.mock_request("PATCH", "/threathunter/watchlistmgr/v3/orgs/test/watchlists",
+    cbcsdk_mock.mock_request("POST", "/threathunter/watchlistmgr/v3/orgs/test/watchlists",
                              WATCHLIST_GET_SPECIFIC_RESP)
     watchlist.id = id2
     result_repr = watchlist.__repr__()


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3539


## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Replaces the v2 Watchlist APIs with v3 APIs, which includes ensuring that the org key is properly formatted into the URIs whenever necessary.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been adjusted to reflect the changes.  No net loss of coverage as a result.  Additionally, a UAT script has been added.