### PR TITLE
CBAPI-4056: Upgrade VM Workloads Search to use v2 APIs

### DIFF
--- a/src/cbc_sdk/workload/__init__.py
+++ b/src/cbc_sdk/workload/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from cbc_sdk.workload.vm_workloads_search import ComputeResource
+from cbc_sdk.workload.vm_workloads_search import ComputeResource, AWSComputeResource
 from cbc_sdk.workload.sensor_lifecycle import SensorKit
 from cbc_sdk.workload.nsx_remediation import NSXRemediationJob
 

--- a/src/cbc_sdk/workload/__init__.py
+++ b/src/cbc_sdk/workload/__init__.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
-from cbc_sdk.workload.vm_workloads_search import ComputeResource, AWSComputeResource
+from cbc_sdk.workload.vm_workloads_search import VCenterComputeResource, AWSComputeResource
 from cbc_sdk.workload.sensor_lifecycle import SensorKit
 from cbc_sdk.workload.nsx_remediation import NSXRemediationJob
 
 # Maintain link for easier migration
 from cbc_sdk.platform.vulnerability_assessment import Vulnerability
+from cbc_sdk.workload.vm_workloads_search import VCenterComputeResource as ComputeResource

--- a/src/cbc_sdk/workload/vm_workloads_search.py
+++ b/src/cbc_sdk/workload/vm_workloads_search.py
@@ -110,7 +110,7 @@ class BaseComputeResource(NewBaseModel):
         Raises:
             NotImplementedError: Always, for BaseComputeResource.
         """
-        raise NotImplementedError("this resource does not allow sensor installation")
+        raise NotImplementedError("Resource does not allow sensor installation")
 
     @classmethod
     def bulk_install(cls, cb, compute_resources, sensor_kit_types, config_file=None):
@@ -132,7 +132,7 @@ class BaseComputeResource(NewBaseModel):
         Raises:
             NotImplementedError: Always, for BaseComputeResource.
         """
-        raise NotImplementedError("this resource does not allow sensor installation")
+        raise NotImplementedError("Resource does not allow sensor installation")
 
     @classmethod
     def bulk_install_by_id(cls, cb, compute_resources, sensor_kit_types, config_file=None):
@@ -154,7 +154,7 @@ class BaseComputeResource(NewBaseModel):
         Raises:
             NotImplementedError: Always, for BaseComputeResource.
         """
-        raise NotImplementedError("this resource does not allow sensor installation")
+        raise NotImplementedError("Resource does not allow sensor installation")
 
 
 class VCenterComputeResource(BaseComputeResource):
@@ -363,7 +363,7 @@ class AWSComputeResource(BaseComputeResource):
         Raises:
             NotImplementedError: Always, for BaseComputeResource.
         """
-        raise NotImplementedError("this resource does not allow sensor installation")
+        raise NotImplementedError("Resource does not allow sensor installation")
 
     @classmethod
     def bulk_install(cls, cb, compute_resources, sensor_kit_types, config_file=None):
@@ -385,7 +385,7 @@ class AWSComputeResource(BaseComputeResource):
         Raises:
             NotImplementedError: Always, for BaseComputeResource.
         """
-        raise NotImplementedError("this resource does not allow sensor installation")
+        raise NotImplementedError("Resource does not allow sensor installation")
 
     @classmethod
     def bulk_install_by_id(cls, cb, compute_resources, sensor_kit_types, config_file=None):
@@ -407,7 +407,7 @@ class AWSComputeResource(BaseComputeResource):
         Raises:
             NotImplementedError: Always, for BaseComputeResource.
         """
-        raise NotImplementedError("this resource does not allow sensor installation")
+        raise NotImplementedError("Resource does not allow sensor installation")
 
 
 class ComputeResourceFacet(UnrefreshableModel):

--- a/src/cbc_sdk/workload/vm_workloads_search.py
+++ b/src/cbc_sdk/workload/vm_workloads_search.py
@@ -71,6 +71,16 @@ class ComputeResource(NewBaseModel):
         self._last_refresh_time = time.time()
         return True
 
+    @classmethod
+    def _get_default_deployment_type(cls):
+        """
+        Return the default deployment type.
+
+        Returns:
+            str: The default deployment type for this class.
+        """
+        return "WORKLOAD"
+
     def _build_api_request_uri(self, http_method="GET"):
         """
         Build the unique URL used to make requests for this object.
@@ -82,7 +92,7 @@ class ComputeResource(NewBaseModel):
             str: The URL used to make requests for this object.
         """
         return self.urlobject_single.format(self._cb.credentials.org_key, self._model_unique_id,
-                                            self._info.get('deployment_type', 'WORKLOAD'))
+                                            self._info.get('deployment_type', self._get_default_deployment_type()))
 
     def _get_sensor_type(self):
         """

--- a/src/cbc_sdk/workload/vm_workloads_search.py
+++ b/src/cbc_sdk/workload/vm_workloads_search.py
@@ -55,8 +55,8 @@ class BaseComputeResource(NewBaseModel):
             cb (BaseAPI): Reference to API object used to communicate with the server.
             **kwargs (dict): Not used, retained for compatibility.
 
-        Returns:
-            VCenterComputeResourceQuery: The query object
+        Raises:
+            NonQueryableModel: Always, since BaseComputeResource cannot be queried directly.
         """
         raise NonQueryableModel("BaseComputeResource is not directly queryable")
 
@@ -161,7 +161,7 @@ class VCenterComputeResource(BaseComputeResource):
     """Models a vCenter compute resource."""
     def __init__(self, cb, model_unique_id, initial_data=None):
         """
-        Initialize the AWSComputeResource object.
+        Initialize the VCenterComputeResource object.
 
         Args:
             cb (BaseAPI): Reference to API object used to communicate with the server.

--- a/src/cbc_sdk/workload/vm_workloads_search.py
+++ b/src/cbc_sdk/workload/vm_workloads_search.py
@@ -269,6 +269,7 @@ class ComputeResourceFacet(UnrefreshableModel):
             self._values = []
 
     class ComputeResourceFacetValue(UnrefreshableModel):
+        """Represents a single facet value inside a ComputeResourceFacet."""
         def __init__(self, cb, model_unique_id, initial_data=None):
             """
             Initialize the ComputeResourceFacetValue object.
@@ -311,6 +312,7 @@ class ComputeResourceFacet(UnrefreshableModel):
 
 class BaseComputeResourceQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupportMixin,
                                IterableQueryMixin, AsyncQueryMixin):
+    """Base class for compute resource queries, not intended for direct use."""
     VALID_DIRECTIONS = ("ASC", "DESC")
     VALID_DEPLOYMENT_TYPE = ("WORKLOAD", "AWS")
     VALID_DOWNLOAD_FORMATS = ("JSON", "CSV")

--- a/src/tests/uat/workloads_search_uat.py
+++ b/src/tests/uat/workloads_search_uat.py
@@ -36,7 +36,7 @@ import requests
 import copy
 
 # Internal library imports
-from cbc_sdk.workload.vm_workloads_search import ComputeResource, AWSComputeResource
+from cbc_sdk.workload.vm_workloads_search import VCenterComputeResource, AWSComputeResource
 from cbc_sdk.helpers import build_cli_parser, get_cb_cloud_object
 
 
@@ -64,7 +64,7 @@ def search_compute_resources_sdk(cb):
     print("Search Compute Resources")
 
     resource_id = None
-    query = list(cb.select(ComputeResource))
+    query = list(cb.select(VCenterComputeResource))
     for resource in query:
         if not resource_id and resource.id and resource.uuid:
             resource_id = resource.id
@@ -119,7 +119,7 @@ def fetch_compute_resource_by_id_sdk(cb, resource_id):
     print("API Calls:")
     print("Fetch Compute Resource by ID")
 
-    return ComputeResource(cb, resource_id)._info
+    return VCenterComputeResource(cb, resource_id)._info
 
 
 def fetch_aws_resource_by_id_api(cb, resource_id):
@@ -158,7 +158,7 @@ def facet_compute_resource_sdk(cb):
     print("API Calls:")
     print("Facet Compute Resource")
 
-    facets = cb.select(ComputeResource).facet(['eligibility', 'os_type', 'installation_status'], 200)
+    facets = cb.select(VCenterComputeResource).facet(['eligibility', 'os_type', 'installation_status'], 200)
     return_array = [copy.deepcopy(facet._info) for facet in facets]
     for item in return_array:
         item.pop("id", None)

--- a/src/tests/uat/workloads_search_uat.py
+++ b/src/tests/uat/workloads_search_uat.py
@@ -184,7 +184,10 @@ def facet_aws_resource_sdk(cb):
     print("Facet AWS Compute Resource")
 
     facets = cb.select(AWSComputeResource).facet(['installation_status', 'platform', 'region'], 200)
-    return [facet._info for facet in facets]
+    return_array = [copy.deepcopy(facet._info) for facet in facets]
+    for item in return_array:
+        item.pop("id", None)
+    return return_array
 
 
 def summarize_aws_api(cb):

--- a/src/tests/uat/workloads_search_uat.py
+++ b/src/tests/uat/workloads_search_uat.py
@@ -15,10 +15,19 @@ The following API calls are tested in this script.
 
 To execute, a profile must be provided using the standard CBC Credentials.
 
+This requires an environment with BOTH vCenter workloads AND AWS workloads enrolled.  If your environment
+has only one or the the other, use the --vcenter-only option to restrict testing to vCenter workloads only, or
+the --aws-only option to restrict testing to AWS workloads only.  Omitting both of these flags causes both
+to be tested.
+
 Workloads Search API:
 * https://developer.carbonblack.com/reference/carbon-black-cloud/workload-protection/latest/vm-workload-search/
 * Fetch Compute Resource by ID
-* Search and Facet Compute Resources
+* Fetch AWS Compute Resource by ID
+* Search Compute Resources
+* Search AWS Compute Resources
+* Facet Compute Resources
+* Facet AWS Compute Resources
 """
 
 # Standard library imports
@@ -26,19 +35,20 @@ import sys
 import requests
 
 # Internal library imports
-from cbc_sdk.workload.vm_workloads_search import ComputeResource
+from cbc_sdk.workload.vm_workloads_search import ComputeResource, AWSComputeResource
 from cbc_sdk.helpers import build_cli_parser, get_cb_cloud_object
 
 
-def search_and_facet_compute_resources_api(cb):
+def search_compute_resources_api(cb):
     """Start API Call"""
     header = {'X-Auth-Token': cb.credentials.token,
               'Content-Type': 'application/json'}
-    url = f'{cb.credentials.url}lcm/view/v1/orgs/{cb.credentials.org_key}/compute_resources/_search'
+    url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/_search'
     count = 0
     api_results = []
     while True:
-        response = requests.post(url, json={"rows": "200", "start": count}, headers=header).json()
+        response = requests.post(url, json={"rows": "200", "start": count, "criteria": {"deployment_type": "WORKLOAD"}},
+                                 headers=header).json()
         count += len(response['results'])
         api_results.extend(response['results'])
         if count >= response['num_found']:
@@ -46,43 +56,159 @@ def search_and_facet_compute_resources_api(cb):
     return api_results
 
 
-def search_and_facet_compute_resources_sdk(cb):
+def search_compute_resources_sdk(cb):
     """Start SDK call"""
     print("----------------------------------------------------------")
     print("API Calls:")
-    print("Search and Facet Compute Resources")
+    print("Search Compute Resources")
 
-    event_id = None
-    query = cb.select(ComputeResource)
-    for event in query:
-        if not event_id and event.id and event.uuid:
-            event_id = event.id
+    resource_id = None
+    query = list(cb.select(ComputeResource))
+    for resource in query:
+        if not resource_id and resource.id and resource.uuid:
+            resource_id = resource.id
 
-    return query, event_id
+    return query, resource_id
 
 
-def fetch_compute_resource_by_id_api(cb, event_id):
+def search_aws_resources_api(cb):
+    """Start API Call"""
+    header = {'X-Auth-Token': cb.credentials.token,
+              'Content-Type': 'application/json'}
+    url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/_search'
+    count = 0
+    api_results = []
+    while True:
+        response = requests.post(url, json={"rows": "200", "start": count, "criteria": {"deployment_type": "AWS"}},
+                                 headers=header).json()
+        count += len(response['results'])
+        api_results.extend(response['results'])
+        if count >= response['num_found']:
+            break
+    return api_results
+
+
+def search_aws_resources_sdk(cb):
+    """Start SDK call"""
+    print("----------------------------------------------------------")
+    print("API Calls:")
+    print("Search AWS Resources")
+
+    resource_id = None
+    query = list(cb.select(AWSComputeResource))
+    for resource in query:
+        if not resource_id and resource.id and resource.image_id:
+            resource_id = resource.id
+
+    return query, resource_id
+
+
+def fetch_compute_resource_by_id_api(cb, resource_id):
     """Start API call"""
     header = {'X-Auth-Token': cb.credentials.token,
               'Content-Type': 'application/json'}
-    url = f'{cb.credentials.url}lcm/view/v1/orgs/{cb.credentials.org_key}/compute_resources/{event_id}'
+    url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/{resource_id}' \
+          '?deployment_type=WORKLOAD'
     return requests.get(url, headers=header).json()
 
 
-def fetch_compute_resource_by_id_sdk(cb, event_id):
+def fetch_compute_resource_by_id_sdk(cb, resource_id):
     """Start SDK call"""
+    print("----------------------------------------------------------")
     print("API Calls:")
     print("Fetch Compute Resource by ID")
 
-    return ComputeResource(cb, event_id)._info
+    return ComputeResource(cb, resource_id)._info
 
 
-def compare_data_facet(sdk_resp, api_resp, api_call):
+def fetch_aws_resource_by_id_api(cb, resource_id):
+    """Start API call"""
+    header = {'X-Auth-Token': cb.credentials.token,
+              'Content-Type': 'application/json'}
+    url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/{resource_id}' \
+          '?deployment_type=AWS'
+    return requests.get(url, headers=header).json()
+
+
+def fetch_aws_resource_by_id_sdk(cb, resource_id):
+    """Start SDK call"""
+    print("----------------------------------------------------------")
+    print("API Calls:")
+    print("Fetch AWS Compute Resource by ID")
+
+    return AWSComputeResource(cb, resource_id)._info
+
+
+def facet_compute_resource_api(cb):
+    """Start API call"""
+    header = {'X-Auth-Token': cb.credentials.token,
+              'Content-Type': 'application/json'}
+    url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/_facet'
+    response = requests.post(url, json={"criteria": {"deployment_type": "WORKLOAD"},
+                                        "terms": {"rows": 200,
+                                                  "fields": ['eligibility', 'os_type', 'os_architecture']}},
+                             headers=header).json()
+    return response['terms']
+
+
+def facet_compute_resource_sdk(cb):
+    """Start SDK call"""
+    print("----------------------------------------------------------")
+    print("API Calls:")
+    print("Facet Compute Resource")
+
+    facets = cb.select(ComputeResource).facet(['eligibility', 'os_type', 'os_architecture'], 200)
+    return [facet._info for facet in facets]
+
+
+def facet_aws_resource_api(cb):
+    """Start API call"""
+    header = {'X-Auth-Token': cb.credentials.token,
+              'Content-Type': 'application/json'}
+    url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/_facet'
+    response = requests.post(url, json={"criteria": {"deployment_type": "AWS"},
+                                        "terms": {"rows": 200,
+                                                  "fields": ['installation_status', 'platform', 'region']}},
+                             headers=header).json()
+    return response['terms']
+
+
+def facet_aws_resource_sdk(cb):
+    """Start SDK call"""
+    print("----------------------------------------------------------")
+    print("API Calls:")
+    print("Facet AWS Compute Resource")
+
+    facets = cb.select(AWSComputeResource).facet(['installation_status', 'platform', 'region'], 200)
+    return [facet._info for facet in facets]
+
+
+def summarize_aws_api(cb):
+    """Start API call"""
+    header = {'X-Auth-Token': cb.credentials.token,
+              'Content-Type': 'application/json'}
+    url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/_summarize'
+    response = requests.post(url, json={"criteria": {"deployment_type": "AWS"},
+                                        "summary_fields": ['installation_status', 'platform', 'region']},
+                             headers=header).json()
+    return response['summaries']
+
+
+def summarize_aws_sdk(cb):
+    """Start SDK call"""
+    print("----------------------------------------------------------")
+    print("API Calls:")
+    print("Summarize AWS Compute Resources")
+
+    return cb.select(AWSComputeResource).summarize(['installation_status', 'platform', 'region'])
+
+
+def compare_data_search(sdk_resp, api_resp, api_call):
     """Compare the data between the sdk and api response"""
     sdk_ids = sorted([_.id for _ in sdk_resp])
     api_ids = sorted([_['id'] for _ in api_resp])
 
-    assert sdk_ids == api_ids, f'TEST FAILED\nDifferance between api and sdk response found for {api_call}'
+    assert sdk_ids == api_ids, f'TEST FAILED\nDifference between api and sdk response found for {api_call}'
 
     print('\nTEST PASSED')
     print("----------------------------------------------------------")
@@ -90,7 +216,17 @@ def compare_data_facet(sdk_resp, api_resp, api_call):
 
 def compare_data_id(sdk_resp, api_resp, api_call):
     """Compare the data between the sdk and api response"""
-    assert sdk_resp == api_resp, f'TEST FAILED\nDifferance between api and sdk response found for {api_call}'
+    assert sdk_resp == api_resp, f'TEST FAILED\nDifference between api and sdk response found for {api_call}'
+    print('\nTEST PASSED')
+    print("----------------------------------------------------------")
+
+
+def compare_data_summary(sdk_resp, api_resp, api_call):
+    """Compare the data between the sdk and api response"""
+    assert len(sdk_resp) == len(api_resp), f'TEST FAILED\nDifference between api and sdk response found for {api_call}'
+    for block in api_resp:
+        assert sdk_resp.get(block['field'], -1) == block['value'],\
+            f'TEST FAILED\nDifference between api and sdk response found for {api_call}'
     print('\nTEST PASSED')
     print("----------------------------------------------------------")
 
@@ -98,17 +234,55 @@ def compare_data_id(sdk_resp, api_resp, api_call):
 def main():
     """Script entry point"""
     parser = build_cli_parser()
+    parser.add_argument('--vcenter-only', action='store_true', type=bool,
+                        help='Run tests only on vCenter compute resources')
+    parser.add_argument('--aws-only', action='store_true', type=bool, help='Run tests only on AWS compute resources')
     args = parser.parse_args()
+
+    run_vcenter = True
+    run_aws = True
+    if args.vcenter_only:
+        if args.aws_only:
+            print("Cannot specify both --vcenter-only and --aws-only options")
+            return 1
+        else:
+            run_aws = False
+    elif args.aws_only:
+        run_vcenter = False
 
     cb = get_cb_cloud_object(args)
 
-    sdk_resp, event_id = search_and_facet_compute_resources_sdk(cb)
-    api_resp = search_and_facet_compute_resources_api(cb)
-    compare_data_facet(sdk_resp, api_resp, 'Search and Facet Compute Resources')
+    if run_vcenter:
+        sdk_resp = search_compute_resources_sdk(cb)
+        api_resp, resource_id = search_compute_resources_api(cb)
+        compare_data_search(sdk_resp, api_resp, 'Search Compute Resources')
 
-    sdk_resp = fetch_compute_resource_by_id_sdk(cb, event_id)
-    api_resp = fetch_compute_resource_by_id_api(cb, event_id)
-    compare_data_id(sdk_resp, api_resp, 'Fetch Compute Resource by ID')
+        sdk_resp = fetch_compute_resource_by_id_sdk(cb, resource_id)
+        api_resp = fetch_compute_resource_by_id_api(cb, resource_id)
+        compare_data_id(sdk_resp, api_resp, 'Fetch Compute Resource by ID')
+
+    if run_aws:
+        sdk_resp = search_aws_resources_sdk(cb)
+        api_resp, resource_id = search_aws_resources_api(cb)
+        compare_data_search(sdk_resp, api_resp, 'Search AWS Compute Resources')
+
+        sdk_resp = fetch_aws_resource_by_id_sdk(cb, resource_id)
+        api_resp = fetch_aws_resource_by_id_api(cb, resource_id)
+        compare_data_id(sdk_resp, api_resp, 'Fetch AWS Compute Resource by ID')
+
+    if run_vcenter:
+        sdk_resp = facet_compute_resource_sdk(cb)
+        api_resp = facet_compute_resource_api(cb)
+        compare_data_id(sdk_resp, api_resp, 'Facet Compute Resources')
+
+    if run_aws:
+        sdk_resp = facet_aws_resource_sdk(cb)
+        api_resp = facet_aws_resource_api(cb)
+        compare_data_id(sdk_resp, api_resp, 'Facet AWS Compute Resources')
+
+        sdk_resp = summarize_aws_sdk(cb)
+        api_resp = summarize_aws_api(cb)
+        compare_data_summary(sdk_resp, api_resp, "Summarize AWS Compute Resources")
 
 
 if __name__ == "__main__":

--- a/src/tests/uat/workloads_search_uat.py
+++ b/src/tests/uat/workloads_search_uat.py
@@ -33,6 +33,7 @@ Workloads Search API:
 # Standard library imports
 import sys
 import requests
+import copy
 
 # Internal library imports
 from cbc_sdk.workload.vm_workloads_search import ComputeResource, AWSComputeResource
@@ -47,7 +48,7 @@ def search_compute_resources_api(cb):
     count = 0
     api_results = []
     while True:
-        response = requests.post(url, json={"rows": "200", "start": count, "criteria": {"deployment_type": "WORKLOAD"}},
+        response = requests.post(url, json={"rows": 200, "start": count, "criteria": {"deployment_type": ["WORKLOAD"]}},
                                  headers=header).json()
         count += len(response['results'])
         api_results.extend(response['results'])
@@ -79,7 +80,7 @@ def search_aws_resources_api(cb):
     count = 0
     api_results = []
     while True:
-        response = requests.post(url, json={"rows": "200", "start": count, "criteria": {"deployment_type": "AWS"}},
+        response = requests.post(url, json={"rows": 200, "start": count, "criteria": {"deployment_type": ["AWS"]}},
                                  headers=header).json()
         count += len(response['results'])
         api_results.extend(response['results'])
@@ -144,9 +145,9 @@ def facet_compute_resource_api(cb):
     header = {'X-Auth-Token': cb.credentials.token,
               'Content-Type': 'application/json'}
     url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/_facet'
-    response = requests.post(url, json={"criteria": {"deployment_type": "WORKLOAD"},
+    response = requests.post(url, json={"criteria": {"deployment_type": ["WORKLOAD"]},
                                         "terms": {"rows": 200,
-                                                  "fields": ['eligibility', 'os_type', 'os_architecture']}},
+                                                  "fields": ['eligibility', 'os_type', 'installation_status']}},
                              headers=header).json()
     return response['terms']
 
@@ -157,8 +158,11 @@ def facet_compute_resource_sdk(cb):
     print("API Calls:")
     print("Facet Compute Resource")
 
-    facets = cb.select(ComputeResource).facet(['eligibility', 'os_type', 'os_architecture'], 200)
-    return [facet._info for facet in facets]
+    facets = cb.select(ComputeResource).facet(['eligibility', 'os_type', 'installation_status'], 200)
+    return_array = [copy.deepcopy(facet._info) for facet in facets]
+    for item in return_array:
+        item.pop("id", None)
+    return return_array
 
 
 def facet_aws_resource_api(cb):
@@ -166,7 +170,7 @@ def facet_aws_resource_api(cb):
     header = {'X-Auth-Token': cb.credentials.token,
               'Content-Type': 'application/json'}
     url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/_facet'
-    response = requests.post(url, json={"criteria": {"deployment_type": "AWS"},
+    response = requests.post(url, json={"criteria": {"deployment_type": ["AWS"]},
                                         "terms": {"rows": 200,
                                                   "fields": ['installation_status', 'platform', 'region']}},
                              headers=header).json()
@@ -188,7 +192,7 @@ def summarize_aws_api(cb):
     header = {'X-Auth-Token': cb.credentials.token,
               'Content-Type': 'application/json'}
     url = f'{cb.credentials.url}lcm/view/v2/orgs/{cb.credentials.org_key}/compute_resources/_summarize'
-    response = requests.post(url, json={"criteria": {"deployment_type": "AWS"},
+    response = requests.post(url, json={"criteria": {"deployment_type": ["AWS"]},
                                         "summary_fields": ['installation_status', 'platform', 'region']},
                              headers=header).json()
     return response['summaries']
@@ -234,9 +238,8 @@ def compare_data_summary(sdk_resp, api_resp, api_call):
 def main():
     """Script entry point"""
     parser = build_cli_parser()
-    parser.add_argument('--vcenter-only', action='store_true', type=bool,
-                        help='Run tests only on vCenter compute resources')
-    parser.add_argument('--aws-only', action='store_true', type=bool, help='Run tests only on AWS compute resources')
+    parser.add_argument('--vcenter-only', action='store_true', help='Run tests only on vCenter compute resources')
+    parser.add_argument('--aws-only', action='store_true', help='Run tests only on AWS compute resources')
     args = parser.parse_args()
 
     run_vcenter = True
@@ -253,22 +256,24 @@ def main():
     cb = get_cb_cloud_object(args)
 
     if run_vcenter:
-        sdk_resp = search_compute_resources_sdk(cb)
-        api_resp, resource_id = search_compute_resources_api(cb)
+        sdk_resp, resource_id = search_compute_resources_sdk(cb)
+        api_resp = search_compute_resources_api(cb)
         compare_data_search(sdk_resp, api_resp, 'Search Compute Resources')
 
-        sdk_resp = fetch_compute_resource_by_id_sdk(cb, resource_id)
-        api_resp = fetch_compute_resource_by_id_api(cb, resource_id)
-        compare_data_id(sdk_resp, api_resp, 'Fetch Compute Resource by ID')
+        if resource_id is not None:
+            sdk_resp = fetch_compute_resource_by_id_sdk(cb, resource_id)
+            api_resp = fetch_compute_resource_by_id_api(cb, resource_id)
+            compare_data_id(sdk_resp, api_resp, 'Fetch Compute Resource by ID')
 
     if run_aws:
-        sdk_resp = search_aws_resources_sdk(cb)
-        api_resp, resource_id = search_aws_resources_api(cb)
+        sdk_resp, resource_id = search_aws_resources_sdk(cb)
+        api_resp = search_aws_resources_api(cb)
         compare_data_search(sdk_resp, api_resp, 'Search AWS Compute Resources')
 
-        sdk_resp = fetch_aws_resource_by_id_sdk(cb, resource_id)
-        api_resp = fetch_aws_resource_by_id_api(cb, resource_id)
-        compare_data_id(sdk_resp, api_resp, 'Fetch AWS Compute Resource by ID')
+        if resource_id is not None:
+            sdk_resp = fetch_aws_resource_by_id_sdk(cb, resource_id)
+            api_resp = fetch_aws_resource_by_id_api(cb, resource_id)
+            compare_data_id(sdk_resp, api_resp, 'Fetch AWS Compute Resource by ID')
 
     if run_vcenter:
         sdk_resp = facet_compute_resource_sdk(cb)

--- a/src/tests/unit/base/test_queries.py
+++ b/src/tests/unit/base/test_queries.py
@@ -134,7 +134,8 @@ def test_raise_ModelNotFound():
 
         # Workload
         ("SensorKit", "SensorKitQuery"),
-        ("ComputeResource", "ComputeResourceQuery"),
+        ("VCenterComputeResource", "VCenterComputeResourceQuery"),
+        ("AWSComputeResource", "AWSComputeResourceQuery"),
     ],
 )
 def test_select_class_instance(klass_name, query_expected):

--- a/src/tests/unit/fixtures/workload/mock_search.py
+++ b/src/tests/unit/fixtures/workload/mock_search.py
@@ -25,7 +25,38 @@ FETCH_COMPUTE_RESOURCE_BY_ID_RESP = {
     "vmwaretools_version": "2147483647"
 }
 
-SEARCH_AND_FACET_COMPUTE_RESEOURCES = {
+FETCH_AWS_RESOURCE_BY_ID_RESP = {
+    "auto_scaling_group_name": "GammaGroup",
+    "availability_zone": "us-west-1c",
+    "cloud_provider_account_id": "0112249969",
+    "cloud_provider_resource_id": "XAW11",
+    "cloud_provider_tags": [
+        "Name##Demo-ASG",
+    ],
+    "create_time": "2022-06-02T05:23:27Z",
+    "deployment_type": "AWS",
+    "external_ip": "192.168.1.1",
+    "id": "7001",
+    "image_description": "Amazon Linux 2 Kernel 5.10 AMI 2.0.20220426.0 x86_64",
+    "image_id": "ami-abcd123443",
+    "image_name": "amzn2-ami-kernel-5.10-hvm-2.0.20220426.0-x86_64-gp2",
+    "installation_status": "NOT_INSTALLED",
+    "instance_state": "running",
+    "instance_type": "t2.micro",
+    "internal_ip": "192.168.2.2",
+    "name": "Demo-ASG",
+    "org_key": "test",
+    "platform": "Unix/Linux",
+    "platform_details": "Linux/UNIX",
+    "region": "us-west-1",
+    "security_group_id": [
+        "kappa-group"
+    ],
+    "subnet_id": "3303",
+    "virtual_private_cloud_id": "90210"
+}
+
+SEARCH_COMPUTE_RESOURCES = {
     "num_found": 1,
     "results": [
         {
@@ -39,9 +70,11 @@ SEARCH_AND_FACET_COMPUTE_RESEOURCES = {
             "vcenter_host_url": "10.105.5.63",
             "vcenter_uuid": "4a6b1382-f917-4e1a-8564-374cb7274bd7",
             "name": "vsvv-2k8r2",
-            "host_name": "",
+            "host_name": "QUIMBY",
             "created_at": "2020-11-18T07:41:18.218Z",
             "ip_address": "192.168.1.1",
+            "device_guid": "a12e0d99-2114-459c-abf8-1af5f719f121",
+            "registration_id": "20-112233999",
             "eligibility": "NOT_ELIGIBLE",
             "eligibility_code": [
                 "VMware Tools install required",
@@ -50,11 +83,48 @@ SEARCH_AND_FACET_COMPUTE_RESEOURCES = {
             ],
             "installation_status": "NOT_INSTALLED",
             "installation_status_code": "",
+            "installation_type": "A",
             "uuid": "502277cc-0aa9-80b0-9ac8-6f540c11edaf",
-            "os_description": "",
+            "os_description": "Windows 10 32-bit",
             "os_type": "WINDOWS",
             "os_architecture": "32",
             "vmwaretools_version": "0"
+        }
+    ]
+}
+
+SEARCH_AWS_RESOURCES = {
+    "num_found": 1,
+    "results": [
+        {
+            "auto_scaling_group_name": "GammaGroup",
+            "availability_zone": "us-west-1c",
+            "cloud_provider_account_id": "0112249969",
+            "cloud_provider_resource_id": "XAW11",
+            "cloud_provider_tags": [
+                "Name##Demo-ASG",
+            ],
+            "create_time": "2022-06-02T05:23:27Z",
+            "deployment_type": "AWS",
+            "external_ip": "192.168.1.1",
+            "id": "7001",
+            "image_description": "Amazon Linux 2 Kernel 5.10 AMI 2.0.20220426.0 x86_64",
+            "image_id": "ami-abcd123443",
+            "image_name": "amzn2-ami-kernel-5.10-hvm-2.0.20220426.0-x86_64-gp2",
+            "installation_status": "NOT_INSTALLED",
+            "instance_state": "running",
+            "instance_type": "t2.micro",
+            "internal_ip": "192.168.2.2",
+            "name": "Demo-ASG",
+            "org_key": "test",
+            "platform": "Unix/Linux",
+            "platform_details": "Linux/UNIX",
+            "region": "us-west-1",
+            "security_group_id": [
+                "kappa-group"
+            ],
+            "subnet_id": "3303",
+            "virtual_private_cloud_id": "90210"
         }
     ]
 }

--- a/src/tests/unit/fixtures/workload/mock_search.py
+++ b/src/tests/unit/fixtures/workload/mock_search.py
@@ -128,3 +128,259 @@ SEARCH_AWS_RESOURCES = {
         }
     ]
 }
+
+WORKLOAD_FACET_REQUEST = {
+    "query": "",
+    "criteria": {
+        "deployment_type": ["WORKLOAD"],
+        "cluster_name": ["buster_cluster"]
+    },
+    "terms": {
+        "rows": 20,
+        "fields": ["eligibility", "installation_status", "vmwaretools_version", "os_type"]
+    }
+}
+
+WORKLOAD_FACET_RESPONSE = {
+    "terms": [
+        {
+            "field": "os_type",
+            "values": [
+                {
+                    "id": "UBUNTU",
+                    "name": "UBUNTU",
+                    "total": 30
+                },
+                {
+                    "id": "WINDOWS",
+                    "name": "WINDOWS",
+                    "total": 15
+                }
+            ]
+        },
+        {
+            "field": "vmwaretools_version",
+            "values": [
+                {
+                    "id": "10336",
+                    "name": "10336",
+                    "total": 27
+                },
+                {
+                    "id": "10400",
+                    "name": "10400",
+                    "total": 18
+                }
+            ]
+        },
+        {
+            "field": "eligibility",
+            "values": [
+                {
+                    "id": "NOT_ELIGIBLE",
+                    "name": "NOT_ELIGIBLE",
+                    "total": 41
+                },
+                {
+                    "id": "ELIGIBLE",
+                    "name": "ELIGIBLE",
+                    "total": 4
+                }
+            ]
+        },
+        {
+            "field": "installation_status",
+            "values": [
+                {
+                    "id": "NOT_INSTALLED",
+                    "name": "NOT_INSTALLED",
+                    "total": 45
+                }
+            ]
+        }
+    ]
+}
+
+AWS_FACET_REQUEST = {
+    "query": "",
+    "criteria": {
+        "deployment_type": ["AWS"],
+        "subnet_id": ["alphaworx"]
+    },
+    "terms": {
+        "rows": 20,
+        "fields": ["auto_scaling_group_name", "cloud_provider_tags", "platform", "platform_details",
+                   "virtual_private_cloud_id"]
+    }
+}
+
+AWS_FACET_RESPONSE = {
+    "terms": [
+        {
+            "field": "cloud_provider_tags",
+            "values": [
+                {
+                    "id": "Name##CB-Installed-Oregon",
+                    "name": "Name##CB-Installed-Oregon",
+                    "total": 6
+                },
+                {
+                    "id": "Name##CB-Installed-Wyoming",
+                    "name": "Name##CB-Installed-Wyoming",
+                    "total": 9
+                }
+            ]
+        },
+        {
+            "field": "auto_scaling_group_name",
+            "values": [
+                {
+                    "id": "Virginia-ASG",
+                    "name": "Virginia-ASG",
+                    "total": 5
+                },
+                {
+                    "id": "Georgia-ASG",
+                    "name": "Georgia-ASG",
+                    "total": 10
+                }
+            ]
+        },
+        {
+            "field": "virtual_private_cloud_id",
+            "values": [
+                {
+                    "id": "vpc-abcd123",
+                    "name": "vpc-abcd123",
+                    "total": 15
+                }
+            ]
+        },
+        {
+            "field": "platform_details",
+            "values": [
+                {
+                    "id": "Linux/UNIX",
+                    "name": "Linux/UNIX",
+                    "total": 15
+                }
+            ]
+        },
+        {
+            "field": "platform",
+            "values": [
+                {
+                    "id": "Unix/Linux",
+                    "name": "Unix/Linux",
+                    "total": 15
+                }
+            ]
+        }
+    ]
+}
+
+WORKLOAD_DOWNLOAD_REQUEST = {
+    "query": "",
+    "rows": 100,
+    "criteria": {
+        "deployment_type": ["WORKLOAD"],
+        "installation_status": [
+            "NOT_INSTALLED",
+            "PENDING",
+            "ERROR"
+        ]
+    },
+    "sort": [
+        {
+            "field": "created_at",
+            "order": "DESC"
+        }
+    ],
+    "format": "CSV"
+}
+
+DOWNLOAD_RESPONSE = {
+    "jobId": 120066
+}
+
+DOWNLOAD_JOB_RESPONSE = {
+    "connector_id": "",
+    "create_time": "",
+    "errors": "",
+    "id": 120066,
+    "job_parameters": {},
+    "last_update_time": "",
+    "org_key": "test",
+    "owner_id": 69,
+    "progress": {
+        "num_total": 40,
+        "num_completed": 0,
+        "message": ""
+    },
+    "status": "",
+    "type": ""
+}
+
+AWS_DOWNLOAD_REQUEST = {
+    "query": "",
+    "rows": 100,
+    "criteria": {
+        "deployment_type": ["AWS"],
+        "auto_scaling_group_name": ["AutoScalingGroup"],
+        "availability_zone": ["us-west-1c"],
+        "cloud_provider_account_id": ["1234567890"],
+        "virtual_private_cloud_id": ["vpc-id"]
+    },
+    "sort": [
+        {
+            "field": "name",
+            "order": "ASC"
+        }
+    ],
+    "format": "JSON"
+}
+
+AWS_SUMMARY_REQUEST = {
+    "query": "",
+    "criteria": {
+        "deployment_type": ["AWS"],
+        "auto_scaling_group_name": ["AutoScalingGroup"],
+        "availability_zone": ["us-west-1c"],
+        "cloud_provider_account_id": ["1234567890"],
+        "virtual_private_cloud_id": ["vpc-id"]
+    },
+    "summary_fields": ["availability_zone", "region", "subnet_id", "virtual_private_cloud_id", "security_group_id"]
+}
+
+AWS_SUMMARY_RESPONSE = {
+    "summaries": [
+        {
+            "count": 14,
+            "field": "availability_zone"
+        },
+        {
+            "count": 17,
+            "field": "security_group_id"
+        },
+        {
+            "count": 16,
+            "field": "subnet_id"
+        },
+        {
+            "count": 6,
+            "field": "region"
+        },
+        {
+            "count": 7,
+            "field": "virtual_private_cloud_id"
+        }
+    ]
+}
+
+AWS_SUMMARY_OUTPUT = {
+    "availability_zone": 14,
+    "security_group_id": 17,
+    "subnet_id": 16,
+    "region": 6,
+    "virtual_private_cloud_id": 7
+}

--- a/src/tests/unit/workload/test_search.py
+++ b/src/tests/unit/workload/test_search.py
@@ -44,7 +44,7 @@ def cbcsdk_mock(monkeypatch, cb):
 # ==================================== UNIT TESTS BELOW ====================================
 def test_compute_resource_by_id(cbcsdk_mock):
     """Tests a simple compute resource querry"""
-    cbcsdk_mock.mock_request("GET", "/lcm/view/v1/orgs/test/compute_resources/1539610",
+    cbcsdk_mock.mock_request("GET", "/lcm/view/v2/orgs/test/compute_resources/15396109?deployment_type=WORKLOAD",
                              FETCH_COMPUTE_RESOURCE_BY_ID_RESP)
     api = cbcsdk_mock.api
     resource = ComputeResource(api, "15396109")
@@ -59,7 +59,7 @@ def test_search_facet_async(cbcsdk_mock):
 
         return SEARCH_AND_FACET_COMPUTE_RESEOURCES
 
-    cbcsdk_mock.mock_request("POST", "/lcm/view/v1/orgs/test/compute_resources/_search",
+    cbcsdk_mock.mock_request("POST", "/lcm/view/v2/orgs/test/compute_resources/_search",
                              post_validate)
     api = cbcsdk_mock.api
     query = api.select(ComputeResource).set_uuid(['502277cc-0aa9-80b0-9ac8-6f540c11edaf'])
@@ -76,6 +76,7 @@ def test_search_facet_with_all_bells_and_whistles(cbcsdk_mock):
     def post_validate(url, body, **kwargs):
         crits = body['criteria']
         assert crits['appliance_uuid'] == ['c89f183b-f201-4bca-bacc-80184b5b8823']
+        assert crits['deployment_type'] == ['WORKLOAD']
         assert crits['eligibility'] == ['NOT_ELIGIBLE']
         assert crits['cluster_name'] == ['launcher-cluster']
         assert crits['name'] == ['vsvv-2k8r2']
@@ -87,7 +88,7 @@ def test_search_facet_with_all_bells_and_whistles(cbcsdk_mock):
 
         return SEARCH_AND_FACET_COMPUTE_RESEOURCES
 
-    cbcsdk_mock.mock_request("POST", "/lcm/view/v1/orgs/test/compute_resources/_search",
+    cbcsdk_mock.mock_request("POST", "/lcm/view/v2/orgs/test/compute_resources/_search",
                              post_validate)
     api = cbcsdk_mock.api
     query = api.select(ComputeResource).set_appliance_uuid(['c89f183b-f201-4bca-bacc-80184b5b8823']) \
@@ -118,6 +119,8 @@ def test_search_facet_with_all_bells_and_whistles(cbcsdk_mock):
 def test_search_facet_with_all_bells_and_whistles_failures(cbcsdk_mock):
     """Testng all set methods"""
     query = cbcsdk_mock.api.select(ComputeResource)
+    with pytest.raises(ApiError):
+        query.set_deployment_type('UNIVERSE')
     with pytest.raises(ApiError):
         query.set_uuid([1])
     with pytest.raises(ApiError):

--- a/src/tests/unit/workload/test_search.py
+++ b/src/tests/unit/workload/test_search.py
@@ -18,9 +18,9 @@ import logging
 from cbc_sdk.errors import ApiError
 from cbc_sdk.rest_api import CBCloudAPI
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
-from cbc_sdk.workload.vm_workloads_search import ComputeResource
-from tests.unit.fixtures.workload.mock_search import (FETCH_COMPUTE_RESOURCE_BY_ID_RESP,
-                                                      SEARCH_AND_FACET_COMPUTE_RESEOURCES)
+from cbc_sdk.workload.vm_workloads_search import ComputeResource, AWSComputeResource
+from tests.unit.fixtures.workload.mock_search import (FETCH_COMPUTE_RESOURCE_BY_ID_RESP, FETCH_AWS_RESOURCE_BY_ID_RESP,
+                                                      SEARCH_COMPUTE_RESOURCES, SEARCH_AWS_RESOURCES)
 
 
 logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
@@ -42,8 +42,9 @@ def cbcsdk_mock(monkeypatch, cb):
 
 
 # ==================================== UNIT TESTS BELOW ====================================
+
 def test_compute_resource_by_id(cbcsdk_mock):
-    """Tests a simple compute resource querry"""
+    """Tests a simple compute resource query"""
     cbcsdk_mock.mock_request("GET", "/lcm/view/v2/orgs/test/compute_resources/15396109?deployment_type=WORKLOAD",
                              FETCH_COMPUTE_RESOURCE_BY_ID_RESP)
     api = cbcsdk_mock.api
@@ -51,91 +52,369 @@ def test_compute_resource_by_id(cbcsdk_mock):
     assert resource._model_unique_id == "15396109"
 
 
-def test_search_facet_async(cbcsdk_mock):
-    """Tests running the async_querry."""
+def test_aws_resource_by_id(cbcsdk_mock):
+    """Tests an AWS compute resource query."""
+    cbcsdk_mock.mock_request("GET", "/lcm/view/v2/orgs/test/compute_resources/7001?deployment_type=AWS",
+                             FETCH_AWS_RESOURCE_BY_ID_RESP)
+    api = cbcsdk_mock.api
+    resource = AWSComputeResource(api, "7001")
+    assert resource._model_unique_id == "7001"
+
+
+def test_search_resource_async(cbcsdk_mock):
+    """Tests running the async_query."""
     def post_validate(url, body, **kwargs):
         crits = body['criteria']
+        assert crits['deployment_type'] == ['WORKLOAD']
         assert crits['uuid'] == ['502277cc-0aa9-80b0-9ac8-6f540c11edaf']
+        assert body['sort'] == [{"field": "name", "order": "ASC"}]
 
-        return SEARCH_AND_FACET_COMPUTE_RESEOURCES
+        return SEARCH_COMPUTE_RESOURCES
 
     cbcsdk_mock.mock_request("POST", "/lcm/view/v2/orgs/test/compute_resources/_search",
                              post_validate)
     api = cbcsdk_mock.api
-    query = api.select(ComputeResource).set_uuid(['502277cc-0aa9-80b0-9ac8-6f540c11edaf'])
+    query = api.select(ComputeResource).set_uuid(['502277cc-0aa9-80b0-9ac8-6f540c11edaf']).sort_by("name", "ASC")
 
     assert query._count() == 1
     results = [result for result in query._run_async_query(None)]
     assert len(results) == 1
-    facet = results[0]
-    assert facet.uuid == '502277cc-0aa9-80b0-9ac8-6f540c11edaf'
+    resource = results[0]
+    assert resource.uuid == '502277cc-0aa9-80b0-9ac8-6f540c11edaf'
 
 
-def test_search_facet_with_all_bells_and_whistles(cbcsdk_mock):
+def test_search_resource_with_all_bells_and_whistles(cbcsdk_mock):
     """Tests running the query with all values set."""
     def post_validate(url, body, **kwargs):
         crits = body['criteria']
-        assert crits['appliance_uuid'] == ['c89f183b-f201-4bca-bacc-80184b5b8823']
         assert crits['deployment_type'] == ['WORKLOAD']
-        assert crits['eligibility'] == ['NOT_ELIGIBLE']
+        assert crits['appliance_uuid'] == ['c89f183b-f201-4bca-bacc-80184b5b8823']
         assert crits['cluster_name'] == ['launcher-cluster']
+        assert crits['datacenter_name'] == ['launcher-dc']
+        assert crits['esx_host_name'] == ['10.105.5.70']
+        assert crits['esx_host_uuid'] == ['d5304d56-5004-a871-1ad1-bd4b4af9977d']
+        assert crits['vcenter_name'] == ['VMware vCenter Server 7.0.0 build-15952599']
+        assert crits['vcenter_host_url'] == ['10.105.5.63']
+        assert crits['vcenter_uuid'] == ['4a6b1382-f917-4e1a-8564-374cb7274bd7']
         assert crits['name'] == ['vsvv-2k8r2']
+        assert crits['host_name'] == ['QUIMBY']
         assert crits['ip_address'] == ['192.168.1.1']
+        assert crits['device_guid'] == ['a12e0d99-2114-459c-abf8-1af5f719f121']
+        assert crits['registration_id'] == ['20-112233999']
+        assert crits['eligibility'] == ['NOT_ELIGIBLE']
+        assert crits['eligibility_code'] == ['VM is offline']
         assert crits['installation_status'] == ['NOT_INSTALLED']
+        assert crits['installation_type'] == ['A']
         assert crits['uuid'] == ['502277cc-0aa9-80b0-9ac8-6f540c11edaf']
+        assert crits['os_description'] == ['Windows 10 32-bit']
         assert crits['os_type'] == ['WINDOWS']
         assert crits['os_architecture'] == ['32']
+        assert crits['vmwaretools_version'] == ["0"]
 
-        return SEARCH_AND_FACET_COMPUTE_RESEOURCES
+        excls = body['exclusions']
+        assert excls['appliance_uuid'] == ['9ee441c2-f245-435d-82d5-615668b760f9']
+        assert excls['cluster_name'] == ['notmy-cluster']
+        assert excls['datacenter_name'] == ['notmy-dc']
+        assert excls['esx_host_name'] == ['10.29.99.254']
+        assert excls['esx_host_uuid'] == ['9fd12239-ce58-4b61-9560-ef4d3c1bb231']
+        assert excls['vcenter_name'] == ['Not VMware']
+        assert excls['vcenter_host_url'] == ['10.29.99.64']
+        assert excls['vcenter_uuid'] == ['1bba86cd-4656-4810-92c1-0875bb8cbf1c']
+        assert excls['name'] == ['vrmm-ou812']
+        assert excls['host_name'] == ['NOTEXIST']
+        assert excls['ip_address'] == ['192.168.42.42']
+        assert excls['device_guid'] == ['ad1a6505-659c-46d3-8f3a-2e1363e2f782']
+        assert excls['registration_id'] == ['666']
+        assert excls['eligibility'] == ['ELIGIBLE']
+        assert excls['eligibility_code'] == ['Bogus']
+        assert excls['installation_status'] == ['SUCCESS']
+        assert excls['installation_type'] == ['Z']
+        assert excls['uuid'] == ['6fb6a53c-350f-4fda-a793-641ac8c7b188']
+        assert excls['os_description'] == ['Linux']
+        assert excls['os_type'] == ['RHEL']
+        assert excls['os_architecture'] == ['64']
+        assert excls['vmwaretools_version'] == ['105']
+
+        return SEARCH_COMPUTE_RESOURCES
 
     cbcsdk_mock.mock_request("POST", "/lcm/view/v2/orgs/test/compute_resources/_search",
                              post_validate)
     api = cbcsdk_mock.api
     query = api.select(ComputeResource).set_appliance_uuid(['c89f183b-f201-4bca-bacc-80184b5b8823']) \
-                                       .set_eligibility(['NOT_ELIGIBLE']) \
-                                       .set_cluster_name(['launcher-cluster']) \
-                                       .set_name(['vsvv-2k8r2']) \
-                                       .set_ip_address(['192.168.1.1']) \
-                                       .set_installation_status(['NOT_INSTALLED']) \
-                                       .set_uuid(['502277cc-0aa9-80b0-9ac8-6f540c11edaf']) \
-                                       .set_os_type(['WINDOWS']) \
-                                       .set_os_architecture(['32'])
+        .set_cluster_name(['launcher-cluster']).set_datacenter_name(['launcher-dc']) \
+        .set_esx_host_name(['10.105.5.70']).set_esx_host_uuid(['d5304d56-5004-a871-1ad1-bd4b4af9977d']) \
+        .set_vcenter_name(['VMware vCenter Server 7.0.0 build-15952599']).set_vcenter_host_url(['10.105.5.63']) \
+        .set_vcenter_uuid(['4a6b1382-f917-4e1a-8564-374cb7274bd7']).set_name(['vsvv-2k8r2']) \
+        .set_host_name(['QUIMBY']).set_ip_address(['192.168.1.1']) \
+        .set_device_guid(['a12e0d99-2114-459c-abf8-1af5f719f121']).set_registration_id(['20-112233999']) \
+        .set_eligibility(['NOT_ELIGIBLE']).set_eligibility_code(['VM is offline']) \
+        .set_installation_status(['NOT_INSTALLED']).set_installation_type(['A']) \
+        .set_uuid(['502277cc-0aa9-80b0-9ac8-6f540c11edaf']).set_os_description(['Windows 10 32-bit']) \
+        .set_os_type(['WINDOWS']).set_os_architecture(['32']).set_vmwaretools_version(["0"]) \
+        .exclude_appliance_uuid(['9ee441c2-f245-435d-82d5-615668b760f9']).exclude_cluster_name(['notmy-cluster']) \
+        .exclude_datacenter_name(['notmy-dc']).exclude_esx_host_name(['10.29.99.254']) \
+        .exclude_esx_host_uuid(['9fd12239-ce58-4b61-9560-ef4d3c1bb231']).exclude_vcenter_name(['Not VMware']) \
+        .exclude_vcenter_host_url(['10.29.99.64']).exclude_vcenter_uuid(['1bba86cd-4656-4810-92c1-0875bb8cbf1c']) \
+        .exclude_name(['vrmm-ou812']).exclude_host_name(['NOTEXIST']).exclude_ip_address(['192.168.42.42']) \
+        .exclude_device_guid(['ad1a6505-659c-46d3-8f3a-2e1363e2f782']).exclude_registration_id(['666']) \
+        .exclude_eligibility(['ELIGIBLE']).exclude_eligibility_code(['Bogus']) \
+        .exclude_installation_status(['SUCCESS']).exclude_installation_type(['Z']) \
+        .exclude_uuid(['6fb6a53c-350f-4fda-a793-641ac8c7b188']).exclude_os_description(['Linux']) \
+        .exclude_os_type(['RHEL']).exclude_os_architecture(['64']).exclude_vmwaretools_version(['105'])
 
     assert query._count() == 1
     results = [result for result in query._perform_query()]
     assert len(results) == 1
-    facet = results[0]
-    assert facet.appliance_uuid == 'c89f183b-f201-4bca-bacc-80184b5b8823'
-    assert facet.eligibility == 'NOT_ELIGIBLE'
-    assert facet.cluster_name == 'launcher-cluster'
-    assert facet.name == 'vsvv-2k8r2'
-    assert facet.ip_address == '192.168.1.1'
-    assert facet.installation_status == 'NOT_INSTALLED'
-    assert facet.uuid == '502277cc-0aa9-80b0-9ac8-6f540c11edaf'
-    assert facet.os_type == 'WINDOWS'
-    assert facet.os_architecture == '32'
+    resource = results[0]
+    assert resource.appliance_uuid == 'c89f183b-f201-4bca-bacc-80184b5b8823'
+    assert resource.eligibility == 'NOT_ELIGIBLE'
+    assert resource.cluster_name == 'launcher-cluster'
+    assert resource.name == 'vsvv-2k8r2'
+    assert resource.ip_address == '192.168.1.1'
+    assert resource.installation_status == 'NOT_INSTALLED'
+    assert resource.uuid == '502277cc-0aa9-80b0-9ac8-6f540c11edaf'
+    assert resource.os_type == 'WINDOWS'
+    assert resource.os_architecture == '32'
 
 
-def test_search_facet_with_all_bells_and_whistles_failures(cbcsdk_mock):
-    """Testng all set methods"""
+def test_search_resource_failures(cbcsdk_mock):
+    """Testng all set methods for failure."""
     query = cbcsdk_mock.api.select(ComputeResource)
-    with pytest.raises(ApiError):
-        query.set_deployment_type('UNIVERSE')
-    with pytest.raises(ApiError):
-        query.set_uuid([1])
     with pytest.raises(ApiError):
         query.set_appliance_uuid([1])
     with pytest.raises(ApiError):
-        query.set_eligibility([1])
-    with pytest.raises(ApiError):
         query.set_cluster_name([1])
+    with pytest.raises(ApiError):
+        query.set_datacenter_name([1])
+    with pytest.raises(ApiError):
+        query.set_esx_host_name([1])
+    with pytest.raises(ApiError):
+        query.set_esx_host_uuid([1])
+    with pytest.raises(ApiError):
+        query.set_vcenter_name([1])
+    with pytest.raises(ApiError):
+        query.set_vcenter_host_url([1])
+    with pytest.raises(ApiError):
+        query.set_vcenter_uuid([1])
     with pytest.raises(ApiError):
         query.set_name([1])
     with pytest.raises(ApiError):
+        query.set_host_name([1])
+    with pytest.raises(ApiError):
         query.set_ip_address([1])
     with pytest.raises(ApiError):
+        query.set_device_guid([1])
+    with pytest.raises(ApiError):
+        query.set_registration_id([1])
+    with pytest.raises(ApiError):
+        query.set_eligibility([1])
+    with pytest.raises(ApiError):
+        query.set_eligibility_code([1])
+    with pytest.raises(ApiError):
         query.set_installation_status([1])
+    with pytest.raises(ApiError):
+        query.set_installation_type([1])
+    with pytest.raises(ApiError):
+        query.set_uuid([1])
+    with pytest.raises(ApiError):
+        query.set_os_description([1])
     with pytest.raises(ApiError):
         query.set_os_type([1])
     with pytest.raises(ApiError):
         query.set_os_architecture([1])
+    with pytest.raises(ApiError):
+        query.set_vmwaretools_version([1])
+    with pytest.raises(ApiError):
+        query.exclude_appliance_uuid([1])
+    with pytest.raises(ApiError):
+        query.exclude_cluster_name([1])
+    with pytest.raises(ApiError):
+        query.exclude_datacenter_name([1])
+    with pytest.raises(ApiError):
+        query.exclude_esx_host_name([1])
+    with pytest.raises(ApiError):
+        query.exclude_esx_host_uuid([1])
+    with pytest.raises(ApiError):
+        query.exclude_vcenter_name([1])
+    with pytest.raises(ApiError):
+        query.exclude_vcenter_host_url([1])
+    with pytest.raises(ApiError):
+        query.exclude_vcenter_uuid([1])
+    with pytest.raises(ApiError):
+        query.exclude_name([1])
+    with pytest.raises(ApiError):
+        query.exclude_host_name([1])
+    with pytest.raises(ApiError):
+        query.exclude_ip_address([1])
+    with pytest.raises(ApiError):
+        query.exclude_device_guid([1])
+    with pytest.raises(ApiError):
+        query.exclude_registration_id([1])
+    with pytest.raises(ApiError):
+        query.exclude_eligibility([1])
+    with pytest.raises(ApiError):
+        query.exclude_eligibility_code([1])
+    with pytest.raises(ApiError):
+        query.exclude_installation_status([1])
+    with pytest.raises(ApiError):
+        query.exclude_installation_type([1])
+    with pytest.raises(ApiError):
+        query.exclude_uuid([1])
+    with pytest.raises(ApiError):
+        query.exclude_os_description([1])
+    with pytest.raises(ApiError):
+        query.exclude_os_type([1])
+    with pytest.raises(ApiError):
+        query.exclude_os_architecture([1])
+    with pytest.raises(ApiError):
+        query.exclude_vmwaretools_version([1])
+    with pytest.raises(ApiError):
+        query.sort_by("name", "BOGUS")
+
+
+def test_search_aws_async(cbcsdk_mock):
+    """Tests running the async_query on AWS."""
+    def post_validate(url, body, **kwargs):
+        crits = body['criteria']
+        assert crits['deployment_type'] == ['AWS']
+        assert crits['id'] == ['7001']
+        assert body['sort'] == [{"field": "name", "order": "ASC"}]
+
+        return SEARCH_AWS_RESOURCES
+
+    cbcsdk_mock.mock_request("POST", "/lcm/view/v2/orgs/test/compute_resources/_search",
+                             post_validate)
+    api = cbcsdk_mock.api
+    query = api.select(AWSComputeResource).set_id(['7001']).sort_by("name", "ASC")
+
+    assert query._count() == 1
+    results = [result for result in query._run_async_query(None)]
+    assert len(results) == 1
+    resource = results[0]
+    assert resource.id == "7001"
+
+
+def test_search_aws_with_all_bells_and_whistles(cbcsdk_mock):
+    """Tests running the query with all values set."""
+    def post_validate(url, body, **kwargs):
+        crits = body['criteria']
+        assert crits['deployment_type'] == ['AWS']
+        assert crits['auto_scaling_group_name'] == ['GammaGroup']
+        assert crits['availability_zone'] == ['us-west-1c']
+        assert crits['cloud_provider_account_id'] == ['0112249969']
+        assert crits['cloud_provider_resource_id'] == ['XAW11']
+        assert crits['cloud_provider_tags'] == ['Name##Demo-ASG']
+        assert crits['id'] == ['7001']
+        assert crits['installation_status'] == ['NOT_INSTALLED']
+        assert crits['name'] == ['Demo-ASG']
+        assert crits['platform'] == ['Unix/Linux']
+        assert crits['platform_details'] == ['Linux/UNIX']
+        assert crits['region'] == ['us-west-1']
+        assert crits['subnet_id'] == ['3303']
+        assert crits['virtual_private_cloud_id'] == ['90210']
+
+        excls = body['exclusions']
+        assert excls['auto_scaling_group_name'] == ['LambdaGroup']
+        assert excls['availability_zone'] == ['eu-east-1x']
+        assert excls['cloud_provider_account_id'] == ['9952230124']
+        assert excls['cloud_provider_resource_id'] == ['XBS54']
+        assert excls['cloud_provider_tags'] == ['Name##Blort-ASG']
+        assert excls['id'] == ['4244']
+        assert excls['installation_status'] == ['SUCCESS']
+        assert excls['name'] == ['Blort-ASG']
+        assert excls['platform'] == ['Solaris']
+        assert excls['platform_details'] == ['Slowlaris']
+        assert excls['region'] == ['eu-east-1']
+        assert excls['subnet_id'] == ['5150']
+        assert excls['virtual_private_cloud_id'] == ['10016']
+
+        return SEARCH_AWS_RESOURCES
+
+    cbcsdk_mock.mock_request("POST", "/lcm/view/v2/orgs/test/compute_resources/_search",
+                             post_validate)
+    api = cbcsdk_mock.api
+    query = api.select(AWSComputeResource).set_auto_scaling_group_name(['GammaGroup']) \
+        .set_availability_zone(['us-west-1c']).set_cloud_provider_account_id(['0112249969']) \
+        .set_cloud_provider_resource_id(['XAW11']).set_cloud_provider_tags(['Name##Demo-ASG']).set_id(['7001']) \
+        .set_installation_status(['NOT_INSTALLED']).set_name(['Demo-ASG']).set_platform(['Unix/Linux']) \
+        .set_platform_details(['Linux/UNIX']).set_region(['us-west-1']).set_subnet_id(['3303']) \
+        .set_virtual_private_cloud_id(['90210']).exclude_auto_scaling_group_name(['LambdaGroup']) \
+        .exclude_availability_zone(['eu-east-1x']).exclude_cloud_provider_account_id(['9952230124']) \
+        .exclude_cloud_provider_resource_id(['XBS54']).exclude_cloud_provider_tags(['Name##Blort-ASG']) \
+        .exclude_id(['4244']).exclude_installation_status(['SUCCESS']).exclude_name(['Blort-ASG']) \
+        .exclude_platform(['Solaris']).exclude_platform_details(['Slowlaris']).exclude_region(['eu-east-1']) \
+        .exclude_subnet_id(['5150']).exclude_virtual_private_cloud_id(['10016'])
+
+    assert query._count() == 1
+    results = [result for result in query._perform_query()]
+    assert len(results) == 1
+    resource = results[0]
+    assert resource.auto_scaling_group_name == 'GammaGroup'
+    assert resource.availability_zone == 'us-west-1c'
+    assert resource.cloud_provider_account_id == '0112249969'
+    assert resource.cloud_provider_resource_id == 'XAW11'
+    assert resource.id == '7001'
+    assert resource.installation_status == 'NOT_INSTALLED'
+    assert resource.name == 'Demo-ASG'
+    assert resource.platform == 'Unix/Linux'
+    assert resource.platform_details == 'Linux/UNIX'
+    assert resource.region == 'us-west-1'
+    assert resource.subnet_id == '3303'
+    assert resource.virtual_private_cloud_id == '90210'
+
+
+def test_search_aws_failures(cbcsdk_mock):
+    """Testng all set methods for failure."""
+    query = cbcsdk_mock.api.select(AWSComputeResource)
+    with pytest.raises(ApiError):
+        query.set_auto_scaling_group_name([1])
+    with pytest.raises(ApiError):
+        query.set_availability_zone([1])
+    with pytest.raises(ApiError):
+        query.set_cloud_provider_account_id([1])
+    with pytest.raises(ApiError):
+        query.set_cloud_provider_resource_id([1])
+    with pytest.raises(ApiError):
+        query.set_cloud_provider_tags([1])
+    with pytest.raises(ApiError):
+        query.set_id([1])
+    with pytest.raises(ApiError):
+        query.set_installation_status([1])
+    with pytest.raises(ApiError):
+        query.set_name([1])
+    with pytest.raises(ApiError):
+        query.set_platform([1])
+    with pytest.raises(ApiError):
+        query.set_platform_details([1])
+    with pytest.raises(ApiError):
+        query.set_region([1])
+    with pytest.raises(ApiError):
+        query.set_subnet_id([1])
+    with pytest.raises(ApiError):
+        query.set_virtual_private_cloud_id([1])
+    with pytest.raises(ApiError):
+        query.exclude_auto_scaling_group_name([1])
+    with pytest.raises(ApiError):
+        query.exclude_availability_zone([1])
+    with pytest.raises(ApiError):
+        query.exclude_cloud_provider_account_id([1])
+    with pytest.raises(ApiError):
+        query.exclude_cloud_provider_resource_id([1])
+    with pytest.raises(ApiError):
+        query.exclude_cloud_provider_tags([1])
+    with pytest.raises(ApiError):
+        query.exclude_id([1])
+    with pytest.raises(ApiError):
+        query.exclude_installation_status([1])
+    with pytest.raises(ApiError):
+        query.exclude_name([1])
+    with pytest.raises(ApiError):
+        query.exclude_platform([1])
+    with pytest.raises(ApiError):
+        query.exclude_platform_details([1])
+    with pytest.raises(ApiError):
+        query.exclude_region([1])
+    with pytest.raises(ApiError):
+        query.exclude_subnet_id([1])
+    with pytest.raises(ApiError):
+        query.exclude_virtual_private_cloud_id([1])

--- a/src/tests/unit/workload/test_sensor_lifecycle.py
+++ b/src/tests/unit/workload/test_sensor_lifecycle.py
@@ -19,7 +19,7 @@ import json
 from cbc_sdk.errors import ApiError
 from cbc_sdk.rest_api import CBCloudAPI
 from cbc_sdk.workload.sensor_lifecycle import SensorKit
-from cbc_sdk.workload.vm_workloads_search import ComputeResource
+from cbc_sdk.workload.vm_workloads_search import VCenterComputeResource
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from tests.unit.fixtures.workload.mock_sensor_lifecycle import (GET_CONFIG_TEMPLATE_RESP, GET_SENSOR_INFO_RESP,
                                                                 REQUEST_SENSOR_INSTALL_RESP)
@@ -45,8 +45,8 @@ def cbcsdk_mock(monkeypatch, cb):
 
 def create_stub_compute_resource(cb, id, uuid, vcenter_uuid, os_type, os_arch, eligibility='ELIGIBLE'):
     """Create a stub ComputeResource object with the data we need."""
-    return ComputeResource(cb, id, {'id': id, 'name': id, 'uuid': uuid, 'vcenter_uuid': vcenter_uuid,
-                                    'eligibility': eligibility, 'os_type': os_type, 'os_architecture': os_arch})
+    return VCenterComputeResource(cb, id, {'id': id, 'name': id, 'uuid': uuid, 'vcenter_uuid': vcenter_uuid,
+                                  'eligibility': eligibility, 'os_type': os_type, 'os_architecture': os_arch})
 
 
 # ==================================== UNIT TESTS BELOW ====================================
@@ -206,7 +206,7 @@ def test_build_compute_resource_list(cb):
     res1 = create_stub_compute_resource(cb, '1', 'Zulu', 'Alpha', 'WINDOWS', '64')
     res2 = create_stub_compute_resource(cb, '2', 'Yankee', 'Bravo', 'WINDOWS', '64')
     res3 = create_stub_compute_resource(cb, '3', 'X-Ray', 'Charlie', 'WINDOWS', '64')
-    output = ComputeResource._build_compute_resource_list([res1, res2, res3])
+    output = VCenterComputeResource._build_compute_resource_list([res1, res2, res3])
     assert output == [{'resource_manager_id': 'Alpha', 'compute_resource_id': '1'},
                       {'resource_manager_id': 'Bravo', 'compute_resource_id': '2'},
                       {'resource_manager_id': 'Charlie', 'compute_resource_id': '3'}]
@@ -230,9 +230,11 @@ def test_sensor_install_bulk_by_id(cbcsdk_mock):
     api = cbcsdk_mock.api
     skit1 = SensorKit.from_type(api, 'LINUX', '64', 'SUSE', '1.2.3.4')
     skit2 = SensorKit.from_type(api, 'MAC', '64', 'MAC', '5.6.7.8')
-    result = ComputeResource.bulk_install_by_id(api, [{'resource_manager_id': 'Alpha', 'compute_resource_id': '1'},
-                                                      {'resource_manager_id': 'Bravo', 'compute_resource_id': '2'}],
-                                                [skit1, skit2], 'MyConfigFile')
+    result = VCenterComputeResource.bulk_install_by_id(api, [{'resource_manager_id': 'Alpha',
+                                                              'compute_resource_id': '1'},
+                                                             {'resource_manager_id': 'Bravo',
+                                                              'compute_resource_id': '2'}],
+                                                       [skit1, skit2], 'MyConfigFile')
     assert result == {'type': "INFO", 'code': "INSTALL_SENSOR_REQUEST_PROCESSED"}
 
 
@@ -256,7 +258,7 @@ def test_sensor_install_bulk(cbcsdk_mock):
     resource2 = create_stub_compute_resource(api, '234', 'Yankee', 'Bravo', 'SUSE', '64')
     skit1 = SensorKit.from_type(api, 'LINUX', '64', 'SUSE', '1.2.3.4')
     skit2 = SensorKit.from_type(api, 'MAC', '64', 'MAC', '5.6.7.8')
-    result = ComputeResource.bulk_install(api, [resource1, resource2], [skit1, skit2], 'MyConfigFile')
+    result = VCenterComputeResource.bulk_install(api, [resource1, resource2], [skit1, skit2], 'MyConfigFile')
     assert result == {'type': "INFO", 'code': "INSTALL_SENSOR_REQUEST_PROCESSED"}
 
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-4056

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Update existing VM Workloads Search code in SDK to use v2 APIs. Also support new functionality, including AWS workloads support.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have covered the workloads search code to 98%.   UAT script has been updated and run against vCenter workloads in a test environment.