### PR TITLE
CBAPI - 3872 - Add single report handle for `Report` class

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,8 @@ universal = 1
 
 [flake8]
 ignore = F400, D415, D212, E722
-exclude = *__init__.py,
+exclude = *__init__.py, venv/*
+per-file-ignores=src/tests/unit/fixtures/*:D103
 max-doc-length = 120
 max-line-length = 120
 docstring-convention=google

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,1 +1,2 @@
 """Test configuration"""
+from tests.unit.fixtures.enterprise_edr.mock_threatintel import *

--- a/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
+++ b/src/tests/unit/enterprise_edr/test_enterprise_edr_threatintel.py
@@ -38,6 +38,7 @@ from tests.unit.fixtures.enterprise_edr.mock_threatintel import (WATCHLIST_GET_R
                                                                  ADD_REPORT_IDS_LIST,
                                                                  ADD_REPORTS_LIST)
 
+
 log = logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
 GUID_PATTERN = '[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}'
 
@@ -339,6 +340,14 @@ def test_report_query(cbcsdk_mock):
     }])
 
     assert reports[0].iocs_v2[0]["values"][0] == "test"
+
+
+def test_report_query_from_watchlist(cbcsdk_mock, get_watchlist_report):
+    """Testing Report Querying from a Watchlist"""
+    cbcsdk_mock.mock_request("GET", "/threathunter/watchlistmgr/v3/orgs/test/reports/1", get_watchlist_report)
+    api = cbcsdk_mock.api
+    report = api.select(Report, "1")
+    assert report.title == "Report Test Title"
 
 
 def test_feed_query_all(cbcsdk_mock):

--- a/src/tests/unit/fixtures/enterprise_edr/mock_threatintel.py
+++ b/src/tests/unit/fixtures/enterprise_edr/mock_threatintel.py
@@ -1,4 +1,5 @@
 """Mock responses for threat intelligence queries."""
+import pytest
 
 WATCHLIST_GET_RESP = {
     "results": [
@@ -1264,3 +1265,28 @@ ADD_REPORTS_LIST = [
     "69e2a8d0-bc36-4970-9834-8687efe1aff7",
     "065fb68d-42a8-4b2e-8f91-17f925f54356"
 ]
+
+
+@pytest.fixture(scope="function")
+def get_watchlist_report():
+    return {
+        "id": "1",
+        "timestamp": 0,
+        "title": "Report Test Title",
+        "description": "Report Test Description",
+        "severity": 8,
+        "link": "https://test.feed.com/report3",
+        "tags": None,
+        "iocs": None,
+        "iocs_v2": [
+            {
+                "id": "test_ioc_2",
+                "match_type": "query",
+                "values": ["process_name:b*"],
+                "field": "123",
+                "link": "https://localhost/"
+            }
+        ],
+        "iocs_total_count": 1,
+        "visibility": None
+    }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [] Docs have been reviewed and added/updated if needed (for bug fixes/features) - I will add this in https://github.com/carbonblack/carbon-black-cloud-sdk-python/pull/290 
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
CBAPI - 3872


## Pull Request Description
Adding a handle for querying a single `Report`.

```
>>> api.select("Report", "uEmrBcMXSHOgPrStxZTg-report4")
<cbc_sdk.enterprise_edr.threat_intelligence.Report: id uEmrBcMXSHOgPrStxZTg-report4> @ https://<cbcurl>
```

Since the Reports from the Feeds can only be queried with `feed_id` I've made the default handle for `model_unique_id` to be handled by the report lookup endpoint.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How Has This Been Tested?
Unit, Manually
