### PR TITLE
CBAPI 5046 legacy alert set methods

### DIFF
--- a/src/cbc_sdk/platform/legacy_alerts.py
+++ b/src/cbc_sdk/platform/legacy_alerts.py
@@ -213,7 +213,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(v, str) for v in alert_ids):
             raise ApiError("One or more invalid alert ID values")
-        self._update_criteria("legacy_alert_id", alert_ids)
+        self._update_criteria("id", alert_ids)
         return self
 
     def set_policy_ids(self, policy_ids):
@@ -228,7 +228,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(policy_id, int) for policy_id in policy_ids):
             raise ApiError("One or more invalid policy IDs")
-        self._update_criteria("policy_id", policy_ids)
+        self._update_criteria("device_policy_id", policy_ids)
         return self
 
     def set_policy_names(self, policy_names):
@@ -243,7 +243,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in policy_names):
             raise ApiError("One or more invalid policy names")
-        self._update_criteria("policy_name", policy_names)
+        self._update_criteria("device_policy", policy_names)
         return self
 
     def set_process_names(self, process_names):
@@ -290,7 +290,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all((r in ALERT_VALID_REPUTATIONS) for r in reps):
             raise ApiError("One or more invalid reputation values")
-        self._update_criteria("reputation", reps)
+        self._update_criteria("process_reputation", reps)
         return self
 
     def set_tags(self, tags):

--- a/src/cbc_sdk/platform/legacy_alerts.py
+++ b/src/cbc_sdk/platform/legacy_alerts.py
@@ -305,7 +305,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(tag, str) for tag in tags):
             raise ApiError("One or more invalid tags")
-        self._update_criteria("tag", tags)
+        self._update_criteria("tags", tags)
         return self
 
     def set_target_priorities(self, priorities):
@@ -321,7 +321,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all((prio in DeviceSearchQuery.VALID_PRIORITIES) for prio in priorities):
             raise ApiError("One or more invalid priority values")
-        self._update_criteria("target_value", priorities)
+        self._update_criteria("device_target_value", priorities)
         return self
 
     def set_threat_ids(self, threats):
@@ -421,7 +421,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in names):
             raise ApiError("One or more invalid cluster name values")
-        self._update_criteria("cluster_name", names)
+        self._update_criteria("k8s_cluster", names)
         return self
 
     def set_namespaces(self, namespaces):
@@ -436,7 +436,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in namespaces):
             raise ApiError("One or more invalid namespace values")
-        self._update_criteria("namespace", namespaces)
+        self._update_criteria("k8s_namespace", namespaces)
         return self
 
     def set_workload_kinds(self, kinds):
@@ -451,23 +451,25 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in kinds):
             raise ApiError("One or more invalid workload kind values")
-        self._update_criteria("workload_kind", kinds)
+        self._update_criteria("k8s_kind", kinds)
         return self
 
     def set_workload_ids(self, ids):
         """
-        Restricts the alerts that this query is performed on to the specified workload IDs.
+        The field `workload_id` was deprecated and not included in v7.  This method has been removed.
+
+        Use workload_name instead. See `Developer Network Alerts v6 Migration
+        <https://developer.carbonblack.com/reference/carbon-black-cloud/guides/api-migration/alerts-migration/>`_
+        for more details.
 
         Args:
             ids (list): List of workload IDs to look for.
 
-        Returns:
-            ContainerRuntimeAlertSearchQuery: This instance.
+        Raises:
+            FunctionalityDecommissioned: If the requested attribute is no longer available.
         """
-        if not all(isinstance(n, str) for n in ids):
-            raise ApiError("One or more invalid workload ID values")
-        self._update_criteria("workload_id", ids)
-        return self
+        raise FunctionalityDecommissioned(
+            "Starting with SDK v1.5.0 workload_id is not a valid field on Alert.")
 
     def set_workload_names(self, names):
         """
@@ -481,7 +483,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in names):
             raise ApiError("One or more invalid workload name values")
-        self._update_criteria("workload_name", names)
+        self._update_criteria("k8s_workload_name", names)
         return self
 
     def set_replica_ids(self, ids):
@@ -496,7 +498,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in ids):
             raise ApiError("One or more invalid replica ID values")
-        self._update_criteria("replica_id", ids)
+        self._update_criteria("k8s_pod_name", ids)
         return self
 
     def set_remote_ips(self, addrs):
@@ -511,7 +513,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in addrs):
             raise ApiError("One or more invalid remote IP values")
-        self._update_criteria("remote_ip", addrs)
+        self._update_criteria("netconn_remote_ip", addrs)
         return self
 
     def set_remote_domains(self, domains):
@@ -526,7 +528,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in domains):
             raise ApiError("One or more invalid remote domain values")
-        self._update_criteria("remote_domain", domains)
+        self._update_criteria("netconn_remote_domain", domains)
         return self
 
     def set_protocols(self, protocols):
@@ -541,22 +543,26 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in protocols):
             raise ApiError("One or more invalid protocol values")
-        self._update_criteria("protocol", protocols)
+        self._update_criteria("netconn_protocol", protocols)
         return self
 
     def set_ports(self, ports):
         """
-        Restricts the alerts that this query is performed on to the specified listening ports.
+        Restricts the alerts that this query is performed on to the specified netconn_local_ports.
+
+        Note that in SDK 1.5.0, to align with Alerts API v7, the search field was updated from
+        `port` to `netconn_local_port`.  It is possible to search on either `netconn_local_port`
+        or `netconn_remote_port` using the `add_criteria(fieldname, [field values]) method.
 
         Args:
-            ports (list): List of listening ports to look for.
+            ports (list): List of netconn_local_ports to look for.
 
         Returns:
             ContainerRuntimeAlertSearchQuery: This instance.
         """
         if not all(isinstance(n, int) for n in ports):
             raise ApiError("One or more invalid port values")
-        self._update_criteria("port", ports)
+        self._update_criteria("netconn_local_port", ports)
         return self
 
     def set_egress_group_ids(self, ids):
@@ -631,7 +637,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in names):
             raise ApiError("One or more invalid rule name values")
-        self._update_criteria("rule_name", names)
+        self._update_criteria("k8s_rule", names)
         return self
 
     def set_watchlist_ids(self, ids):
@@ -843,7 +849,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in ids):
             raise ApiError("One or more invalid device ID values")
-        self._update_criteria("external_device_id", ids)
+        self._update_criteria("device_id", ids)
         return self
 
     def set_product_ids(self, ids):

--- a/src/cbc_sdk/platform/legacy_alerts.py
+++ b/src/cbc_sdk/platform/legacy_alerts.py
@@ -579,6 +579,10 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         Restricts the alerts that this query is performed on to the specified Kubernetes policy rule IDs.
 
+        In SDK prior to 1.5.0 this was only supported for Container Runtime Alerts so will
+        convert to k8s_rule_id in criteria.  In SDK 1.5.0 and later, aligned to Alert v7 API, use add_criteria()
+        should be used for both k8s_rule_id and for other alert types, rule_id.
+
         Args:
             ids (list): List of Kubernetes policy rule IDs to look for.
 
@@ -587,7 +591,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         """
         if not all(isinstance(n, str) for n in ids):
             raise ApiError("One or more invalid rule ID values")
-        self._update_criteria("rule_id", ids)
+        self._update_criteria("k8s_rule_id", ids)
         return self
 
     def set_rule_names(self, names):

--- a/src/cbc_sdk/platform/legacy_alerts.py
+++ b/src/cbc_sdk/platform/legacy_alerts.py
@@ -64,6 +64,7 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         Restricts the alerts that this query is performed on to the specified creation time.
 
         The time may either be specified as a start and end point or as a range.
+        In SDK 1.5.0 to align with Alerts v7 API, create_time is set as time_range outside of criteria.
 
         Args:
             *args (list): Not used.
@@ -77,15 +78,15 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
                 raise ApiError("cannot specify range= in addition to start= and end=")
             stime = kwargs["start"]
             if not isinstance(stime, str):
-                stime = stime.isoformat()
+                stime = stime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
             etime = kwargs["end"]
             if not isinstance(etime, str):
-                etime = etime.isoformat()
-            self._time_filters["create_time"] = {"start": stime, "end": etime}
+                etime = etime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            self.set_time_range(start=stime, end=etime)
         elif kwargs.get("range", None):
             if kwargs.get("start", None) or kwargs.get("end", None):
                 raise ApiError("cannot specify start= or end= in addition to range=")
-            self._time_filters["create_time"] = {"range": kwargs["range"]}
+            self.set_time_range(range=kwargs["range"])
         else:
             raise ApiError("must specify either start= and end= or range=")
         return self

--- a/src/tests/unit/platform/test_alertsv6_api.py
+++ b/src/tests/unit/platform/test_alertsv6_api.py
@@ -528,7 +528,7 @@ def test_query_containeralert_with_all_bells_and_whistles(cbcsdk_mock):
                                      "netconn_remote_ip": ["10.29.99.1"], "netconn_remote_domain": ["example.com"],
                                      "netconn_protocol": ["TCP"], "netconn_local_port": [12345],
                                      "egress_group_id": ["5150"], "egress_group_name": ["EGRET"],
-                                     "ip_reputation": [75], "rule_id": ["66"], "k8s_rule": ["KITTEH"],
+                                     "ip_reputation": [75], "k8s_rule_id": ["66"], "k8s_rule": ["KITTEH"],
                                      "k8s_kind": ["Job"]},
                         "sort": [{"field": "name", "order": "DESC"}]}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",

--- a/src/tests/unit/platform/test_alertsv6_api.py
+++ b/src/tests/unit/platform/test_alertsv6_api.py
@@ -78,11 +78,12 @@ def test_query_basealert_with_all_bells_and_whistles(cbcsdk_mock):
                         "rows": 2,
                         "criteria": {"device_id": [6023], "device_name": ["HAL"],
                                      "device_os": ["LINUX"], "device_os_version": ["0.1.2"],
-                                     "device_username": ["JRN"], "id": ["S0L0"],
-                                     "legacy_alert_id": ["S0L0_1"], "minimum_severity": 6, "policy_id": [8675309],
-                                     "policy_name": ["Strict"], "process_name": ["IEXPLORE.EXE"],
+                                     "device_username": ["JRN"], "id": ["S0L0", "S0L0_1"],
+                                     "minimum_severity": 6, "device_policy_id": [8675309],
+                                     "device_policy": ["Strict"], "process_name": ["IEXPLORE.EXE"],
                                      "process_sha256": ["0123456789ABCDEF0123456789ABCDEF"],
-                                     "reputation": ["SUSPECT_MALWARE"], "tag": ["Frood"], "target_value": ["HIGH"],
+                                     "process_reputation": ["SUSPECT_MALWARE"], "tags": ["Frood"],
+                                     "device_target_value": ["HIGH"],
                                      "threat_id": ["B0RG"], "workflow": ["OPEN"]},
                         "sort": [{"field": "name", "order": "DESC"}]}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG", "type": "WATCHLIST",
@@ -286,11 +287,12 @@ def test_query_cbanalyticsalert_with_all_bells_and_whistles(cbcsdk_mock):
                         "rows": 2,
                         "criteria": {"device_id": [6023], "device_name": ["HAL"],
                                      "device_os": ["LINUX"], "device_os_version": ["0.1.2"],
-                                     "device_username": ["JRN"], "id": ["S0L0"],
-                                     "legacy_alert_id": ["S0L0_1"], "minimum_severity": 6, "policy_id": [8675309],
-                                     "policy_name": ["Strict"], "process_name": ["IEXPLORE.EXE"],
+                                     "device_username": ["JRN"], "id": ["S0L0", "S0L0_1"],
+                                     "minimum_severity": 6, "device_policy_id": [8675309],
+                                     "device_policy": ["Strict"], "process_name": ["IEXPLORE.EXE"],
                                      "process_sha256": ["0123456789ABCDEF0123456789ABCDEF"],
-                                     "reputation": ["SUSPECT_MALWARE"], "tag": ["Frood"], "target_value": ["HIGH"],
+                                     "process_reputation": ["SUSPECT_MALWARE"], "tags": ["Frood"],
+                                     "device_target_value": ["HIGH"],
                                      "threat_id": ["B0RG"], "type": ["CB_ANALYTICS"], "workflow": ["OPEN"],
                                      "device_location": ["ONSITE"], "policy_applied": ["APPLIED"],
                                      "reason_code": ["ATTACK_VECTOR"], "run_state": ["RAN"], "sensor_action": ["DENY"]},
@@ -303,7 +305,7 @@ def test_query_cbanalyticsalert_with_all_bells_and_whistles(cbcsdk_mock):
 
     query = api.select(CBAnalyticsAlert).where("Blort") \
         .set_device_ids([6023]).set_device_names(["HAL"]).set_device_os(["LINUX"]).set_device_os_versions(["0.1.2"]) \
-        .set_device_username(["JRN"]).set_alert_ids(["S0L0"]).set_legacy_alert_ids(["S0L0_1"]) \
+        .set_device_username(["JRN"]).set_alert_ids(["S0L0", "S0L0_1"])\
         .set_minimum_severity(6).set_policy_ids([8675309]).set_policy_names(["Strict"]) \
         .set_process_names(["IEXPLORE.EXE"]).set_process_sha256(["0123456789ABCDEF0123456789ABCDEF"]) \
         .set_reputations(["SUSPECT_MALWARE"]).set_tags(["Frood"]).set_target_priorities(["HIGH"]) \
@@ -358,15 +360,16 @@ def test_query_devicecontrolalert_with_all_bells_and_whistles(cbcsdk_mock):
     def on_post(url, body, **kwargs):
         assert body == {"query": "Blort",
                         "rows": 2,
-                        "criteria": {"device_id": [6023], "device_name": ["HAL"],
+                        "criteria": {"device_name": ["HAL"],
                                      "device_os": ["LINUX"], "device_os_version": ["0.1.2"],
-                                     "device_username": ["JRN"], "id": ["S0L0"],
-                                     "legacy_alert_id": ["S0L0_1"], "minimum_severity": 6, "policy_id": [8675309],
-                                     "policy_name": ["Strict"], "process_name": ["IEXPLORE.EXE"],
+                                     "device_username": ["JRN"], "id": ["S0L0", "S0L0_1"],
+                                     "minimum_severity": 6, "device_policy_id": [8675309],
+                                     "device_policy": ["Strict"], "process_name": ["IEXPLORE.EXE"],
                                      "process_sha256": ["0123456789ABCDEF0123456789ABCDEF"],
-                                     "reputation": ["SUSPECT_MALWARE"], "tag": ["Frood"], "target_value": ["HIGH"],
+                                     "process_reputation": ["SUSPECT_MALWARE"], "tags": ["Frood"],
+                                     "device_target_value": ["HIGH"],
                                      "threat_id": ["B0RG"], "type": ["DEVICE_CONTROL"], "workflow": ["OPEN"],
-                                     "external_device_friendly_name": ["/dev/ice"], "external_device_id": ["626"],
+                                     "external_device_friendly_name": ["/dev/ice"], "device_id": ["626"],
                                      "product_id": ["0x5581"], "product_name": ["Ultra"],
                                      "serial_number": ["4C531001331122115172"], "vendor_id": ["0x0781"],
                                      "vendor_name": ["SanDisk"]},
@@ -377,8 +380,10 @@ def test_query_devicecontrolalert_with_all_bells_and_whistles(cbcsdk_mock):
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
 
+    # in Alert v7 on a Device Control alert, the device_id is the USB device id.
+    # external_device_id does not exist, therefore it's not valid to set both device_id and external_device_id
     query = api.select(DeviceControlAlert).where("Blort") \
-        .set_device_ids([6023]).set_device_names(["HAL"]).set_device_os(["LINUX"]).set_device_os_versions(["0.1.2"]) \
+        .set_device_names(["HAL"]).set_device_os(["LINUX"]).set_device_os_versions(["0.1.2"]) \
         .set_device_username(["JRN"]).set_alert_ids(["S0L0"]) \
         .set_legacy_alert_ids(["S0L0_1"]).set_minimum_severity(6).set_policy_ids([8675309]) \
         .set_policy_names(["Strict"]).set_process_names(["IEXPLORE.EXE"]) \
@@ -439,11 +444,12 @@ def test_query_watchlistalert_with_all_bells_and_whistles(cbcsdk_mock):
                         "rows": 2,
                         "criteria": {"device_id": [6023], "device_name": ["HAL"],
                                      "device_os": ["LINUX"], "device_os_version": ["0.1.2"],
-                                     "device_username": ["JRN"], "id": ["S0L0"],
-                                     "legacy_alert_id": ["S0L0_1"], "minimum_severity": 6, "policy_id": [8675309],
-                                     "policy_name": ["Strict"], "process_name": ["IEXPLORE.EXE"],
+                                     "device_username": ["JRN"], "id": ["S0L0", "S0L0_1"],
+                                     "minimum_severity": 6, "device_policy_id": [8675309],
+                                     "device_policy": ["Strict"], "process_name": ["IEXPLORE.EXE"],
                                      "process_sha256": ["0123456789ABCDEF0123456789ABCDEF"],
-                                     "reputation": ["SUSPECT_MALWARE"], "tag": ["Frood"], "target_value": ["HIGH"],
+                                     "process_reputation": ["SUSPECT_MALWARE"], "tags": ["Frood"],
+                                     "device_target_value": ["HIGH"],
                                      "threat_id": ["B0RG"], "type": ["WATCHLIST"], "workflow": ["OPEN"],
                                      "watchlist_id": ["100"], "watchlist_name": ["Gandalf"]},
                         "sort": [{"field": "name", "order": "DESC"}]}
@@ -502,12 +508,13 @@ def test_query_containeralert_with_all_bells_and_whistles(cbcsdk_mock):
     def on_post(url, body, **kwargs):
         assert body == {"query": "Blort",
                         "rows": 2,
-                        "criteria": {"cluster_name": ["TURTLE"], 'type': ['CONTAINER_RUNTIME'], "namespace": ["RG"],
-                                     "workload_id": ["1234"], "workload_name": ["BUNNY"], "replica_id": ["FAKE"],
-                                     "remote_ip": ["10.29.99.1"], "remote_domain": ["example.com"], "protocol": ["TCP"],
-                                     "port": [12345], "egress_group_id": ["5150"], "egress_group_name": ["EGRET"],
-                                     "ip_reputation": [75], "rule_id": ["66"], "rule_name": ["KITTEH"],
-                                     "workload_kind": ["Job"]},
+                        "criteria": {"k8s_cluster": ["TURTLE"], 'type': ['CONTAINER_RUNTIME'], "k8s_namespace": ["RG"],
+                                     "k8s_workload_name": ["BUNNY"], "k8s_pod_name": ["FAKE"],
+                                     "netconn_remote_ip": ["10.29.99.1"], "netconn_remote_domain": ["example.com"],
+                                     "netconn_protocol": ["TCP"], "netconn_local_port": [12345],
+                                     "egress_group_id": ["5150"], "egress_group_name": ["EGRET"],
+                                     "ip_reputation": [75], "rule_id": ["66"], "k8s_rule": ["KITTEH"],
+                                     "k8s_kind": ["Job"]},
                         "sort": [{"field": "name", "order": "DESC"}]}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"state": "OPEN"}}], "num_found": 1}
@@ -516,7 +523,7 @@ def test_query_containeralert_with_all_bells_and_whistles(cbcsdk_mock):
     api = cbcsdk_mock.api
 
     query = api.select(ContainerRuntimeAlert).where("Blort").set_cluster_names(['TURTLE']).set_namespaces(['RG']) \
-        .set_workload_kinds(['Job']).set_workload_ids(['1234']).set_workload_names(['BUNNY']) \
+        .set_workload_kinds(['Job']).set_workload_names(['BUNNY']) \
         .set_replica_ids(['FAKE']).set_remote_ips(['10.29.99.1']).set_remote_domains(['example.com']) \
         .set_protocols(['TCP']).set_ports([12345]).set_egress_group_ids(['5150']).set_egress_group_names(['EGRET']) \
         .set_ip_reputations([75]).set_rule_ids(['66']).set_rule_names(['KITTEH']).sort_by("name", "DESC")
@@ -531,7 +538,6 @@ def test_query_containeralert_with_all_bells_and_whistles(cbcsdk_mock):
     ("set_cluster_names", [12345]),
     ("set_namespaces", [12345]),
     ("set_workload_kinds", [12345]),
-    ("set_workload_ids", [12345]),
     ("set_workload_names", [12345]),
     ("set_replica_ids", [12345]),
     ("set_remote_ips", [12345]),

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -221,7 +221,7 @@ def test_query_alert_with_time_range_as_start_end(cbcsdk_mock):
                         "rows": 2,
                         "time_range": {"start": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                                        "end": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
-                        "criteria": {}}
+                        }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
 
@@ -240,7 +240,7 @@ def test_query_alert_with_time_range_as_range(cbcsdk_mock):
     """Test an alert query with the time_range specified as a range."""
 
     def on_post(url, body, **kwargs):
-        assert body == {"query": "Blort", "criteria": {}, "time_range": {"range": "-3w"}, "rows": 2}
+        assert body == {"query": "Blort", "time_range": {"range": "-3w"}, "rows": 2}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
 

--- a/src/tests/unit/platform/test_alertsv7_v6_compatibility.py
+++ b/src/tests/unit/platform/test_alertsv7_v6_compatibility.py
@@ -299,26 +299,9 @@ def test_set_device_ids(cbcsdk_mock):
     query = api.select(BaseAlert).set_device_ids([123]).set_rows(1)
     len(query)
 
-    def test_template(cbcsdk_mock):
-        """Test legacy template method"""
-
-        def on_post(url, body, **kwargs):
-            assert body == {
-
-            }
-            return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
-                                 "workflow": {"status": "OPEN"}}], "num_found": 1}
-
-        cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
-        api = cbcsdk_mock.api
-        # no assertions, the check is that the post request is formed correctly.
-        query = api.select(BaseAlert).set_template(["123"]).set_rows(1)
-        len(query)
-
 
 def test_set_device_names(cbcsdk_mock):
     """Test legacy template method"""
-
     def on_post(url, body, **kwargs):
         assert body == {
             "criteria": {
@@ -363,7 +346,6 @@ def test_set_device_os(cbcsdk_mock):
 
 def test_set_device_os_versions(cbcsdk_mock):
     """Test legacy set_device_os_versions method"""
-
     def on_post(url, body, **kwargs):
         assert body == {
             "criteria": {
@@ -386,7 +368,6 @@ def test_set_device_os_versions(cbcsdk_mock):
 
 def test_set_device_username(cbcsdk_mock):
     """Test legacy set_device_username method"""
-
     def on_post(url, body, **kwargs):
         assert body == {
             "criteria": {
@@ -431,7 +412,6 @@ def test_set_legacy_alert_ids(cbcsdk_mock):
 
 def test_set_policy_ids(cbcsdk_mock):
     """Test legacy set_policy_ids method"""
-
     def on_post(url, body, **kwargs):
         assert body == {
             "criteria": {
@@ -454,7 +434,6 @@ def test_set_policy_ids(cbcsdk_mock):
 
 def test_set_policy_names(cbcsdk_mock):
     """Test legacy policy_names method"""
-
     def on_post(url, body, **kwargs):
         assert body == {
             "criteria": {
@@ -520,7 +499,7 @@ def test_set_process_sha256(cbcsdk_mock):
 
 
 def test_set_reputations(cbcsdk_mock):
-    """Test legacy template method"""
+    """Test legacy set_reputations method"""
     def on_post(url, body, **kwargs):
         assert body == {
             "criteria": {
@@ -538,4 +517,290 @@ def test_set_reputations(cbcsdk_mock):
     api = cbcsdk_mock.api
     # no assertions, the check is that the post request is formed correctly.
     query = api.select(BaseAlert).set_reputations(["PUP"]).set_rows(1)
+    len(query)
+
+
+def test_set_tags(cbcsdk_mock):
+    """Test legacy set_tags method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "tags": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_tags(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_target_priorities(cbcsdk_mock):
+    """Test legacy set_target_priorities method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "device_target_value": [
+                    "LOW"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_target_priorities(["LOW"]).set_rows(1)
+    len(query)
+
+
+def test_set_external_device_ids(cbcsdk_mock):
+    """Test legacy set_external_device_ids method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "device_id": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_external_device_ids(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_workload_names(cbcsdk_mock):
+    """Test legacy set_workload_names method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "k8s_workload_name": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_workload_names(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_cluster_names(cbcsdk_mock):
+    """Test legacy set_cluster_names method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "k8s_cluster": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_cluster_names(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_namespaces(cbcsdk_mock):
+    """Test legacy set_namespaces method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "k8s_namespace": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_namespaces(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_ports(cbcsdk_mock):
+    """Test legacy set_ports method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "netconn_local_port": [
+                    123
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_ports([123]).set_rows(1)
+    len(query)
+
+
+def test_set_protocols(cbcsdk_mock):
+    """Test legacy set_protocols method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "netconn_protocol": [
+                    "PROTOCOL"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_protocols(["PROTOCOL"]).set_rows(1)
+    len(query)
+
+
+def test_set_remote_domains(cbcsdk_mock):
+    """Test legacy set_remote_domains method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "netconn_remote_domain": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_remote_domains(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_remote_ips(cbcsdk_mock):
+    """Test legacy set_remote_ips method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "netconn_remote_ip": [
+                    "1.2.3.4"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_remote_ips(["1.2.3.4"]).set_rows(1)
+    len(query)
+
+
+def test_set_replica_ids(cbcsdk_mock):
+    """Test legacy set_replica_ids method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "k8s_pod_name": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_replica_ids(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_rule_names(cbcsdk_mock):
+    """Test legacy set_rule_names method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "k8s_rule": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_rule_names(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_workload_kinds(cbcsdk_mock):
+    """Test legacy set_workload_kinds method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "k8s_kind": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_workload_kinds(["123"]).set_rows(1)
     len(query)

--- a/src/tests/unit/platform/test_alertsv7_v6_compatibility.py
+++ b/src/tests/unit/platform/test_alertsv7_v6_compatibility.py
@@ -242,3 +242,300 @@ def check_field(alert_v6, alert_v6_from_v7, key, alert_type):
                 or (alert_v6.get(key) == 0 and alert_v6_from_v7.get(key) is None)  # device info on CONTAINER_RUNTIME
                 ), "ERROR: Values do not match {} - v6: {} v7: {}".format(key, alert_v6.get(key),
                                                                           alert_v6_from_v7.get(key))
+
+
+def test_set_alert_ids(cbcsdk_mock):
+    """Test legacy set_alert_ids method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "id": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_alert_ids(["123"]).set_rows(1)
+    len(query)
+
+    # def test_set_create_time(cbcsdk_mock):
+    #    """Test legacy template method"""
+    # def on_post(url, body, **kwargs):
+    #    assert body == {
+    # }
+    # return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+    #                     "workflow": {"status": "OPEN"}}], "num_found": 1}
+    # cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    # api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    # query = api.select(BaseAlert).set_create_time(start="2023-09-19T21:00:00.000",end="2023-09-20T01:00:00.000")\
+    #    .set_rows(1)
+    # len(query)
+
+
+def test_set_device_ids(cbcsdk_mock):
+    """Test legacy set_device_ids method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "device_id": [
+                    123
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_device_ids([123]).set_rows(1)
+    len(query)
+
+    def test_template(cbcsdk_mock):
+        """Test legacy template method"""
+
+        def on_post(url, body, **kwargs):
+            assert body == {
+
+            }
+            return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                                 "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+        cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+        api = cbcsdk_mock.api
+        # no assertions, the check is that the post request is formed correctly.
+        query = api.select(BaseAlert).set_template(["123"]).set_rows(1)
+        len(query)
+
+
+def test_set_device_names(cbcsdk_mock):
+    """Test legacy template method"""
+
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "device_name": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_device_names(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_device_os(cbcsdk_mock):
+    """Test legacy set_device_os method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "device_os": [
+                    "LINUX"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_device_os(["LINUX"]).set_rows(1)
+    len(query)
+
+
+def test_set_device_os_versions(cbcsdk_mock):
+    """Test legacy set_device_os_versions method"""
+
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "device_os_version": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_device_os_versions(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_device_username(cbcsdk_mock):
+    """Test legacy set_device_username method"""
+
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "device_username": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_device_username(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_legacy_alert_ids(cbcsdk_mock):
+    """Test legacy set_legacy_alert_ids method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "id": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_legacy_alert_ids(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_policy_ids(cbcsdk_mock):
+    """Test legacy set_policy_ids method"""
+
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "device_policy_id": [
+                    123
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_policy_ids([123]).set_rows(1)
+    len(query)
+
+
+def test_set_policy_names(cbcsdk_mock):
+    """Test legacy policy_names method"""
+
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "device_policy": [
+                    "policy name"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_policy_names(["policy name"]).set_rows(1)
+    len(query)
+
+
+def test_set_process_names(cbcsdk_mock):
+    """Test legacy set_process_names method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "process_name": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_process_names(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_process_sha256(cbcsdk_mock):
+    """Test legacy set_process_sha256 method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "process_sha256": [
+                    "123"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_process_sha256(["123"]).set_rows(1)
+    len(query)
+
+
+def test_set_reputations(cbcsdk_mock):
+    """Test legacy template method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "process_reputation": [
+                    "PUP"
+                ]
+            },
+            "rows": 1,
+            "start": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_reputations(["PUP"]).set_rows(1)
+    len(query)

--- a/src/tests/unit/platform/test_alertsv7_v6_compatibility.py
+++ b/src/tests/unit/platform/test_alertsv7_v6_compatibility.py
@@ -253,8 +253,7 @@ def test_set_alert_ids(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -264,19 +263,25 @@ def test_set_alert_ids(cbcsdk_mock):
     query = api.select(BaseAlert).set_alert_ids(["123"]).set_rows(1)
     len(query)
 
-    # def test_set_create_time(cbcsdk_mock):
-    #    """Test legacy template method"""
-    # def on_post(url, body, **kwargs):
-    #    assert body == {
-    # }
-    # return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
-    #                     "workflow": {"status": "OPEN"}}], "num_found": 1}
-    # cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
-    # api = cbcsdk_mock.api
+
+def test_set_create_time(cbcsdk_mock):
+    """Test legacy set_create_time method"""
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "time_range": {
+                "end": "2023-09-20T01:00:00.000000Z",
+                "start": "2023-09-19T21:00:00.000000Z"
+            },
+            "rows": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
     # no assertions, the check is that the post request is formed correctly.
-    # query = api.select(BaseAlert).set_create_time(start="2023-09-19T21:00:00.000",end="2023-09-20T01:00:00.000")\
-    #    .set_rows(1)
-    # len(query)
+    query = api.select(BaseAlert).set_create_time(start="2023-09-19T21:00:00", end="2023-09-20T01:00:00").\
+        set_rows(1)
+    len(query)
 
 
 def test_set_device_ids(cbcsdk_mock):
@@ -288,8 +293,7 @@ def test_set_device_ids(cbcsdk_mock):
                     123
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -309,8 +313,7 @@ def test_set_device_names(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -331,8 +334,7 @@ def test_set_device_os(cbcsdk_mock):
                     "LINUX"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -353,8 +355,7 @@ def test_set_device_os_versions(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -375,8 +376,7 @@ def test_set_device_username(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -397,8 +397,7 @@ def test_set_legacy_alert_ids(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -419,8 +418,7 @@ def test_set_policy_ids(cbcsdk_mock):
                     123
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -441,8 +439,7 @@ def test_set_policy_names(cbcsdk_mock):
                     "policy name"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -463,8 +460,7 @@ def test_set_process_names(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -485,8 +481,7 @@ def test_set_process_sha256(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -507,8 +502,7 @@ def test_set_reputations(cbcsdk_mock):
                     "PUP"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -529,8 +523,7 @@ def test_set_tags(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -551,8 +544,7 @@ def test_set_target_priorities(cbcsdk_mock):
                     "LOW"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -573,8 +565,7 @@ def test_set_external_device_ids(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -595,8 +586,7 @@ def test_set_workload_names(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -617,8 +607,7 @@ def test_set_cluster_names(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -639,8 +628,7 @@ def test_set_namespaces(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -661,8 +649,7 @@ def test_set_ports(cbcsdk_mock):
                     123
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -683,8 +670,7 @@ def test_set_protocols(cbcsdk_mock):
                     "PROTOCOL"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -705,8 +691,7 @@ def test_set_remote_domains(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -727,8 +712,7 @@ def test_set_remote_ips(cbcsdk_mock):
                     "1.2.3.4"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -749,8 +733,7 @@ def test_set_replica_ids(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -771,8 +754,7 @@ def test_set_rule_names(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
@@ -793,8 +775,7 @@ def test_set_workload_kinds(cbcsdk_mock):
                     "123"
                 ]
             },
-            "rows": 1,
-            "start": 1
+            "rows": 1
         }
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}

--- a/src/tests/unit/platform/test_alertsv7_v6_compatibility.py
+++ b/src/tests/unit/platform/test_alertsv7_v6_compatibility.py
@@ -745,6 +745,32 @@ def test_set_replica_ids(cbcsdk_mock):
     len(query)
 
 
+def test_set_rule_ids(cbcsdk_mock):
+    """Test legacy set_rule_ids method
+
+    In SDK prior to 1.5.0 this was only supported for Container Runtime Alerts so will
+    convert to k8s_rule_id.  For the post SDK 1.5.0 / Alert v7 API version, add_criteria()
+    should be used for both k8s_rule_id and for other alert types, rule_id.
+    """
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "criteria": {
+                "k8s_rule_id": [
+                    "123"
+                ]
+            },
+            "rows": 1
+        }
+        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
+                             "workflow": {"status": "OPEN"}}], "num_found": 1}
+
+    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
+    api = cbcsdk_mock.api
+    # no assertions, the check is that the post request is formed correctly.
+    query = api.select(BaseAlert).set_rule_ids(["123"]).set_rows(1)
+    len(query)
+
+
 def test_set_rule_names(cbcsdk_mock):
     """Test legacy set_rule_names method"""
     def on_post(url, body, **kwargs):

--- a/src/tests/unit/platform/test_platform_alerts_sdk150_breaking_changes.py
+++ b/src/tests/unit/platform/test_platform_alerts_sdk150_breaking_changes.py
@@ -167,6 +167,15 @@ def test_set_threat_cause_vectors(cb):
         cb.select(WatchlistAlert).set_threat_cause_vectors(["EMAIL"])
 
 
+def test_set_workload_ids(cb):
+    """Test the set_kill_chain_statuses method on base and CBAnalytics legacy alert class."""
+    with pytest.raises(FunctionalityDecommissioned):
+        cb.select(BaseAlert).set_workload_ids(["UNKNOWN"])
+
+    with pytest.raises(FunctionalityDecommissioned):
+        cb.select(ContainerRuntimeAlert).set_workload_ids(["UNKNOWN"])
+
+
 def test_get_attr_cb_analytics_alert(cbcsdk_mock):
     """Test the __get_attr_ method for each attribute that applies to cb_analytics alerts."""
     cbcsdk_mock.mock_request("GET", "/api/alerts/v7/orgs/test/alerts/6f1173f5-f921-8e11-2160-edf42b799333",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests have been added that prove the fix is effective or that the feature works.
- [X] New and existing tests pass locally with the changes.
- [X] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [X] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
CBAPI-5046

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
In Alerts v7 API, many fields were renamed.  That means that legacy set_<fieldname> methods need to set the new name in the search criteria.  This PR updates the set methods, updates v6 test mocks to use new names and adds some 
new tests to validate the post request.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Validated with e2e scripts, and the post request checked in postman before using in the new mock requests.