### PR TITLE
CBAPI-3563: fix documenattion for save_watchlist() vs. update() on Report

### DIFF
--- a/docs/watchlists-feeds-reports.rst
+++ b/docs/watchlists-feeds-reports.rst
@@ -69,7 +69,7 @@ report associated with a watchlist, you must look in the watchlist's ``reports``
     >>> report_list = [report for report in watchlist.reports if report.id == '47474d40-1f94-4995-b6d9-1d1eea3528b3']
     >>> report = report_list[0]
     >>> report.append_iocs([IOC_V2.create_query(api, 'evil-connect', 'netconn_ipv4:10.8.16.4')])
-    >>> report.save_watchlist()
+    >>> report.update()
 
 Adding the Report to a Watchlist
 ++++++++++++++++++++++++++++++++
@@ -91,6 +91,7 @@ If you already have an existing Watchlist you wish to enhance, you can add Repor
     >>> from cbc_sdk.enterprise_edr import Watchlist
     >>> watchlist = api.select('Watchlist', 'R4cMgFIhRaakgk749MRr6Q')
     >>> watchlist.add_reports([report])
+    >>> watchlist.save()
 
 Enabling Alerting on a Watchlist
 ++++++++++++++++++++++++++++++++

--- a/src/cbc_sdk/enterprise_edr/threat_intelligence.py
+++ b/src/cbc_sdk/enterprise_edr/threat_intelligence.py
@@ -1121,6 +1121,9 @@ class Report(FeedModel):
             This method **cannot** be used to save a feed report. To save feed reports, create them with `cb.create`
             and use `Feed.replace`.
 
+            This method **cannot** be used to save a report that is *already* part of a watchlist.  Use the `update()`
+            method instead.
+
         Raises:
             InvalidObjectError: If Report.validate() fails.
         """


### PR DESCRIPTION

## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-3563, GitHub issue #271 

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Changed documentation to reflect that `update()` should be used to update a `Report` that is part of a `Watchlist`.  Also documented that `save_watchlist()` should _not_ be used in this circumstance.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Documentation update only, no code changes.