### PR TITLE
CBAPI-4375: Add Basic Rule Config to Policy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ python-dateutil
 schema
 solrq
 validators
+jsonschema
 keyring;platform_system=='Darwin'
 boto3
 

--- a/src/cbc_sdk/platform/__init__.py
+++ b/src/cbc_sdk/platform/__init__.py
@@ -9,7 +9,7 @@ from cbc_sdk.platform.devices import Device, DeviceFacet, DeviceSearchQuery
 
 from cbc_sdk.platform.events import Event, EventFacet
 
-from cbc_sdk.platform.policies import Policy, PolicyRule
+from cbc_sdk.platform.policies import Policy, PolicyRule, PolicyRuleConfig
 
 from cbc_sdk.platform.processes import (Process, ProcessFacet,
                                         AsyncProcessQuery, SummaryQuery)

--- a/src/cbc_sdk/platform/models/policy_ruleconfig.yaml
+++ b/src/cbc_sdk/platform/models/policy_ruleconfig.yaml
@@ -1,0 +1,20 @@
+type: object
+properties:
+  id:
+    type: string
+    description: The ID of this rule config
+  name:
+    type: string
+    description: The name of this rule config
+  description:
+    type: string
+    description: The description of this rule config
+  inherited_from:
+    type: string
+    description: Indicates where the rule config was inherited from
+  category:
+    type: string
+    description: The category for this rule config
+  parameters:
+    type: object
+    description: The parameters associated with this rule config

--- a/src/cbc_sdk/platform/policies.py
+++ b/src/cbc_sdk/platform/policies.py
@@ -1277,7 +1277,7 @@ class PolicyRule(MutableBaseModel):
 
 class PolicyRuleConfig(MutableBaseModel):
     primary_key = "id"
-    swagger_meta_file = "platform/models/policy_rule.yaml"
+    swagger_meta_file = "platform/models/policy_ruleconfig.yaml"
 
     def __init__(self, cb, parent, model_unique_id=None, initial_data=None, force_init=False, full_doc=False):
         """
@@ -1291,8 +1291,8 @@ class PolicyRuleConfig(MutableBaseModel):
             force_init (bool): If True, forces the object to be refreshed after constructing.  Default False.
             full_doc (bool): If True, object is considered "fully" initialized. Default False.
         """
-        super(PolicyRule, self).__init__(cb, model_unique_id=model_unique_id, initial_data=initial_data,
-                                         force_init=force_init, full_doc=full_doc)
+        super(PolicyRuleConfig, self).__init__(cb, model_unique_id=model_unique_id, initial_data=initial_data,
+                                               force_init=force_init, full_doc=full_doc)
         self._parent = parent
         if model_unique_id is None:
             self.touch(True)

--- a/src/cbc_sdk/platform/policies.py
+++ b/src/cbc_sdk/platform/policies.py
@@ -104,8 +104,7 @@ class Policy(MutableBaseModel):
                 cb (BaseAPI): Reference to API object used to communicate with the server.
             """
             self._cb = cb
-            self._new_policy_data = {"org_key": cb.credentials.org_key, "priority_level": "MEDIUM",
-                                     "is_system": False, "rapid_configs": []}
+            self._new_policy_data = {"org_key": cb.credentials.org_key, "priority_level": "MEDIUM", "is_system": False}
             self._sensor_settings = {}
             self._new_rules = []
             self._new_rule_configs = []

--- a/src/cbc_sdk/platform/policies.py
+++ b/src/cbc_sdk/platform/policies.py
@@ -1267,7 +1267,7 @@ class PolicyRuleConfig(MutableBaseModel):
     To update a PolicyRuleConfig, change the values of its property fields, then call its save() method.  This
     requires the org.policies(UPDATE) permission.
 
-    To delete an existing PolicyRuleConfig, call its delete() method. This requires the org.policies(UPDATE) permission.
+    To delete an existing PolicyRuleConfig, call its delete() method. This requires the org.policies(DELETE) permission.
 
     """
     primary_key = "id"
@@ -1323,7 +1323,7 @@ class PolicyRuleConfig(MutableBaseModel):
         Deletes this rule configuration object from the policy on the server.
 
         Required Permissions:
-            org.policies(UPDATE)
+            org.policies(DELETE)
         """
         was_deleted = False
         try:

--- a/src/cbc_sdk/rest_api.py
+++ b/src/cbc_sdk/rest_api.py
@@ -501,14 +501,13 @@ class CBCloudAPI(BaseAPI):
             ruleconfig_id (str): The rule configuration ID (UUID).
 
         Returns:
-            dict: The parameter schema for this particular rule configuration.
+            dict: The parameter schema for this particular rule configuration (as a JSON schema).
 
         Raises:
             InvalidObjectError: If the rule configuration ID is not valid.
         """
         url = f"/policyservice/v1/orgs/{self.credentials.org_key}/rule_configs/{ruleconfig_id}/parameters/schema"
         try:
-            result = self.get_object(url)
-            return result.get('properties', {})
+            return self.get_object(url)
         except ServerError:
             raise InvalidObjectError(f"invalid rule config ID {ruleconfig_id}")

--- a/src/cbc_sdk/rest_api.py
+++ b/src/cbc_sdk/rest_api.py
@@ -14,7 +14,7 @@
 """Definition of the CBCloudAPI object, the core object for interacting with the Carbon Black Cloud SDK."""
 
 from cbc_sdk.connection import BaseAPI
-from cbc_sdk.errors import ApiError, CredentialError, ServerError
+from cbc_sdk.errors import ApiError, CredentialError, ServerError, InvalidObjectError
 from cbc_sdk.live_response_api import LiveResponseSessionManager
 from cbc_sdk.audit_remediation import Run, RunHistory
 from cbc_sdk.enterprise_edr.threat_intelligence import ReportSeverity
@@ -489,3 +489,26 @@ class CBCloudAPI(BaseAPI):
             self.credentials.org_key
         )
         return self.get_object(url)
+
+    # --- Policies
+
+    def get_policy_ruleconfig_parameter_schema(self, ruleconfig_id):
+        """
+        Returns the parameter schema for a specified rule configuration.
+
+        Args:
+            cb (BaseAPI): Reference to API object used to communicate with the server.
+            ruleconfig_id (str): The rule configuration ID (UUID).
+
+        Returns:
+            dict: The parameter schema for this particular rule configuration.
+
+        Raises:
+            InvalidObjectError: If the rule configuration ID is not valid.
+        """
+        url = f"/policyservice/v1/orgs/{self.credentials.org_key}/rule_configs/{ruleconfig_id}/parameters/schema"
+        try:
+            result = self.get_object(url)
+            return result.get('properties', {})
+        except ServerError:
+            raise InvalidObjectError(f"invalid rule config ID {ruleconfig_id}")

--- a/src/tests/unit/fixtures/platform/mock_policies.py
+++ b/src/tests/unit/fixtures/platform/mock_policies.py
@@ -190,7 +190,48 @@ FULL_POLICY_1 = {
             "value": "true"
         }
     ],
-    "rule_configs": []
+    "rule_configs": [
+        {
+            "id": "1f8a5e4b-34f2-4d31-9f8f-87c56facaec8",
+            "name": "Advanced Scripting Prevention",
+            "description": "Addresses malicious fileless and file-backed scripts that leverage native programs [...]",
+            "inherited_from": "psc:region",
+            "category": "core_prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "BLOCK"
+            }
+        },
+        {
+            "id": "ac67fa14-f6be-4df9-93f2-6de0dbd96061",
+            "name": "Credential Theft",
+            "description": "Addresses threat actors obtaining credentials and relies on detecting the malicious [...]",
+            "inherited_from": "psc:region",
+            "category": "core_prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "REPORT"
+            }
+        },
+        {
+            "id": "c4ed61b3-d5aa-41a9-814f-0f277451532b",
+            "name": "Carbon Black Threat Intel",
+            "description": "Addresses common and pervasive TTPs used for malicious activity as well as [...]",
+            "inherited_from": "psc:region",
+            "category": "core_prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "REPORT"
+            }
+        },
+        {
+            "id": "88b19232-7ebb-48ef-a198-2a75a282de5d",
+            "name": "Privilege Escalation",
+            "description": "Addresses behaviors that indicate a threat actor has gained elevated access via [...]",
+            "inherited_from": "psc:region",
+            "category": "core_prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "BLOCK"
+            }
+        }
+    ]
 }
 
 SUMMARY_POLICY_1 = {
@@ -1509,5 +1550,72 @@ NEW_POLICY_RETURN_1 = {
         "policy_modification": False,
         "quarantine": True
     },
-    "rule_configs": []
+    "rule_configs": [
+        {
+            "id": "1f8a5e4b-34f2-4d31-9f8f-87c56facaec8",
+            "name": "Advanced Scripting Prevention",
+            "description": "Addresses malicious fileless and file-backed scripts that leverage native programs [...]",
+            "inherited_from": "psc:region",
+            "category": "core_prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "BLOCK"
+            }
+        },
+        {
+            "id": "ac67fa14-f6be-4df9-93f2-6de0dbd96061",
+            "name": "Credential Theft",
+            "description": "Addresses threat actors obtaining credentials and relies on detecting the malicious [...]",
+            "inherited_from": "psc:region",
+            "category": "core_prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "REPORT"
+            }
+        },
+        {
+            "id": "c4ed61b3-d5aa-41a9-814f-0f277451532b",
+            "name": "Carbon Black Threat Intel",
+            "description": "Addresses common and pervasive TTPs used for malicious activity as well as [...]",
+            "inherited_from": "psc:region",
+            "category": "core_prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "REPORT"
+            }
+        },
+        {
+            "id": "88b19232-7ebb-48ef-a198-2a75a282de5d",
+            "name": "Privilege Escalation",
+            "description": "Addresses behaviors that indicate a threat actor has gained elevated access via [...]",
+            "inherited_from": "psc:region",
+            "category": "core_prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "BLOCK"
+            }
+        }
+    ]
+}
+
+BASIC_CONFIG_TEMPLATE_RETURN = {
+    "type": "object",
+    "properties": {
+        "WindowsAssignmentMode": {
+            "default": "BLOCK",
+            "description": "Used to change assignment mode to PREVENT or BLOCK",
+            "type": "string",
+            "enum": [
+                "REPORT",
+                "BLOCK"
+            ]
+        }
+    }
+}
+
+TEMPLATE_RETURN_BOGUS_TYPE = {
+    "type": "object",
+    "properties": {
+        "WindowsAssignmentMode": {
+            "default": "BLOCK",
+            "description": "Used to change assignment mode to PREVENT or BLOCK",
+            "type": "bogus"
+        }
+    }
 }

--- a/src/tests/unit/fixtures/platform/mock_policies.py
+++ b/src/tests/unit/fixtures/platform/mock_policies.py
@@ -196,7 +196,7 @@ FULL_POLICY_1 = {
             "name": "Advanced Scripting Prevention",
             "description": "Addresses malicious fileless and file-backed scripts that leverage native programs [...]",
             "inherited_from": "psc:region",
-            "category": "core_prevention",
+            "category": "core-prevention",
             "parameters": {
                 "WindowsAssignmentMode": "BLOCK"
             }
@@ -206,7 +206,7 @@ FULL_POLICY_1 = {
             "name": "Credential Theft",
             "description": "Addresses threat actors obtaining credentials and relies on detecting the malicious [...]",
             "inherited_from": "psc:region",
-            "category": "core_prevention",
+            "category": "core-prevention",
             "parameters": {
                 "WindowsAssignmentMode": "REPORT"
             }
@@ -216,7 +216,7 @@ FULL_POLICY_1 = {
             "name": "Carbon Black Threat Intel",
             "description": "Addresses common and pervasive TTPs used for malicious activity as well as [...]",
             "inherited_from": "psc:region",
-            "category": "core_prevention",
+            "category": "core-prevention",
             "parameters": {
                 "WindowsAssignmentMode": "REPORT"
             }
@@ -226,7 +226,7 @@ FULL_POLICY_1 = {
             "name": "Privilege Escalation",
             "description": "Addresses behaviors that indicate a threat actor has gained elevated access via [...]",
             "inherited_from": "psc:region",
-            "category": "core_prevention",
+            "category": "core-prevention",
             "parameters": {
                 "WindowsAssignmentMode": "BLOCK"
             }
@@ -1556,7 +1556,7 @@ NEW_POLICY_RETURN_1 = {
             "name": "Advanced Scripting Prevention",
             "description": "Addresses malicious fileless and file-backed scripts that leverage native programs [...]",
             "inherited_from": "psc:region",
-            "category": "core_prevention",
+            "category": "core-prevention",
             "parameters": {
                 "WindowsAssignmentMode": "BLOCK"
             }
@@ -1566,7 +1566,7 @@ NEW_POLICY_RETURN_1 = {
             "name": "Credential Theft",
             "description": "Addresses threat actors obtaining credentials and relies on detecting the malicious [...]",
             "inherited_from": "psc:region",
-            "category": "core_prevention",
+            "category": "core-prevention",
             "parameters": {
                 "WindowsAssignmentMode": "REPORT"
             }
@@ -1576,7 +1576,7 @@ NEW_POLICY_RETURN_1 = {
             "name": "Carbon Black Threat Intel",
             "description": "Addresses common and pervasive TTPs used for malicious activity as well as [...]",
             "inherited_from": "psc:region",
-            "category": "core_prevention",
+            "category": "core-prevention",
             "parameters": {
                 "WindowsAssignmentMode": "REPORT"
             }
@@ -1586,7 +1586,7 @@ NEW_POLICY_RETURN_1 = {
             "name": "Privilege Escalation",
             "description": "Addresses behaviors that indicate a threat actor has gained elevated access via [...]",
             "inherited_from": "psc:region",
-            "category": "core_prevention",
+            "category": "core-prevention",
             "parameters": {
                 "WindowsAssignmentMode": "BLOCK"
             }
@@ -1625,7 +1625,7 @@ POLICY_CONFIG_PRESENTATION = {
         {
             "id": "1f8a5e4b-34f2-4d31-9f8f-87c56facaec8",
             "name": "Advanced Scripting Prevention",
-            "description": "Addresses malicious fileless and file-backed scripts that leverage native programs and common scripting languages.",
+            "description": "Addresses malicious fileless and file-backed scripts that leverage native programs [...]",
             "presentation": {
                 "name": "amsi.name",
                 "category": "core-prevention",
@@ -1669,7 +1669,7 @@ POLICY_CONFIG_PRESENTATION = {
         {
             "id": "ac67fa14-f6be-4df9-93f2-6de0dbd96061",
             "name": "Credential Theft",
-            "description": "Addresses threat actors obtaining credentials and relies on detecting the malicious use of TTPs/behaviors that indicate such activity.",
+            "description": "Addresses threat actors obtaining credentials and relies on detecting the malicious [...]",
             "presentation": {
                 "name": "cred_theft.name",
                 "category": "core-prevention",
@@ -1713,7 +1713,7 @@ POLICY_CONFIG_PRESENTATION = {
         {
             "id": "c4ed61b3-d5aa-41a9-814f-0f277451532b",
             "name": "Carbon Black Threat Intel",
-            "description": "Addresses common and pervasive TTPs used for malicious activity as well as living off the land TTPs/behaviors detected by Carbon Black’s Threat Analysis Unit.",
+            "description": "Addresses common and pervasive TTPs used for malicious activity as well as [...]",
             "presentation": {
                 "name": "cbti.name",
                 "category": "core-prevention",
@@ -1757,7 +1757,7 @@ POLICY_CONFIG_PRESENTATION = {
         {
             "id": "88b19232-7ebb-48ef-a198-2a75a282de5d",
             "name": "Privilege Escalation",
-            "description": "Addresses behaviors that indicate a threat actor has gained elevated access via a bug or misconfiguration within an operating system, and leverages the detection of TTPs/behaviors to prevent such activity.",
+            "description": "Addresses behaviors that indicate a threat actor has gained elevated access via [...]",
             "presentation": {
                 "name": "privesc.name",
                 "category": "core-prevention",
@@ -1799,4 +1799,15 @@ POLICY_CONFIG_PRESENTATION = {
             ]
         }
     ]
+}
+
+REPLACE_RULECONFIG = {
+    "id": "88b19232-7ebb-48ef-a198-2a75a282de5d",
+    "name": "Privilege Escalation",
+    "description": "Addresses behaviors that indicate a threat actor has gained elevated access via [...]",
+    "inherited_from": "psc:region",
+    "category": "core-prevention",
+    "parameters": {
+        "WindowsAssignmentMode": "REPORT"
+    }
 }

--- a/src/tests/unit/fixtures/platform/mock_policies.py
+++ b/src/tests/unit/fixtures/platform/mock_policies.py
@@ -1619,3 +1619,184 @@ TEMPLATE_RETURN_BOGUS_TYPE = {
         }
     }
 }
+
+POLICY_CONFIG_PRESENTATION = {
+    "configs": [
+        {
+            "id": "1f8a5e4b-34f2-4d31-9f8f-87c56facaec8",
+            "name": "Advanced Scripting Prevention",
+            "description": "Addresses malicious fileless and file-backed scripts that leverage native programs and common scripting languages.",
+            "presentation": {
+                "name": "amsi.name",
+                "category": "core-prevention",
+                "description": [
+                    "amsi.description"
+                ],
+                "platforms": [
+                    {
+                        "platform": "WINDOWS",
+                        "header": "amsi.windows.heading",
+                        "subHeader": [
+                            "amsi.windows.sub_heading"
+                        ],
+                        "actions": [
+                            {
+                                "component": "assignment-mode-selector",
+                                "parameter": "WindowsAssignmentMode"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "default": "BLOCK",
+                    "name": "WindowsAssignmentMode",
+                    "description": "Used to change assignment mode to PREVENT or BLOCK",
+                    "recommended": "BLOCK",
+                    "validations": [
+                        {
+                            "type": "enum",
+                            "values": [
+                                "REPORT",
+                                "BLOCK"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "ac67fa14-f6be-4df9-93f2-6de0dbd96061",
+            "name": "Credential Theft",
+            "description": "Addresses threat actors obtaining credentials and relies on detecting the malicious use of TTPs/behaviors that indicate such activity.",
+            "presentation": {
+                "name": "cred_theft.name",
+                "category": "core-prevention",
+                "description": [
+                    "cred_theft.description"
+                ],
+                "platforms": [
+                    {
+                        "platform": "WINDOWS",
+                        "header": "cred_theft.windows.heading",
+                        "subHeader": [
+                            "cred_theft.windows.sub_heading"
+                        ],
+                        "actions": [
+                            {
+                                "component": "assignment-mode-selector",
+                                "parameter": "WindowsAssignmentMode"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "default": "BLOCK",
+                    "name": "WindowsAssignmentMode",
+                    "description": "Used to change assignment mode to PREVENT or BLOCK",
+                    "recommended": "BLOCK",
+                    "validations": [
+                        {
+                            "type": "enum",
+                            "values": [
+                                "REPORT",
+                                "BLOCK"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "c4ed61b3-d5aa-41a9-814f-0f277451532b",
+            "name": "Carbon Black Threat Intel",
+            "description": "Addresses common and pervasive TTPs used for malicious activity as well as living off the land TTPs/behaviors detected by Carbon Black’s Threat Analysis Unit.",
+            "presentation": {
+                "name": "cbti.name",
+                "category": "core-prevention",
+                "description": [
+                    "cbti.description"
+                ],
+                "platforms": [
+                    {
+                        "platform": "WINDOWS",
+                        "header": "cbti.windows.heading",
+                        "subHeader": [
+                            "cbti.windows.sub_heading"
+                        ],
+                        "actions": [
+                            {
+                                "component": "assignment-mode-selector",
+                                "parameter": "WindowsAssignmentMode"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "default": "BLOCK",
+                    "name": "WindowsAssignmentMode",
+                    "description": "Used to change assignment mode to PREVENT or BLOCK",
+                    "recommended": "BLOCK",
+                    "validations": [
+                        {
+                            "type": "enum",
+                            "values": [
+                                "REPORT",
+                                "BLOCK"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "88b19232-7ebb-48ef-a198-2a75a282de5d",
+            "name": "Privilege Escalation",
+            "description": "Addresses behaviors that indicate a threat actor has gained elevated access via a bug or misconfiguration within an operating system, and leverages the detection of TTPs/behaviors to prevent such activity.",
+            "presentation": {
+                "name": "privesc.name",
+                "category": "core-prevention",
+                "description": [
+                    "privesc.description"
+                ],
+                "platforms": [
+                    {
+                        "platform": "WINDOWS",
+                        "header": "privesc.windows.heading",
+                        "subHeader": [
+                            "privesc.windows.sub_heading"
+                        ],
+                        "actions": [
+                            {
+                                "component": "assignment-mode-selector",
+                                "parameter": "WindowsAssignmentMode"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "default": "BLOCK",
+                    "name": "WindowsAssignmentMode",
+                    "description": "Used to change assignment mode to PREVENT or BLOCK",
+                    "recommended": "BLOCK",
+                    "validations": [
+                        {
+                            "type": "enum",
+                            "values": [
+                                "REPORT",
+                                "BLOCK"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/tests/unit/fixtures/platform/mock_policies.py
+++ b/src/tests/unit/fixtures/platform/mock_policies.py
@@ -190,7 +190,7 @@ FULL_POLICY_1 = {
             "value": "true"
         }
     ],
-    "rapid_configs": []
+    "rule_configs": []
 }
 
 SUMMARY_POLICY_1 = {
@@ -1396,7 +1396,7 @@ NEW_POLICY_CONSTRUCT_1 = {
         "policy_modification": False,
         "quarantine": True
     },
-    "rapid_configs": []
+    "rule_configs": []
 }
 
 NEW_POLICY_RETURN_1 = {
@@ -1509,5 +1509,5 @@ NEW_POLICY_RETURN_1 = {
         "policy_modification": False,
         "quarantine": True
     },
-    "rapid_configs": []
+    "rule_configs": []
 }

--- a/src/tests/unit/fixtures/platform/mock_policies.py
+++ b/src/tests/unit/fixtures/platform/mock_policies.py
@@ -1437,7 +1437,26 @@ NEW_POLICY_CONSTRUCT_1 = {
         "policy_modification": False,
         "quarantine": True
     },
-    "rule_configs": []
+    "rule_configs": [
+        {
+            "id": "88b19232-7ebb-48ef-a198-2a75a282de5d",
+            "name": "Privilege Escalation",
+            "inherited_from": "",
+            "category": "core-prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "BLOCK"
+            }
+        },
+        {
+            "id": "ac67fa14-f6be-4df9-93f2-6de0dbd96061",
+            "name": "Credential Theft",
+            "inherited_from": "",
+            "category": "core-prevention",
+            "parameters": {
+                "WindowsAssignmentMode": "REPORT"
+            }
+        }
+    ]
 }
 
 NEW_POLICY_RETURN_1 = {
@@ -1809,5 +1828,15 @@ REPLACE_RULECONFIG = {
     "category": "core-prevention",
     "parameters": {
         "WindowsAssignmentMode": "REPORT"
+    }
+}
+
+BUILD_RULECONFIG_1 = {
+    "id": "88b19232-7ebb-48ef-a198-2a75a282de5d",
+    "name": "Privilege Escalation",
+    "inherited_from": "",
+    "category": "core-prevention",
+    "parameters": {
+        "WindowsAssignmentMode": "BLOCK"
     }
 }

--- a/src/tests/unit/platform/test_policies.py
+++ b/src/tests/unit/platform/test_policies.py
@@ -497,15 +497,16 @@ def test_rule_delete_is_new(cb):
      BASIC_CONFIG_TEMPLATE_RETURN, does_not_raise(), None),
     ({"id": "88b19232-7ebb-48ef-a198-2a75a282de5d", "name": "Privilege Escalation", "inherited_from": "",
       "category": "core_prevention", "parameters": {"WindowsAssignmentMode": "BLOCK"}},
-     TEMPLATE_RETURN_BOGUS_TYPE, pytest.raises(ApiError), "internal error: unknown parameter type bogus"),
+     TEMPLATE_RETURN_BOGUS_TYPE, pytest.raises(ApiError),
+     "internal error: 'bogus' is not valid under any of the given schemas"),
     ({"id": "88b19232-7ebb-48ef-a198-2a75a282de5d", "name": "Privilege Escalation", "inherited_from": "",
       "category": "core_prevention", "parameters": {"WindowsAssignmentMode": 666}},
      BASIC_CONFIG_TEMPLATE_RETURN, pytest.raises(InvalidObjectError),
-     "rule configuration parameter 'WindowsAssignmentMode' is not a string"),
+     "parameter error: 666 is not of type 'string'"),
     ({"id": "88b19232-7ebb-48ef-a198-2a75a282de5d", "name": "Privilege Escalation", "inherited_from": "",
       "category": "core_prevention", "parameters": {"WindowsAssignmentMode": "BOGUSVALUE"}},
      BASIC_CONFIG_TEMPLATE_RETURN, pytest.raises(InvalidObjectError),
-     "invalid value 'BOGUSVALUE' for rule configuration parameter 'WindowsAssignmentMode'"),
+     "parameter error: 'BOGUSVALUE' is not one of ['REPORT', 'BLOCK']"),
 ])
 def test_rule_config_validate(cbcsdk_mock, initial_data, param_schema_return, handler, message):
     """Tests rule configuration validation."""
@@ -537,12 +538,10 @@ def test_rule_config_validate(cbcsdk_mock, initial_data, param_schema_return, ha
      None, does_not_raise(), None),
     ({"id": "88b19232-7ebb-48ef-a198-2a75a282de5d", "name": "Privilege Escalation", "inherited_from": "",
       "category": "core_prevention", "parameters": {"WindowsAssignmentMode": 666}},
-     None, pytest.raises(InvalidObjectError),
-     "rule configuration parameter 'WindowsAssignmentMode' is not a string"),
+     None, pytest.raises(InvalidObjectError), "parameter error: 666 is not of type 'string'"),
     ({"id": "88b19232-7ebb-48ef-a198-2a75a282de5d", "name": "Privilege Escalation", "inherited_from": "",
       "category": "core_prevention", "parameters": {"WindowsAssignmentMode": "BOGUSVALUE"}},
-     None, pytest.raises(InvalidObjectError),
-     "invalid value 'BOGUSVALUE' for rule configuration parameter 'WindowsAssignmentMode'"),
+     None, pytest.raises(InvalidObjectError), "parameter error: 'BOGUSVALUE' is not one of ['REPORT', 'BLOCK']"),
 ])
 def test_rule_config_validate_inside_policy(cbcsdk_mock, new_data, get_id, handler, message):
     """Tests rule configuration validation when it's part of a policy."""

--- a/src/tests/unit/platform/test_policies.py
+++ b/src/tests/unit/platform/test_policies.py
@@ -15,6 +15,7 @@ import copy
 import pytest
 import logging
 import random
+import json
 from contextlib import ExitStack as does_not_raise
 from cbc_sdk.rest_api import CBCloudAPI
 from cbc_sdk.platform import Policy, PolicyRule, PolicyRuleConfig
@@ -24,7 +25,8 @@ from tests.unit.fixtures.platform.mock_policies import (FULL_POLICY_1, SUMMARY_P
                                                         SUMMARY_POLICY_3, OLD_POLICY_1, FULL_POLICY_2, OLD_POLICY_2,
                                                         RULE_ADD_1, RULE_ADD_2, RULE_MODIFY_1, NEW_POLICY_CONSTRUCT_1,
                                                         NEW_POLICY_RETURN_1, BASIC_CONFIG_TEMPLATE_RETURN,
-                                                        TEMPLATE_RETURN_BOGUS_TYPE, POLICY_CONFIG_PRESENTATION)
+                                                        TEMPLATE_RETURN_BOGUS_TYPE, POLICY_CONFIG_PRESENTATION,
+                                                        REPLACE_RULECONFIG)
 
 
 logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
@@ -544,6 +546,7 @@ def test_rule_config_validate(cbcsdk_mock, initial_data, param_schema_return, ha
      "invalid value 'BOGUSVALUE' for rule configuration parameter 'WindowsAssignmentMode'"),
 ])
 def test_rule_config_validate_inside_policy(cbcsdk_mock, new_data, get_id, handler, message):
+    """Tests rule configuration validation when it's part of a policy."""
     cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65535/configs/presentation',
                              POLICY_CONFIG_PRESENTATION)
     api = cbcsdk_mock.api
@@ -555,6 +558,188 @@ def test_rule_config_validate_inside_policy(cbcsdk_mock, new_data, get_id, handl
         rule_config.validate()
     if message is not None:
         assert h.value.args[0] == message
+
+
+def test_rule_config_refresh(cbcsdk_mock):
+    """Tests the rule config refresh() operation."""
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65536', FULL_POLICY_1)
+    api = cbcsdk_mock.api
+    policy = Policy(api, 65536, FULL_POLICY_1, False, True)
+    rule_config = random.choice(list(policy.object_rule_configs.values()))
+    old_name = rule_config.name
+    old_category = rule_config.category
+    old_parameters = rule_config.parameters
+    rule_config.refresh()
+    assert rule_config.name == old_name
+    assert rule_config.category == old_category
+    assert rule_config.parameters == old_parameters
+
+
+@pytest.mark.parametrize("give_error, handler", [
+    (False, does_not_raise()),
+    (True, pytest.raises(ServerError))
+])
+def test_rule_config_add_by_object(cbcsdk_mock, give_error, handler):
+    """Tests using a PolicyRuleConfig object to add a rule configuration."""
+    def on_put(url, body, **kwargs):
+        assert body == FULL_POLICY_1
+        if give_error:
+            return CBCSDKMock.StubResponse("Failure", scode=404)
+        rc = copy.deepcopy(body)
+        return rc
+
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65536/configs/presentation',
+                             POLICY_CONFIG_PRESENTATION)
+    cbcsdk_mock.mock_request('PUT', '/policyservice/v1/orgs/test/policies/65536', on_put)
+    api = cbcsdk_mock.api
+    policy_data = copy.deepcopy(FULL_POLICY_1)
+    rule_config_data1 = [p for p in enumerate(policy_data['rule_configs'])
+                         if p[1]['id'] == '88b19232-7ebb-48ef-a198-2a75a282de5d']
+    rule_config_data = rule_config_data1[0][1]
+    del policy_data['rule_configs'][rule_config_data1[0][0]]
+    policy = Policy(api, 65536, policy_data, False, True)
+    rule_config_count = len(policy.object_rule_configs)
+    new_rule_config = PolicyRuleConfig._create_rule_config(api, policy, rule_config_data)
+    new_rule_config.touch()
+    with handler:
+        new_rule_config.save()
+        assert len(policy.object_rule_configs) == rule_config_count + 1
+        assert '88b19232-7ebb-48ef-a198-2a75a282de5d' in policy.object_rule_configs
+
+
+def test_rule_config_add_by_base_method(cbcsdk_mock):
+    """Tests using the base method on Policy to add a rule."""
+    def on_put(url, body, **kwargs):
+        assert body == FULL_POLICY_1
+        return copy.deepcopy(body)
+
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65536/configs/presentation',
+                             POLICY_CONFIG_PRESENTATION)
+    cbcsdk_mock.mock_request('PUT', '/policyservice/v1/orgs/test/policies/65536', on_put)
+    api = cbcsdk_mock.api
+    policy_data = copy.deepcopy(FULL_POLICY_1)
+    rule_config_data1 = [p for p in enumerate(policy_data['rule_configs'])
+                         if p[1]['id'] == '88b19232-7ebb-48ef-a198-2a75a282de5d']
+    rule_config_data = rule_config_data1[0][1]
+    del policy_data['rule_configs'][rule_config_data1[0][0]]
+    policy = Policy(api, 65536, policy_data, False, True)
+    rule_config_count = len(policy.object_rule_configs)
+    policy.add_rule_config(rule_config_data)
+    assert len(policy.object_rule_configs) == rule_config_count + 1
+    assert '88b19232-7ebb-48ef-a198-2a75a282de5d' in policy.object_rule_configs
+
+
+def test_rule_config_modify_by_object(cbcsdk_mock):
+    """Tests modifying a PolicyRuleConfig object within the policy."""
+    def on_put(url, body, **kwargs):
+        nonlocal new_data
+        assert body == new_data
+        return copy.deepcopy(body)
+
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65536/configs/presentation',
+                             POLICY_CONFIG_PRESENTATION)
+    cbcsdk_mock.mock_request('PUT', '/policyservice/v1/orgs/test/policies/65536', on_put)
+    api = cbcsdk_mock.api
+    new_data = copy.deepcopy(FULL_POLICY_1)
+    new_data['rule_configs'][3]['parameters']['WindowsAssignmentMode'] = 'REPORT'
+    policy = Policy(api, 65536, copy.deepcopy(FULL_POLICY_1), False, True)
+    rule_config_count = len(policy.object_rule_configs)
+    rule_config = policy.object_rule_configs['88b19232-7ebb-48ef-a198-2a75a282de5d']
+    rule_config.set_parameter('WindowsAssignmentMode', 'REPORT')
+    rule_config.save()
+    assert len(policy.object_rule_configs) == rule_config_count
+    rule_config = policy.object_rule_configs['88b19232-7ebb-48ef-a198-2a75a282de5d']
+    assert rule_config.get_parameter('WindowsAssignmentMode') == 'REPORT'
+
+
+def test_rule_config_modify_by_base_method(cbcsdk_mock):
+    """Tests modifying a PolicyRuleConfig object using the replace_rule_config method."""
+    def on_put(url, body, **kwargs):
+        nonlocal new_data
+        assert body == new_data
+        return copy.deepcopy(body)
+
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65536/configs/presentation',
+                             POLICY_CONFIG_PRESENTATION)
+    cbcsdk_mock.mock_request('PUT', '/policyservice/v1/orgs/test/policies/65536', on_put)
+    api = cbcsdk_mock.api
+    new_data = copy.deepcopy(FULL_POLICY_1)
+    new_data['rule_configs'][3]['parameters']['WindowsAssignmentMode'] = 'REPORT'
+    policy = Policy(api, 65536, copy.deepcopy(FULL_POLICY_1), False, True)
+    rule_config_count = len(policy.object_rule_configs)
+    policy.replace_rule_config('88b19232-7ebb-48ef-a198-2a75a282de5d', REPLACE_RULECONFIG)
+    assert len(policy.object_rule_configs) == rule_config_count
+    rule_config = policy.object_rule_configs['88b19232-7ebb-48ef-a198-2a75a282de5d']
+    assert rule_config.get_parameter('WindowsAssignmentMode') == 'REPORT'
+
+
+def test_rule_config_modify_by_base_method_invalid_id(cb):
+    """Tests modifying a PolicyRuleConfig object using replace_rule_config, but with an invalid ID."""
+    policy = Policy(cb, 65536, copy.deepcopy(FULL_POLICY_1), False, True)
+    with pytest.raises(ApiError):
+        policy.replace_rule_config('88b19266-7ebb-48ef-a198-2a75a282de5d', REPLACE_RULECONFIG)
+
+
+def test_rule_config_delete_by_object(cbcsdk_mock):
+    """Tests deleting a PolicyRuleConfig object from a policy."""
+    def on_put(url, body, **kwargs):
+        nonlocal new_data
+        assert body == new_data
+        return copy.deepcopy(body)
+
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65536/configs/presentation',
+                             POLICY_CONFIG_PRESENTATION)
+    cbcsdk_mock.mock_request('PUT', '/policyservice/v1/orgs/test/policies/65536', on_put)
+    api = cbcsdk_mock.api
+    new_data = copy.deepcopy(FULL_POLICY_1)
+    rule_config_data1 = [p for p in enumerate(new_data['rule_configs'])
+                         if p[1]['id'] == '88b19232-7ebb-48ef-a198-2a75a282de5d']
+    del new_data['rule_configs'][rule_config_data1[0][0]]
+    policy = Policy(api, 65536, copy.deepcopy(FULL_POLICY_1), False, True)
+    rule_config_count = len(policy.object_rule_configs)
+    rule_config = policy.object_rule_configs['88b19232-7ebb-48ef-a198-2a75a282de5d']
+    assert not rule_config.is_deleted
+    rule_config.delete()
+    assert len(policy.object_rule_configs) == rule_config_count - 1
+    assert '88b19232-7ebb-48ef-a198-2a75a282de5d' not in policy.object_rule_configs
+    assert rule_config.is_deleted
+
+
+def test_rule_config_delete_by_base_method(cbcsdk_mock):
+    """Tests deleting a rule configuration from a policy via the delete_rule_config method."""
+    def on_put(url, body, **kwargs):
+        nonlocal new_data
+        assert body == new_data
+        return copy.deepcopy(body)
+
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65536/configs/presentation',
+                             POLICY_CONFIG_PRESENTATION)
+    cbcsdk_mock.mock_request('PUT', '/policyservice/v1/orgs/test/policies/65536', on_put)
+    api = cbcsdk_mock.api
+    new_data = copy.deepcopy(FULL_POLICY_1)
+    rule_config_data1 = [p for p in enumerate(new_data['rule_configs'])
+                         if p[1]['id'] == '88b19232-7ebb-48ef-a198-2a75a282de5d']
+    del new_data['rule_configs'][rule_config_data1[0][0]]
+    policy = Policy(api, 65536, copy.deepcopy(FULL_POLICY_1), False, True)
+    rule_config_count = len(policy.object_rule_configs)
+    policy.delete_rule_config('88b19232-7ebb-48ef-a198-2a75a282de5d')
+    assert len(policy.object_rule_configs) == rule_config_count - 1
+    assert '88b19232-7ebb-48ef-a198-2a75a282de5d' not in policy.object_rule_configs
+
+
+def test_rule_config_delete_by_base_method_nonexistent(cb):
+    """Tests what happens when you try to delete a nonexistent rule configuration via delete_rule_config."""
+    policy = Policy(cb, 65536, copy.deepcopy(FULL_POLICY_1), False, True)
+    with pytest.raises(ApiError):
+        policy.delete_rule_config('88b19266-7ebb-48ef-a198-2a75a282de5d')
+
+
+def test_rule_config_delete_is_new(cb):
+    """Tests that deleting a new PolicyRuleConfig raises an error."""
+    policy = Policy(cb, 65536, copy.deepcopy(FULL_POLICY_1), False, True)
+    new_rule_config = PolicyRuleConfig(cb, policy, None, REPLACE_RULECONFIG, False, True)
+    with pytest.raises(ApiError):
+        new_rule_config.delete()
 
 
 def test_policy_builder_make_policy(cbcsdk_mock):

--- a/src/tests/unit/platform/test_policies.py
+++ b/src/tests/unit/platform/test_policies.py
@@ -517,7 +517,7 @@ def test_rule_config_validate(cbcsdk_mock, initial_data, param_schema_return, ha
     cbcsdk_mock.mock_request('GET', f"/policyservice/v1/orgs/test/rule_configs/{initial_data['id']}/parameters/schema",
                              param_schema)
     api = cbcsdk_mock.api
-    rule_config = PolicyRuleConfig._create_rule_config(api, None, initial_data)
+    rule_config = Policy._create_rule_config(api, None, initial_data)
     with handler as h:
         rule_config.validate()
     if message is not None:
@@ -598,7 +598,7 @@ def test_rule_config_add_by_object(cbcsdk_mock, give_error, handler):
     del policy_data['rule_configs'][rule_config_data1[0][0]]
     policy = Policy(api, 65536, policy_data, False, True)
     rule_config_count = len(policy.object_rule_configs)
-    new_rule_config = PolicyRuleConfig._create_rule_config(api, policy, rule_config_data)
+    new_rule_config = Policy._create_rule_config(api, policy, rule_config_data)
     new_rule_config.touch()
     with handler:
         new_rule_config.save()


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-4375


## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Add basic rule config information to the `Policy` object.  This includes support for getting rule configurations, modifying them, adding them, deleting them, and incorporating them into a new `Policy` built with `PolicyBuilder.`

Some of this may overlap with the "core prevention" facilities; this is because "core prevention" rule configurations are among the simplest, and easy to use to verify operation.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit test coverage has been added for all new code in the module.  Coverage on `policies.py` stands at 97% overall.