### PR TITLE
Adjust read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"

--- a/docs/cbc_sdk.audit_remediation.rst
+++ b/docs/cbc_sdk.audit_remediation.rst
@@ -6,7 +6,7 @@ Base Module
 
 .. automodule:: cbc_sdk.audit_remediation.base
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Differential Module
@@ -14,5 +14,5 @@ Differential Module
 
 .. automodule:: cbc_sdk.audit_remediation.differential
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:

--- a/docs/cbc_sdk.cache.rst
+++ b/docs/cbc_sdk.cache.rst
@@ -6,5 +6,5 @@ LRU Module
 
 .. automodule:: cbc_sdk.cache.lru
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:

--- a/docs/cbc_sdk.credential_providers.rst
+++ b/docs/cbc_sdk.credential_providers.rst
@@ -6,7 +6,7 @@ Default Module
 
 .. automodule:: cbc_sdk.credential_providers.default
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 AWS SM Credential Provider Module
@@ -14,7 +14,7 @@ AWS SM Credential Provider Module
 
 .. automodule:: cbc_sdk.credential_providers.aws_sm_credential_provider
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Environ Credential Provider Module
@@ -22,7 +22,7 @@ Environ Credential Provider Module
 
 .. automodule:: cbc_sdk.credential_providers.environ_credential_provider
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 File Credential Provider Module
@@ -30,7 +30,7 @@ File Credential Provider Module
 
 .. automodule:: cbc_sdk.credential_providers.file_credential_provider
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Keychain Credential Provider Module
@@ -38,7 +38,7 @@ Keychain Credential Provider Module
 
 .. automodule:: cbc_sdk.credential_providers.keychain_credential_provider
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Registry Credential Provider Module
@@ -46,6 +46,5 @@ Registry Credential Provider Module
 
 .. automodule:: cbc_sdk.credential_providers.registry_credential_provider
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
-

--- a/docs/cbc_sdk.endpoint_standard.rst
+++ b/docs/cbc_sdk.endpoint_standard.rst
@@ -6,7 +6,7 @@ Base Module
 
 .. automodule:: cbc_sdk.endpoint_standard.base
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Standard Recommendation Module
@@ -14,7 +14,7 @@ Standard Recommendation Module
 
 .. automodule:: cbc_sdk.endpoint_standard.recommendation
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 USB Device Control Module
@@ -22,6 +22,5 @@ USB Device Control Module
 
 .. automodule:: cbc_sdk.endpoint_standard.usb_device_control
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
-

--- a/docs/cbc_sdk.enterprise_edr.rst
+++ b/docs/cbc_sdk.enterprise_edr.rst
@@ -6,7 +6,7 @@ Auth Events Module
 
 .. automodule:: cbc_sdk.enterprise_edr.auth_events
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Threat Intelligence Module
@@ -14,7 +14,7 @@ Threat Intelligence Module
 
 .. automodule:: cbc_sdk.enterprise_edr.threat_intelligence
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 UBS Module
@@ -22,5 +22,5 @@ UBS Module
 
 .. automodule:: cbc_sdk.enterprise_edr.ubs
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:

--- a/docs/cbc_sdk.platform.rst
+++ b/docs/cbc_sdk.platform.rst
@@ -6,7 +6,7 @@ Base Module
 
 .. automodule:: cbc_sdk.platform.base
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Alerts Module
@@ -14,15 +14,15 @@ Alerts Module
 
 .. automodule:: cbc_sdk.platform.alerts
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
-   
+
 Audit Module
 ------------------------------
 
 .. automodule:: cbc_sdk.platform.audit
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Devices Module
@@ -30,7 +30,7 @@ Devices Module
 
 .. automodule:: cbc_sdk.platform.devices
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Events Module
@@ -38,7 +38,7 @@ Events Module
 
 .. automodule:: cbc_sdk.platform.events
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Grants Module
@@ -46,7 +46,7 @@ Grants Module
 
 .. automodule:: cbc_sdk.platform.grants
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Jobs Module
@@ -54,7 +54,7 @@ Jobs Module
 
 .. automodule:: cbc_sdk.platform.jobs
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Network Threat Metadata Module
@@ -62,7 +62,7 @@ Network Threat Metadata Module
 
 .. automodule:: cbc_sdk.platform.network_threat_metadata
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Observations Module
@@ -70,7 +70,7 @@ Observations Module
 
 .. automodule:: cbc_sdk.platform.observations
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Policies Module
@@ -78,7 +78,7 @@ Policies Module
 
 .. automodule:: cbc_sdk.platform.policies
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 RuleConfigs Module
@@ -86,7 +86,7 @@ RuleConfigs Module
 
 .. automodule:: cbc_sdk.platform.policy_ruleconfigs
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Processes Module
@@ -94,7 +94,7 @@ Processes Module
 
 .. automodule:: cbc_sdk.platform.processes
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Reputation Module
@@ -102,7 +102,7 @@ Reputation Module
 
 .. automodule:: cbc_sdk.platform.reputation
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Users Module
@@ -110,7 +110,7 @@ Users Module
 
 .. automodule:: cbc_sdk.platform.users
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Vulnerability Assessment Module
@@ -118,5 +118,5 @@ Vulnerability Assessment Module
 
 .. automodule:: cbc_sdk.platform.vulnerability_assessment
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:

--- a/docs/cbc_sdk.rst
+++ b/docs/cbc_sdk.rst
@@ -23,7 +23,7 @@ Base Module
 
 .. automodule:: cbc_sdk.base
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Connection Module
@@ -31,7 +31,7 @@ Connection Module
 
 .. automodule:: cbc_sdk.connection
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Credentials Module
@@ -39,7 +39,7 @@ Credentials Module
 
 .. automodule:: cbc_sdk.credentials
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Errors Module
@@ -47,7 +47,7 @@ Errors Module
 
 .. automodule:: cbc_sdk.errors
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Helpers Module
@@ -55,7 +55,7 @@ Helpers Module
 
 .. automodule:: cbc_sdk.helpers
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Live Response API Module
@@ -63,7 +63,7 @@ Live Response API Module
 
 .. automodule:: cbc_sdk.live_response_api
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 REST API Module
@@ -71,7 +71,7 @@ REST API Module
 
 .. automodule:: cbc_sdk.rest_api
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Utils Module
@@ -79,7 +79,7 @@ Utils Module
 
 .. automodule:: cbc_sdk.utils
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 WinError Module
@@ -87,5 +87,5 @@ WinError Module
 
 .. automodule:: cbc_sdk.winerror
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:

--- a/docs/cbc_sdk.workload.rst
+++ b/docs/cbc_sdk.workload.rst
@@ -6,7 +6,7 @@ NSX Remediation Module
 
 .. automodule:: cbc_sdk.workload.nsx_remediation
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 Sensor Lifecycle Module
@@ -14,7 +14,7 @@ Sensor Lifecycle Module
 
 .. automodule:: cbc_sdk.workload.sensor_lifecycle
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:
 
 VM Workloads Search Module
@@ -22,5 +22,5 @@ VM Workloads Search Module
 
 .. automodule:: cbc_sdk.workload.vm_workloads_search
    :members:
-   :undoc-members:
+   :inherited-members:
    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,7 +99,7 @@ See detailed information on the objects and methods exposed by the Carbon Black 
 
 .. toctree::
    :caption: SDK Documentation
-   :maxdepth: 2
+   :maxdepth: 4
 
    cbc_sdk.audit_remediation
    cbc_sdk.credential_providers

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ Get started with Carbon Black Cloud Python SDK here. For detailed information on
    Getting Started <getting-started>
    concepts
    resources
-   porting-guide
+   guides
 
 Guides
 ------
@@ -76,13 +76,15 @@ Guides
    :caption: Guides
    :maxdepth: 2
 
+   porting-guide
    alerts
-   developing-credential-providers
    audit-log
+   developing-credential-providers
    device-control
    differential-analysis
    live-query
    live-response
+   live-response-v6-migration
    policy
    recommendations
    reputation-override

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-cbc_sdk
-=======
-
-.. toctree::
-   :maxdepth: 4
-
-   cbc_sdk

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,7 @@
 # Defining the exact version will make sure things don't break
 sphinx==6.2.1
+sphinx-copybutton==0.4.0
+sphinx-rtd-theme==1.2.2
 sphinxcontrib-apidoc
 sphinx-copybutton==0.4.0
 pygments

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 # Defining the exact version will make sure things don't break
+sphinx==6.2.1
 sphinxcontrib-apidoc
 sphinx-copybutton==0.4.0
 pygments

--- a/src/cbc_sdk/errors.py
+++ b/src/cbc_sdk/errors.py
@@ -52,8 +52,8 @@ class ClientError(ApiError):
             error_code (int): The error code that was received from the server.
             message (str): The actual error message.
             kwargs (dict): Additional arguments, which may include 'result' (server operation result),
-                          'original_exception' (exception causing this one to be raised), and 'uri' (URI being accessed
-                           when this error was raised).
+                'original_exception' (exception causing this one to be raised), and 'uri' (URI being accessed
+                when this error was raised).
         """
         super(ClientError, self).__init__(message=message, original_exception=kwargs.get('original_exception', None))
 
@@ -119,8 +119,8 @@ class ServerError(ApiError):
             error_code (int): The error code that was received from the server.
             message (str): The actual error message.
             kwargs (dict): Additional arguments, which may include 'result' (server operation result),
-                          'original_exception' (exception causing this one to be raised), and 'uri' (URI being accessed
-                           when this error was raised).
+                'original_exception' (exception causing this one to be raised), and 'uri' (URI being accessed
+                when this error was raised).
         """
         super(ServerError, self).__init__(message=message, original_exception=kwargs.get('original_exception', None))
 

--- a/src/cbc_sdk/platform/vulnerability_assessment.py
+++ b/src/cbc_sdk/platform/vulnerability_assessment.py
@@ -238,7 +238,8 @@ class VulnerabilityOrgSummaryQuery(BaseQuery):
         Args:
             doc_class (class): The model class that will be returned by this query.
             cb (BaseAPI): Reference to API object used to communicate with the server.
-            device (Device): Optional Device object to indicate VulnerabilityQuery is for a specific device
+            device (cbc_sdk.platform.devices.Device): Optional Device object to indicate
+                VulnerabilityQuery is for a specific device
         """
         self._doc_class = doc_class
         self._cb = cb
@@ -346,7 +347,8 @@ class VulnerabilityQuery(BaseQuery, QueryBuilderSupportMixin,
         Args:
             doc_class (class): The model class that will be returned by this query.
             cb (BaseAPI): Reference to API object used to communicate with the server.
-            device (Device): Optional Device object to indicate VulnerabilityQuery is for a specific device
+            device (cbc_sdk.platform.devices.Device): Optional Device object to indicate
+                VulnerabilityQuery is for a specific device
         """
         self._doc_class = doc_class
         self._cb = cb


### PR DESCRIPTION
## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
I modified the maxdepth of the SDK Documentation toctree to 4 as this enables the left nav to have the abiliity to see the file contents which makes identifiying and switching to the desired function easier

<img width="293" alt="Screenshot 2023-07-28 at 11 51 23 AM" src="https://github.com/carbonblack/carbon-black-cloud-sdk-python/assets/51210614/e9053e49-6eef-4bf2-9e14-7965a818fd7e">

Additionally I think we want to swap  `:inherited-members:` for `:undoc-members:` as the undoc members seem to mostly be the properties which get pulled in from the swagger file and documented twice. The swagger properties are documented under the models Parameters section which should be enough. Plus any of the properties we do want users to see should have doc strings so there should be no undoc-members which we actually want documented

<img width="733" alt="Screenshot 2023-07-28 at 11 54 41 AM" src="https://github.com/carbonblack/carbon-black-cloud-sdk-python/assets/51210614/62c0e81c-15d3-40ab-b1b9-3fdf5c8d2a73">
