### PR TITLE
Move get process to base Alert instead of Watchlist

### DIFF
--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -180,6 +180,37 @@ class Alert(PlatformModel):
         if model_unique_id is not None and initial_data is None:
             self._refresh()
 
+    def get_process(self, async_mode=False):
+        """
+        Gets the process corresponding with the alert.
+
+        Args:
+            async_mode: True to request process in an asynchronous manner.
+
+        Returns:
+            Process: The process corresponding to the alert.
+        """
+        process_guid = self._info.get("process_guid")
+        if not process_guid:
+            raise ApiError(f"Trying to get process details on an invalid process_id {process_guid}")
+        if async_mode:
+            return self._cb._async_submit(self._get_process)
+        return self._get_process()
+
+    def _get_process(self, *args, **kwargs):
+        """
+        Implementation of the get_process.
+
+        Returns:
+            Process: The process corresponding to the alert. May return None if no process is found.
+        """
+        process_guid = self._info.get("process_guid")
+        try:
+            process = AsyncProcessQuery(Process, self._cb).where(process_guid=process_guid).one()
+        except ObjectNotFoundError:
+            return None
+        return process
+
     def get_observations(self, timeout=0):
         """Requests observations that are associated with the Alert.
 
@@ -654,37 +685,6 @@ class WatchlistAlert(Alert):
             AlertSearchQuery: The query object for this alert type.
         """
         return AlertSearchQuery(cls, cb).add_criteria("type", ["WATCHLIST"])
-
-    def get_process(self, async_mode=False):
-        """
-        Gets the process corresponding with the alert.
-
-        Args:
-            async_mode: True to request process in an asynchronous manner.
-
-        Returns:
-            Process: The process corresponding to the alert.
-        """
-        process_guid = self._info.get("process_guid")
-        if not process_guid:
-            raise ApiError(f"Trying to get process details on an invalid process_id {process_guid}")
-        if async_mode:
-            return self._cb._async_submit(self._get_process)
-        return self._get_process()
-
-    def _get_process(self, *args, **kwargs):
-        """
-        Implementation of the get_process.
-
-        Returns:
-            Process: The process corresponding to the alert. May return None if no process is found.
-        """
-        process_guid = self._info.get("process_guid")
-        try:
-            process = AsyncProcessQuery(Process, self._cb).where(process_guid=process_guid).one()
-        except ObjectNotFoundError:
-            return None
-        return process
 
 
 class CBAnalyticsAlert(Alert):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [X] New and existing tests pass locally with the changes.
- [X] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [X] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->


## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
In Alerts v7 API, several alert types can be associated with a process, not only Watchlist.
If the alert does not have a process guid, the process request will fail.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
