### PR TITLE
Cleanup code to use requests to parse query params

### DIFF
--- a/src/cbc_sdk/connection.py
+++ b/src/cbc_sdk/connection.py
@@ -42,8 +42,6 @@ except ImportError:
 import logging
 import json
 
-import urllib
-
 from .credentials import Credentials
 from .credential_providers.default import default_credential_provider
 from .errors import ClientError, QuerySyntaxError, ServerError, TimeoutError, ApiError, ObjectNotFoundError, \
@@ -52,7 +50,6 @@ from . import __version__
 
 from .cache.lru import lru_cache_function
 from .base import CreatableModelMixin, NewBaseModel
-from .utils import convert_query_params
 
 log = logging.getLogger(__name__)
 DEFAULT_STREAM_BUFFER_SIZE = 1024
@@ -470,12 +467,7 @@ class BaseAPI(object):
         Returns:
             object: Result of the GET request.
         """
-        if query_parameters:
-            if isinstance(query_parameters, dict):
-                query_parameters = convert_query_params(query_parameters)
-            uri += '?%s' % (urllib.parse.urlencode(sorted(query_parameters)))
-
-        result = self.api_json_request("GET", uri)
+        result = self.api_json_request("GET", uri, params=query_parameters)
         if result.status_code == 200:
             try:
                 return result.json()
@@ -500,13 +492,8 @@ class BaseAPI(object):
         Returns:
             object: Result of the GET request.
         """
-        if query_parameters:
-            if isinstance(query_parameters, dict):
-                query_parameters = convert_query_params(query_parameters)
-            uri += '?%s' % (urllib.parse.urlencode(sorted(query_parameters)))
-
         hdrs = kwargs.pop("headers", {})
-        result = self.api_json_request("GET", uri, headers=hdrs)
+        result = self.api_json_request("GET", uri, headers=hdrs, params=query_parameters)
         if result.status_code == 200:
             return result.text
         elif result.status_code == 204:

--- a/src/cbc_sdk/utils.py
+++ b/src/cbc_sdk/utils.py
@@ -20,27 +20,6 @@ import dateutil.parser
 cb_datetime_format = "%Y-%m-%d %H:%M:%S.%f"
 
 
-def convert_query_params(qd):
-    """
-    Expand a dictionary of query parameters by turning "list" values into multiple pairings of key with value.
-
-    Args:
-        qd (dict): A mapping of parameter names to values.
-
-    Returns:
-        list: A list of query parameters, each one a tuple containing name and value, after the expansion is applied.
-    """
-    o = []
-    for k, v in iter(qd.items()):
-        if type(v) == list:
-            for item in v:
-                o.append((k, item))
-        else:
-            o.append((k, v))
-
-    return o
-
-
 def convert_from_cb(s):
     """
     Parse a date and time value into a datetime object.

--- a/src/tests/unit/test_base_api.py
+++ b/src/tests/unit/test_base_api.py
@@ -185,15 +185,15 @@ def test_BaseAPI_raise_unless_json_raises(response, expected, scode):
 
 @pytest.mark.parametrize("expath, response, params, default, expected", [
     ('/path', StubResponse({'a': 1, 'b': 2}), None, {'a': 8, 'b': 9}, {'a': 1, 'b': 2}),
-    ('/path?x=1&y=2', StubResponse({'a': 1, 'b': 2}), [('x', 1), ('y', 2)], {'a': 8, 'b': 9}, {'a': 1, 'b': 2}),
-    ('/path?x=1&y=2', StubResponse({'a': 1, 'b': 2}), {'x': 1, 'y': 2}, {'a': 8, 'b': 9}, {'a': 1, 'b': 2}),
+    ('/path', StubResponse({'a': 1, 'b': 2}), [('x', 1), ('y', 2)], {'a': 8, 'b': 9}, {'a': 1, 'b': 2}),
+    ('/path', StubResponse({'a': 1, 'b': 2}), {'x': 1, 'y': 2}, {'a': 8, 'b': 9}, {'a': 1, 'b': 2}),
     ('/path', StubResponse({'a': 1, 'b': 2}, 204), None, {'a': 8, 'b': 9}, {'a': 8, 'b': 9})
 ])
 def test_BaseAPI_get_object_returns(mox, expath, response, params, default, expected):
     """Test the cases where get_object returns a value."""
     sut = BaseAPI(url='https://example.com', token='ABCDEFGH', org_key='A1B2C3D4')
     mox.StubOutWithMock(sut.session, 'http_request')
-    sut.session.http_request('GET', expath, headers={}, data=None).AndReturn(response)
+    sut.session.http_request('GET', expath, headers={}, data=None, params=params).AndReturn(response)
     mox.ReplayAll()
     rc = sut.get_object('/path', params, default)
     assert rc == expected
@@ -209,7 +209,7 @@ def test_BaseAPI_get_object_raises_from_returns(mox, response, errcode, prefix):
     """Test the cases where get_object raises an exception based on what it receives."""
     sut = BaseAPI(url='https://example.com', token='ABCDEFGH', org_key='A1B2C3D4')
     mox.StubOutWithMock(sut.session, 'http_request')
-    sut.session.http_request('GET', '/path', headers={}, data=None).AndReturn(response)
+    sut.session.http_request('GET', '/path', headers={}, data=None, params=None).AndReturn(response)
     mox.ReplayAll()
     with pytest.raises(ServerError) as excinfo:
         sut.get_object('/path')
@@ -220,15 +220,15 @@ def test_BaseAPI_get_object_raises_from_returns(mox, response, errcode, prefix):
 
 @pytest.mark.parametrize("expath, code, response, params, default, expected", [
     ('/path', 200, 'Boston1', None, 'Denver0', 'Boston1'),
-    ('/path?x=1&y=2', 200, 'Boston1', [('x', 1), ('y', 2)], 'Denver0', 'Boston1'),
-    ('/path?x=1&y=2', 200, 'Boston1', {'x': 1, 'y': 2}, 'Denver0', 'Boston1'),
+    ('/path', 200, 'Boston1', [('x', 1), ('y', 2)], 'Denver0', 'Boston1'),
+    ('/path', 200, 'Boston1', {'x': 1, 'y': 2}, 'Denver0', 'Boston1'),
     ('/path', 204, 'Boston1', None, 'Denver0', 'Denver0')
 ])
 def test_BaseAPI_get_raw_data_returns(mox, expath, code, response, params, default, expected):
     """Test the cases where get_raw_data returns a value."""
     sut = BaseAPI(url='https://example.com', token='ABCDEFGH', org_key='A1B2C3D4')
     mox.StubOutWithMock(sut.session, 'http_request')
-    sut.session.http_request('GET', expath, headers={}, data=None).AndReturn(StubResponse(None, code, response))
+    sut.session.http_request('GET', expath, headers={}, data=None, params=params).AndReturn(StubResponse(None, code, response))
     mox.ReplayAll()
     rc = sut.get_raw_data('/path', params, default)
     assert rc == expected
@@ -243,7 +243,7 @@ def test_BaseAPI_get_raw_data_raises_from_returns(mox, response, errcode, prefix
     """Test the cases where get_raw_data raises an exception based on what it receives."""
     sut = BaseAPI(url='https://example.com', token='ABCDEFGH', org_key='A1B2C3D4')
     mox.StubOutWithMock(sut.session, 'http_request')
-    sut.session.http_request('GET', '/path', headers={}, data=None).AndReturn(response)
+    sut.session.http_request('GET', '/path', headers={}, data=None, params=None).AndReturn(response)
     mox.ReplayAll()
     with pytest.raises(ServerError) as excinfo:
         sut.get_raw_data('/path')

--- a/src/tests/unit/test_utils.py
+++ b/src/tests/unit/test_utils.py
@@ -13,25 +13,10 @@
 
 # import pytest
 from datetime import datetime
-from cbc_sdk.utils import convert_query_params, convert_from_cb, convert_to_cb
+from cbc_sdk.utils import convert_from_cb, convert_to_cb
 
 
 # ==================================== Unit TESTS BELOW ====================================
-
-
-def test_convert_query_params():
-    """Test that query parameter dicts are properly converted."""
-    lv = convert_query_params({'answer': 42, 'hup': [2, 3, 4], 'goody': 'twoshoes'})
-    assert isinstance(lv, list)
-    assert len(lv) == 5
-    assert ('answer', 42) in lv
-    assert ('hup', 2) in lv
-    assert ('hup', 3) in lv
-    assert ('hup', 4) in lv
-    assert ('goody', 'twoshoes') in lv
-    lv = convert_query_params({})
-    assert isinstance(lv, list)
-    assert len(lv) == 0
 
 
 def test_convert_from_cb():


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.



## Pull Request Description
Removes code which manually handles query string parameters letting `requests` handle it (as described in [requests doc](https://docs.python-requests.org/en/latest/user/quickstart/?highlight=query%20params#passing-parameters-in-urls)).


## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Now the query_parameters param used in `get_object` and `get_raw_data` methods must be a dict or None.

When the param is a dict, it should not bring breaking changes. The only notable change is that requests does not add in query-string elements which values are `None`.

> Note that any dictionary key whose value is `None` will not be added to the URL’s query string.


## How Has This Been Tested?
- Run tests with py.test locally 
- manual fetch "Devices" by quering on `ad_group_id` and changing sort field/direction.
