### PR TITLE
added function set_time_criterion_filters which has the same function…

### DIFF
--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -1035,6 +1035,7 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
             >>> second_query = api.select(Alert).
             ...     set_time_range(start="2020-10-20T20:34:07Z", end="2020-10-30T20:34:07Z")
             >>> third_query = api.select(Alert).set_time_range(range='-3d')
+            >>> fourth_query = api.select(Alert).set_time_range("create_time", range='-3d')
 
         """
         args_count = args.__len__()
@@ -1066,6 +1067,13 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
 
         Returns:
             AlertSearchQuery: This instance.
+
+        Examples:
+            >>> query = api.select(Alert).
+            ...     add_time_criteria("backend_timestamp", start="2020-10-20T20:34:07Z", end="2020-10-30T20:34:07Z")
+            >>> second_query = api.select(Alert).add_time_criteria("backend_timestamp", range='-3d')
+            >>> third_query = api.select(Alert).set_time_range("create_time", range='-3d')
+
         """
         # this first if statement will be removed after v6 is deprecated
         if not self._valid_criteria:
@@ -1080,8 +1088,9 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
         Verifies that an alert criteria key has the timerange functionality
 
         Args:
-            args (str): The key to use for criteria one of create_time, first_event_time, last_event_time,
-             backend_timestamp, backend_update_timestamp, or last_update_time
+            args (str): The key to use for criteria one of one of backend_timestamp, backend_update_timestamp,
+            detection_timestamp, first_event_timestamp, last_event_timestamp, mdr_determination_change_timestamp,
+            mdr_workflow_change_timestamp, user_update_timestamp, or workflow_change_timestamp
 
         Returns:
             boolean true
@@ -1096,7 +1105,7 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
 
     def _is_valid_time_criteria_key_v6(self, key):
         """
-        Verifies that an alert criteria key has the timerange functionality
+        Verifies that an alert criteria key has the timerange functionality for v6 sdk calls
 
         Args:
             args (str): The key to use for criteria one of create_time, first_event_time, last_event_time,

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -1044,6 +1044,7 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
             key = args[0]
             self._valid_criteria = self._is_valid_time_criteria_key_v6(key)
             if self._valid_criteria:
+                key = Alert.REMAPPED_ALERTS_V6_TO_V7.get(key, key)
                 self.add_time_criteria(key, **kwargs)
                 if key in ["create_time", "backend_timestamp"]:
                     self._time_range = time_filter

--- a/src/cbc_sdk/platform/legacy_alerts.py
+++ b/src/cbc_sdk/platform/legacy_alerts.py
@@ -339,42 +339,6 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         self._update_criteria("threat_id", threats)
         return self
 
-    def set_time_range(self, key, **kwargs):
-        """
-        Restricts the alerts that this query is performed on to the specified time range.
-
-        The time may either be specified as a start and end point or as a range.
-
-        Args:
-            key (str): The key to use for criteria one of create_time,
-                       first_event_time, last_event_time, or last_update_time
-            **kwargs (dict): Used to specify start= for start time, end= for end time, and range= for range.
-
-        Returns:
-            AlertSearchQuery: This instance.
-        """
-        if key not in ["create_time", "first_event_time", "last_event_time", "last_update_time", "backend_timestamp",
-                       "backend_update_timestamp"]:
-            raise ApiError("key must be one of create_time, first_event_time, last_event_time, backend_timestamp, "
-                           "backend_update_timestamp, or last_update_time")
-        if kwargs.get("start", None) and kwargs.get("end", None):
-            if kwargs.get("range", None):
-                raise ApiError("cannot specify range= in addition to start= and end=")
-            stime = kwargs["start"]
-            if not isinstance(stime, str):
-                stime = stime.isoformat()
-            etime = kwargs["end"]
-            if not isinstance(etime, str):
-                etime = etime.isoformat()
-            self._time_filters[key] = {"start": stime, "end": etime}
-        elif kwargs.get("range", None):
-            if kwargs.get("start", None) or kwargs.get("end", None):
-                raise ApiError("cannot specify start= or end= in addition to range=")
-            self._time_filters[key] = {"range": kwargs["range"]}
-        else:
-            raise ApiError("must specify either start= and end= or range=")
-        return self
-
     def set_types(self, alerttypes):
         """
         Restricts the alerts that this query is performed on to the specified alert type values.

--- a/src/tests/unit/platform/test_alertsv6_api.py
+++ b/src/tests/unit/platform/test_alertsv6_api.py
@@ -175,7 +175,7 @@ def test_query_basealert_with_time_range(cbcsdk_mock):
 
     def on_post(url, body, **kwargs):
         nonlocal _timestamp
-        assert body == {"query": "Blort", "criteria": {"last_update_time": {
+        assert body == {"query": "Blort", "criteria": {"backend_update_timestamp": {
             "start": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "end": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}},
             "rows": 2}
@@ -199,7 +199,7 @@ def test_query_basealert_with_time_range_start_end(cbcsdk_mock):
     """Test an alert query with the last_update_time specified as a range."""
 
     def on_post(url, body, **kwargs):
-        assert body == {"query": "Blort", "criteria": {"last_update_time": {"range": "-3w"}}, "rows": 2}
+        assert body == {"query": "Blort", "criteria": {"backend_update_timestamp": {"range": "-3w"}}, "rows": 2}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"state": "OPEN"}}], "num_found": 1}
 
@@ -218,7 +218,7 @@ def test_query_basealert_with_time_range_create_time_as_start_end(cbcsdk_mock):
     """Test an alert query with the create_time specified as a range which should also set the global time_range."""
 
     def on_post(url, body, **kwargs):
-        assert body == {"query": "Blort", "criteria": {"create_time": {"range": "-3w"}}, "rows": 2,
+        assert body == {"query": "Blort", "criteria": {"backend_timestamp": {"range": "-3w"}}, "rows": 2,
                         'time_range': {'range': '-3w'}}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"state": "OPEN"}}], "num_found": 1}

--- a/src/tests/unit/platform/test_alertsv6_api.py
+++ b/src/tests/unit/platform/test_alertsv6_api.py
@@ -175,9 +175,10 @@ def test_query_basealert_with_time_range(cbcsdk_mock):
 
     def on_post(url, body, **kwargs):
         nonlocal _timestamp
-        assert body == {"query": "Blort", "criteria": {"last_update_time": {"start": _timestamp.isoformat(),
-                                                                            "end": _timestamp.isoformat()}},
-                        "rows": 2}
+        assert body == {"query": "Blort", "criteria": {"last_update_time": {
+            "start": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "end": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}},
+            "rows": 2}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"state": "OPEN"}}], "num_found": 1}
 
@@ -571,6 +572,7 @@ def test_query_set_rows(cbcsdk_mock):
         assert a.id == "S0L0"
         assert a.org_key == "test"
         assert a.threat_id == "B0RG"
+
 
 # TODO replace bulk tests
 # def test_alerts_bulk_dismiss(cbcsdk_mock):
@@ -967,7 +969,7 @@ def test_query_basealert_with_time_range_errors(cbcsdk_mock):
     api = cbcsdk_mock.api
     with pytest.raises(ApiError) as ex:
         api.select(BaseAlert).where("Blort").set_time_range("invalid", range="whatever")
-    assert "key must be one of create_time, first_event_time, last_event_time, backend_timestamp, "\
+    assert "key must be one of create_time, first_event_time, last_event_time, backend_timestamp, " \
            "backend_update_timestamp, or last_update_time" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
@@ -1028,6 +1030,7 @@ def test_get_notes_for_alert(cbcsdk_mock):
 
 def test_base_alert_create_note(cbcsdk_mock):
     """Test creating a new note on an alert"""
+
     def on_post(url, body, **kwargs):
         body == {"note": "I am Grogu"}
         return CREATE_ALERT_NOTE

--- a/src/tests/unit/platform/test_alertsv6_api.py
+++ b/src/tests/unit/platform/test_alertsv6_api.py
@@ -90,7 +90,6 @@ def test_query_basealert_with_all_bells_and_whistles(cbcsdk_mock):
 
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
-
     query = api.select(BaseAlert).where("Blort").set_device_ids([6023]) \
         .set_device_names(["HAL"]).set_device_os(["LINUX"]).set_device_os_versions(["0.1.2"]) \
         .set_device_username(["JRN"]).set_alert_ids(["S0L0"]) \

--- a/src/tests/unit/platform/test_alertsv6_api.py
+++ b/src/tests/unit/platform/test_alertsv6_api.py
@@ -214,6 +214,26 @@ def test_query_basealert_with_time_range_start_end(cbcsdk_mock):
     assert a.workflow_.state == "OPEN"
 
 
+def test_query_basealert_with_time_range_create_time_as_start_end(cbcsdk_mock):
+    """Test an alert query with the create_time specified as a range which should also set the global time_range."""
+
+    def on_post(url, body, **kwargs):
+        assert body == {"query": "Blort", "criteria": {"create_time": {"range": "-3w"}}, "rows": 2,
+                        'time_range': {'range': '-3w'}}
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"state": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+
+    query = api.select(BaseAlert).where("Blort").set_time_range("create_time", range="-3w")
+    a = query.one()
+    assert a.id == "S0L0"
+    assert a.org_key == "test"
+    assert a.threat_id == "B0RG"
+    assert a.workflow_.state == "OPEN"
+
+
 def test_query_basealert_facets(cbcsdk_mock):
     """Test an alert facet query."""
 

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -109,8 +109,8 @@ def test_query_alert_with_backend_timestamp_as_start_end(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
-    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp", start="2019-09-30T12:34:56",
-                                                                       end="2019-10-01T12:00:12")
+    query = api.select(Alert).where("Blort").add_time_criteria("backend_timestamp", start="2019-09-30T12:34:56",
+                                                               end="2019-10-01T12:00:12")
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -134,8 +134,8 @@ def test_query_alert_with_backend_timestamp_as_start_end_as_objs(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
-    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp", start=_timestamp,
-                                                                       end=_timestamp)
+    query = api.select(Alert).where("Blort").add_time_criteria("backend_timestamp", start=_timestamp,
+                                                               end=_timestamp)
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -154,7 +154,7 @@ def test_query_alert_with_backend_timestamp_as_range(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
-    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp", range="-3w")
+    query = api.select(Alert).where("Blort").add_time_criteria("backend_timestamp", range="-3w")
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -177,8 +177,8 @@ def test_query_alert_with_backend_update_timestamp_as_start_end(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
-    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_update_timestamp", start=_timestamp,
-                                                                       end=_timestamp)
+    query = api.select(Alert).where("Blort").add_time_criteria("backend_update_timestamp", start=_timestamp,
+                                                               end=_timestamp)
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -196,8 +196,7 @@ def test_query_alert_with_backend_update_timestamp_as_range(cbcsdk_mock):
 
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
-
-    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_update_timestamp", range="-3w")
+    query = api.select(Alert).where("Blort").add_time_criteria("backend_update_timestamp", range="-3w")
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -232,14 +231,14 @@ def test_query_alert_facets(cbcsdk_mock):
 def test_query_alert_invalid_backend_timestamp_combinations(cb):
     """Test invalid backend_timestamp combinations being supplied to alert queries."""
     with pytest.raises(ApiError):
-        cb.select(Alert).set_time_criterion_filter("backend_timestamp")
+        cb.select(Alert).add_time_criteria("backend_timestamp")
     with pytest.raises(ApiError):
-        cb.select(Alert).set_time_criterion_filter("backend_timestamp", start="2019-09-30T12:34:56",
-                                                   end="2019-10-01T12:00:12", range="-3w")
+        cb.select(Alert).add_time_criteria("backend_timestamp", start="2019-09-30T12:34:56",
+                                           end="2019-10-01T12:00:12", range="-3w")
     with pytest.raises(ApiError):
-        cb.select(Alert).set_time_criterion_filter("backend_timestamp", start="2019-09-30T12:34:56", range="-3w")
+        cb.select(Alert).add_time_criteria("backend_timestamp", start="2019-09-30T12:34:56", range="-3w")
     with pytest.raises(ApiError):
-        cb.select(Alert).set_time_criterion_filter("backend_timestamp", end="2019-10-01T12:00:12", range="-3w")
+        cb.select(Alert).add_time_criteria("backend_timestamp", end="2019-10-01T12:00:12", range="-3w")
 
 
 def test_query_cbanalyticsalert_with_all_bells_and_whistles(cbcsdk_mock):
@@ -286,7 +285,6 @@ def test_query_cbanalyticsalert_with_all_bells_and_whistles(cbcsdk_mock):
 
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
-
     query = api.select(Alert).where("Blort").add_criteria("device_id", ["6023"]) \
         .add_criteria("device_name", ["HAL"]).add_criteria("device_os", ["LINUX"]) \
         .add_criteria("device_os_version", ["0.1.2"]) \
@@ -728,25 +726,25 @@ def test_query_alert_with_time_range_errors(cbcsdk_mock):
     """Test exceptions in alert query"""
     api = cbcsdk_mock.api
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").set_time_criterion_filter("invalid", range="whatever")
+        api.select(Alert).where("Blort").add_time_criteria("invalid", range="whatever")
     assert "key must be one of create_time, first_event_time, last_event_time, backend_timestamp," \
            " backend_update_timestamp, or last_update_time" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp",
-                                                                   start="2019-09-30T12:34:56",
-                                                                   end="2019-10-01T12:00:12",
-                                                                   range="-3w")
+        api.select(Alert).where("Blort").add_time_criteria("backend_timestamp",
+                                                           start="2019-09-30T12:34:56",
+                                                           end="2019-10-01T12:00:12",
+                                                           range="-3w")
     assert "cannot specify range= in addition to start= and end=" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp",
-                                                                   end="2019-10-01T12:00:12",
-                                                                   range="-3w")
+        api.select(Alert).where("Blort").add_time_criteria("backend_timestamp",
+                                                           end="2019-10-01T12:00:12",
+                                                           range="-3w")
     assert "cannot specify start= or end= in addition to range=" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp")
+        api.select(Alert).where("Blort").add_time_criteria("backend_timestamp")
 
     assert "must specify either start= and end= or range=" in str(ex.value)
 

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -109,8 +109,8 @@ def test_query_alert_with_backend_timestamp_as_start_end(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
-    query = api.select(Alert).where("Blort").set_time_range("backend_timestamp", start="2019-09-30T12:34:56",
-                                                            end="2019-10-01T12:00:12")
+    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp", start="2019-09-30T12:34:56",
+                                                                       end="2019-10-01T12:00:12")
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -134,7 +134,8 @@ def test_query_alert_with_backend_timestamp_as_start_end_as_objs(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
-    query = api.select(Alert).where("Blort").set_time_range("backend_timestamp", start=_timestamp, end=_timestamp)
+    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp", start=_timestamp,
+                                                                       end=_timestamp)
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -153,7 +154,7 @@ def test_query_alert_with_backend_timestamp_as_range(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
-    query = api.select(Alert).where("Blort").set_time_range("backend_timestamp", range="-3w")
+    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp", range="-3w")
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -176,8 +177,8 @@ def test_query_alert_with_backend_update_timestamp_as_start_end(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
-    query = api.select(Alert).where("Blort").set_time_range("backend_update_timestamp", start=_timestamp,
-                                                            end=_timestamp)
+    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_update_timestamp", start=_timestamp,
+                                                                       end=_timestamp)
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -196,7 +197,7 @@ def test_query_alert_with_backend_update_timestamp_as_range(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
-    query = api.select(Alert).where("Blort").set_time_range("backend_update_timestamp", range="-3w")
+    query = api.select(Alert).where("Blort").set_time_criterion_filter("backend_update_timestamp", range="-3w")
     a = query.one()
     assert a.id == "S0L0"
     assert a.org_key == "test"
@@ -231,14 +232,14 @@ def test_query_alert_facets(cbcsdk_mock):
 def test_query_alert_invalid_backend_timestamp_combinations(cb):
     """Test invalid backend_timestamp combinations being supplied to alert queries."""
     with pytest.raises(ApiError):
-        cb.select(Alert).set_time_range("backend_timestamp")
+        cb.select(Alert).set_time_criterion_filter("backend_timestamp")
     with pytest.raises(ApiError):
-        cb.select(Alert).set_time_range("backend_timestamp", start="2019-09-30T12:34:56", end="2019-10-01T12:00:12",
-                                        range="-3w")
+        cb.select(Alert).set_time_criterion_filter("backend_timestamp", start="2019-09-30T12:34:56",
+                                                   end="2019-10-01T12:00:12", range="-3w")
     with pytest.raises(ApiError):
-        cb.select(Alert).set_time_range("backend_timestamp", start="2019-09-30T12:34:56", range="-3w")
+        cb.select(Alert).set_time_criterion_filter("backend_timestamp", start="2019-09-30T12:34:56", range="-3w")
     with pytest.raises(ApiError):
-        cb.select(Alert).set_time_range("backend_timestamp", end="2019-10-01T12:00:12", range="-3w")
+        cb.select(Alert).set_time_criterion_filter("backend_timestamp", end="2019-10-01T12:00:12", range="-3w")
 
 
 def test_query_cbanalyticsalert_with_all_bells_and_whistles(cbcsdk_mock):
@@ -313,7 +314,7 @@ def test_query_cbanalyticsalert_with_all_bells_and_whistles(cbcsdk_mock):
         "childproc_sha256", ["sha256_child"]) \
         .add_criteria("childproc_username", ["steven"]) \
         .add_criteria("parent_cmdline", ["/usr/bin/python"]).add_criteria("parent_effective_reputation", ["PUP"]) \
-        .add_criteria("parent_guid", ["12345678"]).add_criteria("parent_name", ["python"])\
+        .add_criteria("parent_guid", ["12345678"]).add_criteria("parent_name", ["python"]) \
         .add_criteria("parent_sha256", ["sha256_parent"]) \
         .add_criteria("parent_username", ["steven"]) \
         .add_criteria("process_cmdline", ["/usr/bin/python"]).add_criteria("process_effective_reputation", ["PUP"]) \
@@ -474,13 +475,13 @@ def test_query_watchlistalert_with_all_bells_and_whistles(cbcsdk_mock):
         .add_criteria("device_target_value", ["HIGH"]).add_criteria("threat_id", ["B0RG"]) \
         .add_criteria("workflow_status", ["OPEN"]).add_criteria("watchlists_id", ["100"]).add_criteria(
         "watchlists_name", ["Gandalf"]) \
-        .add_criteria("childproc_cmdline", ["/usr/bin/python"])\
+        .add_criteria("childproc_cmdline", ["/usr/bin/python"]) \
         .add_criteria("childproc_effective_reputation", ["PUP"]) \
         .add_criteria("childproc_guid", ["12345678"]).add_criteria("childproc_name", ["python"]).add_criteria(
         "childproc_sha256", ["sha256_child"]) \
         .add_criteria("childproc_username", ["steven"]) \
         .add_criteria("parent_cmdline", ["/usr/bin/python"]).add_criteria("parent_effective_reputation", ["PUP"]) \
-        .add_criteria("parent_guid", ["12345678"]).add_criteria("parent_name", ["python"])\
+        .add_criteria("parent_guid", ["12345678"]).add_criteria("parent_name", ["python"]) \
         .add_criteria("parent_sha256", ["sha256_parent"]) \
         .add_criteria("parent_username", ["steven"]) \
         .add_criteria("process_cmdline", ["/usr/bin/python"]).add_criteria("process_effective_reputation", ["PUP"]) \
@@ -543,7 +544,7 @@ def test_query_containeralert_with_all_bells_and_whistles(cbcsdk_mock):
     api = cbcsdk_mock.api
 
     query = api.select(ContainerRuntimeAlert).where("Blort").add_criteria("k8s_cluster", ['TURTLE']) \
-        .add_criteria("k8s_namespace", ['RG']).add_criteria("k8s_rule_id", ['66'])\
+        .add_criteria("k8s_namespace", ['RG']).add_criteria("k8s_rule_id", ['66']) \
         .add_criteria("k8s_rule", ['KITTEH']) \
         .add_criteria("k8s_policy_id", ['']).add_criteria("k8s_policy", ['']).add_criteria("k8s_pod_name", ['FAKE']) \
         .add_criteria("k8s_workload_kind", ['Job']).add_criteria("k8s_workload_name", ['BUNNY']) \
@@ -727,25 +728,25 @@ def test_query_alert_with_time_range_errors(cbcsdk_mock):
     """Test exceptions in alert query"""
     api = cbcsdk_mock.api
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").set_time_range("invalid", range="whatever")
+        api.select(Alert).where("Blort").set_time_criterion_filter("invalid", range="whatever")
     assert "key must be one of create_time, first_event_time, last_event_time, backend_timestamp," \
            " backend_update_timestamp, or last_update_time" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").set_time_range("backend_timestamp",
-                                                        start="2019-09-30T12:34:56",
-                                                        end="2019-10-01T12:00:12",
-                                                        range="-3w")
+        api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp",
+                                                                   start="2019-09-30T12:34:56",
+                                                                   end="2019-10-01T12:00:12",
+                                                                   range="-3w")
     assert "cannot specify range= in addition to start= and end=" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").set_time_range("backend_timestamp",
-                                                        end="2019-10-01T12:00:12",
-                                                        range="-3w")
+        api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp",
+                                                                   end="2019-10-01T12:00:12",
+                                                                   range="-3w")
     assert "cannot specify start= or end= in addition to range=" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").set_time_range("backend_timestamp")
+        api.select(Alert).where("Blort").set_time_criterion_filter("backend_timestamp")
 
     assert "must specify either start= and end= or range=" in str(ex.value)
 

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -101,8 +101,8 @@ def test_query_alert_with_backend_timestamp_as_start_end(cbcsdk_mock):
     def on_post(url, body, **kwargs):
         assert body == {"query": "Blort",
                         "rows": 2,
-                        "criteria": {"backend_timestamp": {"start": "2019-09-30T12:34:56",
-                                                           "end": "2019-10-01T12:00:12"}}}
+                        "criteria": {"backend_timestamp": {"start": "2019-09-30T12:34:56.000000Z",
+                                                           "end": "2019-10-01T12:00:12.000000Z"}}}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
 
@@ -126,8 +126,8 @@ def test_query_alert_with_backend_timestamp_as_start_end_as_objs(cbcsdk_mock):
         nonlocal _timestamp
         assert body == {"query": "Blort",
                         "rows": 2,
-                        "criteria": {"backend_timestamp": {"start": _timestamp.isoformat(),
-                                                           "end": _timestamp.isoformat()}}}
+                        "criteria": {"backend_timestamp": {"start": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                                                           "end": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}}}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
 
@@ -168,9 +168,10 @@ def test_query_alert_with_backend_update_timestamp_as_start_end(cbcsdk_mock):
 
     def on_post(url, body, **kwargs):
         nonlocal _timestamp
-        assert body == {"query": "Blort", "criteria": {"backend_update_timestamp": {"start": _timestamp.isoformat(),
-                                                                                    "end": _timestamp.isoformat()}},
-                        "rows": 2}
+        assert body == {"query": "Blort", "criteria": {"backend_update_timestamp": {
+            "start": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "end": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}},
+            "rows": 2}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
 
@@ -306,8 +307,8 @@ def test_query_cbanalyticsalert_with_all_bells_and_whistles(cbcsdk_mock):
         .add_criteria("blocked_effective_reputation", ["NOT_LISTED"]).add_criteria("blocked_md5",
                                                                                    ["md5_hash"]).add_criteria(
         "blocked_name", ["tim"]) \
-        .add_criteria("blocked_sha256", ["sha256_hash"]) \
-        .add_criteria("childproc_cmdline", ["/usr/bin/python"]).add_criteria("childproc_effective_reputation", ["PUP"])\
+        .add_criteria("blocked_sha256", ["sha256_hash"]).add_criteria("childproc_cmdline", ["/usr/bin/python"]) \
+        .add_criteria("childproc_effective_reputation", ["PUP"]) \
         .add_criteria("childproc_guid", ["12345678"]).add_criteria("childproc_name", ["python"]).add_criteria(
         "childproc_sha256", ["sha256_child"]) \
         .add_criteria("childproc_username", ["steven"]) \
@@ -727,8 +728,9 @@ def test_query_alert_with_time_range_errors(cbcsdk_mock):
     api = cbcsdk_mock.api
     with pytest.raises(ApiError) as ex:
         api.select(Alert).where("Blort").add_time_criteria("invalid", range="whatever")
-    assert "key must be one of create_time, first_event_time, last_event_time, backend_timestamp," \
-           " backend_update_timestamp, or last_update_time" in str(ex.value)
+    assert "key must be one of backend_timestamp, backend_update_timestamp, detection_timestamp, " \
+           "first_event_timestamp, last_event_timestamp, mdr_determination_change_timestamp, " \
+           "mdr_workflow_change_timestamp, user_update_timestamp, or workflow_change_timestamp" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
         api.select(Alert).where("Blort").add_time_criteria("backend_timestamp",


### PR DESCRIPTION
…ality as the legacy set_time_range. AlertsSearchQuery.set_time_range now sets the overall timerange if no field name is used, or if a field name is used adds to the criterion for the field for v6 backwards compatibility

## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
[CBAPI-4979: V7 Set Time Range](https://jira.carbonblack.local/browse/CBAPI-4979)

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
This implements the global time range feature added in the v7 api via set_time_range method on the AlertSearchQuery class. also added to the AlertSearchQuery class is set_time_criterion_filter, which handles setting a time range on a criterion field, it is a copy of set_time_range from legacy. The set_time_range method essentially implements the base set_time_range but if the first argument is an criterion field calls the set_time_criterion_filter method. this can be removed after v6 is deprecated

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
manual testing with debugger and unit tests