### PR TITLE
CBAPI-4786: Add Documentation & UAT for External Device Export & Approval Export routes

### DIFF
--- a/docs/device-control.rst
+++ b/docs/device-control.rst
@@ -27,6 +27,18 @@ organization.
 Note that individual USB devices may be ``APPROVED`` or ``UNAPPROVED``. USB devices which are ``UNAPPROVED`` cannot
 be read on any endpoint with a policy that blocks unknown USB devices.
 
+A USB device query can also be exported to either CSV or JSON format, for use by other software systems.
+
+::
+
+    >>> from cbc_sdk import CBCloudAPI
+    >>> api = CBCloudAPI(profile='sample')
+    >>> from cbc_sdk.endpoint_standard import USBDevice
+    >>> query = api.select(USBDevice).where('1')
+    >>> job = query.export('CSV')
+    >>> csv_report = job.get_output_as_string()
+    >>> # can also get the output as a file or as enumerated lines of text
+
 Approving A Specific Device
 ---------------------------
 
@@ -82,6 +94,33 @@ Device approvals may be removed via the API as well. Starting from the end of th
 
 The ``delete()`` method is what causes the approval to be removed.  We then use ``refresh()`` on the actual
 ``USBDevice`` object to allow its ``status`` to be updated.
+
+Retrieving the List of Approvals
+--------------------------------
+
+USB device approvals can also be enumerated directly.
+
+::
+
+    >>> from cbc_sdk import CBCloudAPI
+    >>> api = CBCloudAPI(profile='sample')
+    >>> from cbc_sdk.endpoint_standard import USBDeviceApproval
+    >>> query = api.select(USBDeviceApproval)
+    >>> for approval in query:
+    ...     print(f"{approval.id} {approval.approval_name} {approval.serial_number}")
+    ...
+
+They can also be exported in a similar manner to USB devices.
+
+::
+
+    >>> from cbc_sdk import CBCloudAPI
+    >>> api = CBCloudAPI(profile='sample')
+    >>> from cbc_sdk.endpoint_standard import USBDeviceApproval
+    >>> query = api.select(USBDeviceApproval)
+    >>> job = query.export('CSV')
+    >>> csv_report = job.get_output_as_string()
+    >>> # can also get the output as a file or as enumerated lines of text
 
 Device Control Alerts
 ---------------------

--- a/src/tests/uat/device_control_uat.py
+++ b/src/tests/uat/device_control_uat.py
@@ -107,6 +107,7 @@ def export_usb_device_approvals():
     resp = requests.get(job_url, headers=HEADERS)
     return resp.text
 
+
 def get_usb_device_block_by_id_api(block_id):
     """Get Block by ID"""
     url = USB_DEVICE_BLOCKS.format(HOSTNAME, ORG_KEY)

--- a/src/tests/uat/device_control_uat.py
+++ b/src/tests/uat/device_control_uat.py
@@ -57,6 +57,7 @@ USB_DEVICE_APPROVAL = '{}device_control/v3/orgs/{}/approvals'
 USB_DEVICE_BLOCKS = '{}device_control/v3/orgs/{}/blocks'
 USB_DEVICES = '{}device_control/v3/orgs/{}/devices'
 USB_DEVICES_FACETS = '{}device_control/v3/orgs/{}/devices/_facet'
+JOB_OUTPUT = '{}/jobs/v1/orgs/{}/jobs/{}/download'
 HEADERS = {'X-Auth-Token': '', 'Content-Type': 'application/json'}
 ORG_KEY = ''
 HOSTNAME = ''
@@ -96,6 +97,11 @@ def search_usb_device_approval():
     return requests.post(usb_url, json={}, headers=HEADERS)
 
 
+def export_usb_device_approval():
+    """Export USB Device Approval"""
+    ...
+
+
 def get_usb_device_block_by_id_api(block_id):
     """Get Block by ID"""
     url = USB_DEVICE_BLOCKS.format(HOSTNAME, ORG_KEY)
@@ -114,6 +120,15 @@ def search_usb_devices():
     usb_url = USB_DEVICES.format(HOSTNAME, ORG_KEY)
     usb_url += '/_search'
     return requests.post(usb_url, json={}, headers=HEADERS)
+
+
+def export_usb_devices():
+    """Export USB Devices"""
+    usb_url = USB_DEVICES.format(HOSTNAME, ORG_KEY)
+    usb_url += '/_export'
+    job_ref = requests.post(usb_url, json={"format": "CSV"}, headers=HEADERS).json()
+    job_url = JOB_OUTPUT.format(HOSTNAME, ORG_KEY, job_ref['job_id'])
+    return requests.get(job_url, headers=HEADERS)
 
 
 def search_usb_devices_facets():
@@ -173,10 +188,12 @@ def main():
         'Actual: {}'.format(api_search, sdk_results)
     print('Search Test...................................OK')
 
+    # export device approvals
+    # TODO
+
     # update the object
     sdk_created_obj.approval_name = 'Changed Approval'
     sdk_created_obj._update_object()
-    sdk_created_new = None
     query = cb.select(USBDeviceApproval)
     sdk_created_new = query[0]
     assert sdk_created_new.approval_name == 'Changed Approval', 'Update Test '\
@@ -234,6 +251,7 @@ def main():
     print('USB Devices')
     print(SYMBOLS * DELIMITER)
 
+    # Search USB Devices
     query = cb.select(USBDevice)
     sdk_results = []
     for device in query:
@@ -245,6 +263,9 @@ def main():
     assert sdk_results == api_search['results'], 'Device Search Test Failed -'\
         'Expected: {}, Actual: {}'.format(api_search['results'], sdk_results)
     print('Device Search.................................OK')
+
+    # Export USB Devices
+    # TODO
 
     # Facet USB Devices
     query = cb.select(USBDevice).facets(["status"])
@@ -263,6 +284,8 @@ def main():
     assert api_results == sdk_result, 'Get USB Device Vendors and Products '\
         'Failed - Expected: {}, Actual: {}'.format(api_results, sdk_result)
     print('Get USB Device Vendors and Products Seen......OK')
+
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [ ] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [ ] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-4876

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added documentation in ReadTheDocs for device export functions, and added code to UAT to test them.

(Also updated and "hardened" the UAT script a bit; it was a tad "brittle" in some aspects.)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
UAT script has been run; log is in [device_control_uat.log](https://github.com/carbonblack/carbon-black-cloud-sdk-python/files/12233648/device_control_uat.log).  Doc file has been previewed for formatting errors.
