### PR TITLE
CBAPI-4055: Devices API - add 3 additional valid facet fields

### DIFF
--- a/src/cbc_sdk/platform/devices.py
+++ b/src/cbc_sdk/platform/devices.py
@@ -596,17 +596,17 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         self._update_criteria("target_priority", target_priorities)
         return self
 
-    def set_cloud_provider_account_id(self, cloud_ids):
+    def set_cloud_provider_account_id(self, account_ids):
         """
         Restricts the devices that this query is performed on to the specified cloud provider account IDs.
 
         Args:
-            cloud_ids (list): List of account IDs to restrict search to.
+            account_ids (list): List of account IDs to restrict search to.
 
         Returns:
             DeviceSearchQuery: This instance.
         """
-        self._update_criteria("cloud_provider_account_id", cloud_ids)
+        self._update_criteria("cloud_provider_account_id", account_ids)
         return self
 
     def set_auto_scaling_group_name(self, group_names):

--- a/src/cbc_sdk/platform/devices.py
+++ b/src/cbc_sdk/platform/devices.py
@@ -353,6 +353,12 @@ class DeviceFacet(UnrefreshableModel):
                 query.set_os([self.id.upper()])
             elif self._outer.field == 'ad_group_id':
                 query.set_ad_group_ids([int(self.id)])
+            elif self._outer.field == "cloud_provider_account_id":
+                query.set_cloud_provider_account_id([self.id])
+            elif self._outer.field == "auto_scaling_group_name":
+                query.set_auto_scaling_group_name([self.id])
+            elif self._outer.field == "virtual_private_cloud_id":
+                query.set_virtual_private_cloud_id([self.id])
             return query
 
     @classmethod
@@ -408,7 +414,8 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
     VALID_PRIORITIES = ["LOW", "MEDIUM", "HIGH", "MISSION_CRITICAL"]
     VALID_DIRECTIONS = ["ASC", "DESC"]
     VALID_DEPLOYMENT_TYPES = ["ENDPOINT", "WORKLOAD"]
-    VALID_FACET_FIELDS = ["policy_id", "status", "os", "ad_group_id"]
+    VALID_FACET_FIELDS = ["policy_id", "status", "os", "ad_group_id", "cloud_provider_account_id",
+                          "auto_scaling_group_name", "virtual_private_cloud_id"]
 
     def __init__(self, doc_class, cb):
         """
@@ -587,6 +594,45 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
         if not all((prio in DeviceSearchQuery.VALID_PRIORITIES) for prio in target_priorities):
             raise ApiError("One or more invalid target priority values")
         self._update_criteria("target_priority", target_priorities)
+        return self
+
+    def set_cloud_provider_account_id(self, cloud_ids):
+        """
+        Restricts the devices that this query is performed on to the specified cloud provider account IDs.
+
+        Args:
+            cloud_ids (list): List of account IDs to restrict search to.
+
+        Returns:
+            DeviceSearchQuery: This instance.
+        """
+        self._update_criteria("cloud_provider_account_id", cloud_ids)
+        return self
+
+    def set_auto_scaling_group_name(self, group_names):
+        """
+        Restricts the devices that this query is performed on to the specified auto scaling group names.
+
+        Args:
+            group_names (list): List of group names to restrict search to.
+
+        Returns:
+            DeviceSearchQuery: This instance.
+        """
+        self._update_criteria("auto_scaling_group_name", group_names)
+        return self
+
+    def set_virtual_private_cloud_id(self, cloud_ids):
+        """
+        Restricts the devices that this query is performed on to the specified virtual private cloud IDs.
+
+        Args:
+            cloud_ids (list): List of cloud IDs to restrict search to.
+
+        Returns:
+            DeviceSearchQuery: This instance.
+        """
+        self._update_criteria("virtual_private_cloud_id", cloud_ids)
         return self
 
     def set_exclude_sensor_versions(self, sensor_versions):
@@ -815,7 +861,8 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
 
         Args:
             fieldlist (list[str]): List of facet field names. Valid names are "policy_id", "status", "os",
-                                   and "ad_group_id".
+                                   "ad_group_id", "cloud_provider_account_id", "auto_scaling_group_name",
+                                   and "virtual_private_cloud_id".
             max_rows (int): The maximum number of rows to return. 0 means return all rows.
 
         Returns:

--- a/src/tests/unit/fixtures/platform/mock_devices.py
+++ b/src/tests/unit/fixtures/platform/mock_devices.py
@@ -377,3 +377,36 @@ FACET_INIT_4 = {
         }
     ]
 }
+
+FACET_INIT_5 = {
+    "field": "cloud_provider_account_id",
+    "values": [
+        {
+            "total": 2,
+            "id": "303",
+            "name": "303"
+        }
+    ]
+}
+
+FACET_INIT_6 = {
+    "field": "auto_scaling_group_name",
+    "values": [
+        {
+            "total": 2,
+            "id": "ARGON",
+            "name": "ARGON"
+        }
+    ]
+}
+
+FACET_INIT_7 = {
+    "field": "virtual_private_cloud_id",
+    "values": [
+        {
+            "total": 2,
+            "id": "65534",
+            "name": "65534"
+        }
+    ]
+}

--- a/src/tests/unit/platform/test_devicev6_api.py
+++ b/src/tests/unit/platform/test_devicev6_api.py
@@ -17,7 +17,7 @@ from cbc_sdk.platform import Device, DeviceFacet
 from cbc_sdk.rest_api import CBCloudAPI
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from tests.unit.fixtures.platform.mock_devices import (FACET_RESPONSE, FACET_INIT_1, FACET_INIT_2, FACET_INIT_3,
-                                                       FACET_INIT_4)
+                                                       FACET_INIT_4, FACET_INIT_5, FACET_INIT_6, FACET_INIT_7)
 
 
 @pytest.fixture(scope="function")
@@ -250,7 +250,10 @@ def test_query_device_facet(cbcsdk_mock):
     (FACET_INIT_1, {'policy_id': [68727]}),
     (FACET_INIT_2, {'status': ['ACTIVE']}),
     (FACET_INIT_3, {'os': ['LINUX']}),
-    (FACET_INIT_4, {'ad_group_id': [955]})
+    (FACET_INIT_4, {'ad_group_id': [955]}),
+    (FACET_INIT_5, {'cloud_provider_account_id': ['303']}),
+    (FACET_INIT_6, {'auto_scaling_group_name': ['ARGON']}),
+    (FACET_INIT_7, {'virtual_private_cloud_id': ['65534']})
 ])
 def test_facet_generated_queries(cb, init_facet, desired_criteria):
     """Test to make sure the query_devices() API generates queries with the correct criteria."""


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-4055

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Add the ability to facet devices on 3 new fields: `cloud_provider_account_id`, `auto_scaling_group_name`, and `virtual_private_cloud_id`.  This includes supporting `DeviceFacetValue.query_devices()` for each of the new field values.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been extended to cover all new code written; code coverage of the relevant file now stands at 95%. UAT did not require updates.