### PR TITLE
Alerts - updated time validation and added bulk export example script

### DIFF
--- a/examples/platform/alerts_bulk_export.py
+++ b/examples/platform/alerts_bulk_export.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# *******************************************************
+# Copyright (c) VMware, Inc. 2020-2023. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+# *******************************************************
+# *
+# * DISCLAIMER. THIS PROGRAM IS PROVIDED TO YOU "AS IS" WITHOUT
+# * WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER ORAL OR WRITTEN,
+# * EXPRESS OR IMPLIED. THE AUTHOR SPECIFICALLY DISCLAIMS ANY IMPLIED
+# * WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
+# * NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
+
+"""
+This example shows how to use the SDK the poll for alerts.
+
+The SDK documentation is published on Read The Docs.  An Alerts Guide is available there.
+https://carbon-black-cloud-python-sdk.readthedocs.io
+
+This example contains the supporting code for the Alert Bulk Export -v 7 API Guide on Developer Network.
+https://developer.carbonblack.com/reference/carbon-black-cloud/guides/alert-bulk-export
+"""
+
+import sys
+from cbc_sdk import CBCloudAPI
+from cbc_sdk.platform import Alert
+
+from datetime import datetime, timedelta, timezone
+
+
+def main():
+    """This script demonstrates how to use Alerts in the SDK and common operations to link to related objects."""
+    api = CBCloudAPI(profile="YOUR_PROFILE_HERE")
+
+    # Time field and format to use
+    time_field = "backend_timestamp"
+    time_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+    # Time window to fetch.
+    # Uses current time - 30s to allow for Carbon Black Cloud asynchronous event processing completion
+    end = datetime.now(timezone.utc) - timedelta(seconds=30)
+    start = end - timedelta(minutes=5)
+
+    # Fetch initial Alert batch
+    alerts = list(api.select(Alert)
+                  .set_time_range(start=start.strftime(time_format),
+                                  end=end.strftime(time_format))
+                  .sort_by(time_field, "ASC"))
+
+    # Check if 10k limit was hit.
+    # Iteratively fetch remaining alerts by increasing start time to the last alert fetched
+    if len(alerts) >= 10000:
+        last_alert = alerts[-1]
+        while True:
+            new_start = datetime.strptime(last_alert.create_time, time_format) + timedelta(milliseconds=1)
+            overflow = list(api.select(Alert)
+                            .set_time_range(start=new_start.strftime(time_format),
+                                            end=end.strftime(time_format))
+                            .sort_by(time_field, "ASC"))
+
+            # Extend alert list with follow up alert batches
+            alerts.extend(overflow)
+            if len(overflow) >= 10000:
+                last_alert = overflow[-1]
+            else:
+                break
+
+    print(f"Fetched {len(alerts)} alert(s) from {start.strftime(time_format)} to {end.strftime(time_format)}")
+
+
+if __name__ == "__main__":
+    # Trap keyboard interrupts while running the script.
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("\nKeyboard interrupt\n")
+        sys.exit(0)

--- a/examples/platform/alerts_bulk_export.py
+++ b/examples/platform/alerts_bulk_export.py
@@ -29,7 +29,7 @@ from datetime import datetime, timedelta, timezone
 
 def main():
     """This script demonstrates how to use Alerts in the SDK and common operations to link to related objects."""
-    api = CBCloudAPI(profile="EXPLORE_DEMO")
+    api = CBCloudAPI(profile="YOUR_PROFILE_HERE")
 
     # Time field and format to use
     time_field = "backend_timestamp"

--- a/examples/platform/alerts_bulk_export.py
+++ b/examples/platform/alerts_bulk_export.py
@@ -36,8 +36,8 @@ def main():
     time_format = "%Y-%m-%dT%H:%M:%S.%fZ"
 
     # Time window to fetch.
-    # Uses current time - 30s to allow for Carbon Black Cloud asynchronous event processing completion
-    end = datetime.now(timezone.utc) - timedelta(seconds=30)
+    # Uses current time - 60s to allow for Carbon Black Cloud asynchronous event processing completion
+    end = datetime.now(timezone.utc) - timedelta(seconds=60)
     start = end - timedelta(minutes=5)
 
     # Fetch initial Alert batch

--- a/examples/platform/alerts_bulk_export.py
+++ b/examples/platform/alerts_bulk_export.py
@@ -29,7 +29,7 @@ from datetime import datetime, timedelta, timezone
 
 def main():
     """This script demonstrates how to use Alerts in the SDK and common operations to link to related objects."""
-    api = CBCloudAPI(profile="YOUR_PROFILE_HERE")
+    api = CBCloudAPI(profile="EXPLORE_DEMO")
 
     # Time field and format to use
     time_field = "backend_timestamp"

--- a/examples/platform/alerts_bulk_export.py
+++ b/examples/platform/alerts_bulk_export.py
@@ -41,9 +41,10 @@ def main():
     start = end - timedelta(minutes=5)
 
     # Fetch initial Alert batch
-    alerts = list(api.select(Alert)
-                  .set_time_range(start=start.strftime(time_format),
-                                  end=end.strftime(time_format))
+    # the time stamp can be set either as a datetime object:
+    # alerts_time_as_object = list(api.select(Alert).set_time_range(start=start, end=end).sort_by(time_field, "ASC"))
+    # or as ISO 8601 strings
+    alerts = list(api.select(Alert).set_time_range(start=start.isoformat(), end=end.isoformat())
                   .sort_by(time_field, "ASC"))
 
     # Check if 10k limit was hit.
@@ -53,8 +54,7 @@ def main():
         while True:
             new_start = datetime.strptime(last_alert.create_time, time_format) + timedelta(milliseconds=1)
             overflow = list(api.select(Alert)
-                            .set_time_range(start=new_start.strftime(time_format),
-                                            end=end.strftime(time_format))
+                            .set_time_range(start=new_start, end=end)
                             .sort_by(time_field, "ASC"))
 
             # Extend alert list with follow up alert batches

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -973,13 +973,11 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
 
         Args:
             *args: not used
-            **kwargs (dict): Used to specify
+            **kwargs (dict): Used to specify the period to search within
 
-                * start= for start time, either timestamp ISO 8601 strings or datetime objects
-                * end= for end time, either timestamp ISO 8601 strings or datetime objects
-                * range= for range.
-
-                Range is the period on which to execute the result search, ending on the current time.
+                * start= either timestamp ISO 8601 strings or datetime objects
+                * end= either timestamp ISO 8601 strings or datetime objects
+                * range= the period on which to execute the result search, ending on the current time.
 
                 Range must be in the format "-<quantity><units>" where quantity is an integer, and units is one of:
 
@@ -996,27 +994,22 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
         the 'time_range' as in the v7 usage if key is create_time and set a criteria value for any other valid key.
 
         Args:
-            key (str): The key to use for criteria one of create_time, first_event_time, last_event_time,
-             backend_timestamp, backend_update_timestamp, or last_update_time
-            **kwargs (dict): Used to specify
+            key (str): The key to use for criteria one of create_time, first_event_time, last_event_time
+             or last_update_time. i.e. legacy field names from the Alert v6 API.
+            **kwargs (dict): Used to specify the period to search within
 
-                * start= for start time, either timestamp ISO 8601 strings or datetime objects
-                * end= for end time, either timestamp ISO 8601 strings or datetime objects
-                * range= for range
-
-                Values are for start and end time.
-                For range the time range to execute the result search, ending on the current time. The same format as
-                above for v7.
+                * start= either timestamp ISO 8601 strings or datetime objects
+                * end= either timestamp ISO 8601 strings or datetime objects
+                * range= the period on which to execute the result search, ending on the current time.
 
         Returns:
             AlertSearchQuery: This instance.
 
         Examples:
-            >>> query = api.select(Alert).set_time_range(start="2020-10-20T20:34:07Z")
-            >>> second_query = api.select(Alert).
+            >>> query_specify_start_and_end = api.select(Alert).
             ...     set_time_range(start="2020-10-20T20:34:07Z", end="2020-10-30T20:34:07Z")
-            >>> third_query = api.select(Alert).set_time_range(range='-3d')
-            >>> fourth_query = api.select(Alert).set_time_range("create_time", range='-3d')
+            >>> query_specify_range = api.select(Alert).set_time_range(range='-3d')
+            >>> query_legacy_use = api.select(Alert).set_time_range("create_time", range='-3d')
 
         """
         args_count = args.__len__()

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -1045,7 +1045,7 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
 
         Args:
             key (str): The key to use for criteria one of create_time, first_event_time, last_event_time,
-             backend_timestamp, backend_update_timestamp, or last_update_time
+             backend_update_timestamp, or last_update_time
             **kwargs (dict): Used to specify:
 
                 * start= for start time
@@ -1058,9 +1058,9 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
 
         Examples:
             >>> query = api.select(Alert).
-            ...     add_time_criteria("backend_timestamp", start="2020-10-20T20:34:07Z", end="2020-10-30T20:34:07Z")
-            >>> second_query = api.select(Alert).add_time_criteria("backend_timestamp", range='-3d')
-            >>> third_query = api.select(Alert).set_time_range("create_time", range='-3d')
+            ...     add_time_criteria("detection_timestamp", start="2020-10-20T20:34:07Z", end="2020-10-30T20:34:07Z")
+            >>> second_query = api.select(Alert).add_time_criteria("detection_timestamp", range='-3d')
+            >>> third_query_legacy = api.select(Alert).set_time_range("create_time", range='-3d')
             >>> exclusions_query = api.add_time_criteria("detection_timestamp", range="-2h", exclude=True)
 
         """
@@ -1080,17 +1080,17 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
         Verifies that an alert criteria key has the timerange functionality
 
         Args:
-            args (str): The key to use for criteria one of one of backend_timestamp, backend_update_timestamp,
+            args (str): The key to use for criteria must be one of backend_update_timestamp,
             detection_timestamp, first_event_timestamp, last_event_timestamp, mdr_determination_change_timestamp,
             mdr_workflow_change_timestamp, user_update_timestamp, or workflow_change_timestamp
 
         Returns:
             boolean true
         """
-        if key not in ["backend_timestamp", "backend_update_timestamp", "detection_timestamp", "first_event_timestamp",
+        if key not in ["backend_update_timestamp", "detection_timestamp", "first_event_timestamp",
                        "last_event_timestamp", "mdr_determination_change_timestamp", "mdr_workflow_change_timestamp",
                        "user_update_timestamp", "workflow_change_timestamp"]:
-            raise ApiError("key must be one of backend_timestamp, backend_update_timestamp, detection_timestamp, "
+            raise ApiError("key must be one of backend_update_timestamp, detection_timestamp, "
                            "first_event_timestamp, last_event_timestamp, mdr_determination_change_timestamp, "
                            "mdr_workflow_change_timestamp, user_update_timestamp, or workflow_change_timestamp")
         return True

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -979,9 +979,9 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
                 * end= for end time
                 * range= for range.
 
-            Values are either timestamp ISO 8601 strings or datetime objects for start and end time.
-            For range the time range to execute the result search, ending on the current time. Range should be in the
-            format "-<quantity><units>" where quantity is an integer, and units is one of:
+                Values are either timestamp ISO 8601 strings or datetime objects for start and end time.
+                For range the time range to execute the result search, ending on the current time. Range should be in
+                the format "-<quantity><units>" where quantity is an integer, and units is one of:
 
                 * M: month(s)
                 * w: week(s)
@@ -1005,9 +1005,9 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
                 * end= for end time
                 * range= for range
 
-            Values are either timestamp ISO 8601 strings or datetime objects for start and end time.
-            For range the time range to execute the result search, ending on the current time. The same format as above
-            for v7.
+                Values are either timestamp ISO 8601 strings or datetime objects for start and end time.
+                For range the time range to execute the result search, ending on the current time. The same format as
+                above for v7.
 
         Returns:
             AlertSearchQuery: This instance.

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -975,13 +975,13 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
             *args: not used
             **kwargs (dict): Used to specify
 
-                * start= for start time
-                * end= for end time
+                * start= for start time, either timestamp ISO 8601 strings or datetime objects
+                * end= for end time, either timestamp ISO 8601 strings or datetime objects
                 * range= for range.
 
-                Values are either timestamp ISO 8601 strings or datetime objects for start and end time.
-                For range the time range to execute the result search, ending on the current time. Range should be in
-                the format "-<quantity><units>" where quantity is an integer, and units is one of:
+                Range is the period on which to execute the result search, ending on the current time.
+
+                Range must be in the format "-<quantity><units>" where quantity is an integer, and units is one of:
 
                 * M: month(s)
                 * w: week(s)
@@ -992,20 +992,19 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
 
         For v6 Alerts (backwards compatibility):
 
-        Restricts the alerts that this query is performed on to the specified time range for a given key. Will also set
-        the 'time_range' as in the v7 usage if key is create_time or backend_timestamp. Will be deprecated with v6 alert
-        api
+        Restricts the alerts that this query is performed on to the specified time range for a given key. Will set
+        the 'time_range' as in the v7 usage if key is create_time and set a criteria value for any other valid key.
 
         Args:
             key (str): The key to use for criteria one of create_time, first_event_time, last_event_time,
              backend_timestamp, backend_update_timestamp, or last_update_time
             **kwargs (dict): Used to specify
 
-                * start= for start time
-                * end= for end time
+                * start= for start time, either timestamp ISO 8601 strings or datetime objects
+                * end= for end time, either timestamp ISO 8601 strings or datetime objects
                 * range= for range
 
-                Values are either timestamp ISO 8601 strings or datetime objects for start and end time.
+                Values are for start and end time.
                 For range the time range to execute the result search, ending on the current time. The same format as
                 above for v7.
 
@@ -1027,9 +1026,11 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
             self._valid_criteria = self._is_valid_time_criteria_key_v6(key)
             if self._valid_criteria:
                 key = Alert.REMAPPED_ALERTS_V6_TO_V7.get(key, key)
-                self.add_time_criteria(key, **kwargs)
-                if key in ["create_time", "backend_timestamp"]:
+                # key has been converted so v6 values are not expected here
+                if key in ["backend_timestamp"]:
                     self._time_range = time_filter
+                else:
+                    self.add_time_criteria(key, **kwargs)
         else:
             # everything before this is only for backwards compatibility, once v6 deprecates all the other
             # checks can be removed
@@ -1077,10 +1078,10 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
 
     def _is_valid_time_criteria_key(self, key):
         """
-        Verifies that an alert criteria key has the timerange functionality
+        Verifies that an alert criteria key is a valid searchable time range field
 
         Args:
-            args (str): The key to use for criteria must be one of backend_update_timestamp,
+            args (str): The key to use for criteria must be a valid v7 time range field; backend_update_timestamp,
             detection_timestamp, first_event_timestamp, last_event_timestamp, mdr_determination_change_timestamp,
             mdr_workflow_change_timestamp, user_update_timestamp, or workflow_change_timestamp
 
@@ -1097,7 +1098,9 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
 
     def _is_valid_time_criteria_key_v6(self, key):
         """
-        Verifies that an alert criteria key has the timerange functionality for v6 sdk calls
+        Verifies that an alert criteria key has the timerange functionality for v6 sdk calls.
+
+        Only v6 field names are valid.
 
         Args:
             args (str): The key to use for criteria one of create_time, first_event_time, last_event_time,
@@ -1106,10 +1109,8 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
         Returns:
             boolean true
         """
-        if key not in ["create_time", "first_event_time", "last_event_time", "last_update_time", "backend_timestamp",
-                       "backend_update_timestamp"]:
-            raise ApiError("key must be one of create_time, first_event_time, last_event_time, backend_timestamp,"
-                           " backend_update_timestamp, or last_update_time")
+        if key not in ["create_time", "first_event_time", "last_event_time", "last_update_time"]:
+            raise ApiError("key must be one of create_time, first_event_time, last_event_time or last_update_time")
         return True
 
     def _create_valid_time_filter(self, kwargs):

--- a/src/tests/unit/platform/test_alertsv6_api.py
+++ b/src/tests/unit/platform/test_alertsv6_api.py
@@ -226,8 +226,7 @@ def test_query_basealert_with_time_range_create_time_as_start_end(cbcsdk_mock):
     """Test an alert query with the create_time specified as a range which should also set the global time_range."""
 
     def on_post(url, body, **kwargs):
-        assert body == {"query": "Blort", "criteria": {"backend_timestamp": {"range": "-3w"}}, "rows": 2,
-                        'time_range': {'range': '-3w'}}
+        assert body == {"query": "Blort", "rows": 2, 'time_range': {'range': '-3w'}}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
 
@@ -845,8 +844,7 @@ def test_query_basealert_with_time_range_errors(cbcsdk_mock):
     api = cbcsdk_mock.api
     with pytest.raises(ApiError) as ex:
         api.select(BaseAlert).where("Blort").set_time_range("invalid", range="whatever")
-    assert "key must be one of create_time, first_event_time, last_event_time, backend_timestamp, " \
-           "backend_update_timestamp, or last_update_time" in str(ex.value)
+    assert "key must be one of create_time, first_event_time, last_event_time or last_update_time" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
         api.select(BaseAlert).where("Blort").set_time_range("create_time",
@@ -863,8 +861,15 @@ def test_query_basealert_with_time_range_errors(cbcsdk_mock):
 
     with pytest.raises(ApiError) as ex:
         api.select(BaseAlert).where("Blort").set_time_range("create_time")
-
     assert "must specify either start= and end= or range=" in str(ex.value)
+
+    with pytest.raises(ApiError) as ex:
+        api.select(BaseAlert).where("Blort").set_time_range("backend_timestamp", range="-3w")
+    assert "key must be one of create_time, first_event_time, last_event_time or last_update_time" in str(ex.value)
+
+    with pytest.raises(ApiError) as ex:
+        api.select(BaseAlert).where("Blort").set_time_range("detection_timestamp", range="-3w")
+    assert "key must be one of create_time, first_event_time, last_event_time or last_update_time" in str(ex.value)
 
 
 def test_query_basealert_sort_error(cbcsdk_mock):

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -1848,3 +1848,10 @@ def test_delete_threat_tag(cbcsdk_mock):
     alert = api.select(Alert, "6f1173f5-f921-8e11-2160-edf42b799333")
 
     assert tags == alert.delete_threat_tag("tag2")
+
+
+def test_backend_timestamp_as_criteria(cbcsdk_mock):
+    """Test that setting backend_timestamp as a criteria field raises an error"""
+    api = cbcsdk_mock.api
+    with pytest.raises(ApiError):
+        api.select(Alert).add_time_criteria("backend_timestamp")

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -126,83 +126,16 @@ def test_query_alert_with_all_bells_and_whistles(cbcsdk_mock):
     assert a.workflow["status"] == "OPEN"
 
 
-def test_query_alert_with_backend_timestamp_as_start_end(cbcsdk_mock):
-    """Test an alert query with the backend_timestamp specified as a start and end time."""
-
-    def on_post(url, body, **kwargs):
-        assert body == {"query": "Blort",
-                        "rows": 2,
-                        "criteria": {"backend_timestamp": {"start": "2019-09-30T12:34:56.000000Z",
-                                                           "end": "2019-10-01T12:00:12.000000Z"}}}
-        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
-                             "workflow": {"status": "OPEN"}}], "num_found": 1}
-
-    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
-    api = cbcsdk_mock.api
-
-    query = api.select(Alert).where("Blort").add_time_criteria("backend_timestamp", start="2019-09-30T12:34:56",
-                                                               end="2019-10-01T12:00:12")
-    a = query.one()
-    assert a.id == "S0L0"
-    assert a.org_key == "test"
-    assert a.threat_id == "B0RG"
-    assert a.workflow["status"] == "OPEN"
-
-
-def test_query_alert_with_backend_timestamp_as_start_end_as_objs(cbcsdk_mock):
-    """Test an alert query with the backend_timestamp specified as a start and end time."""
+def test_query_alert_with_backend_update_timestamp_as_start_end_as_objs(cbcsdk_mock):
+    """Test an alert query with the backend_update_timestamp specified as a start and end time."""
     _timestamp = datetime.now()
 
     def on_post(url, body, **kwargs):
         nonlocal _timestamp
         assert body == {"query": "Blort",
                         "rows": 2,
-                        "criteria": {"backend_timestamp": {"start": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                                                           "end": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}}}
-        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
-                             "workflow": {"status": "OPEN"}}], "num_found": 1}
-
-    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
-    api = cbcsdk_mock.api
-
-    query = api.select(Alert).where("Blort").add_time_criteria("backend_timestamp", start=_timestamp,
-                                                               end=_timestamp)
-    a = query.one()
-    assert a.id == "S0L0"
-    assert a.org_key == "test"
-    assert a.threat_id == "B0RG"
-    assert a.workflow["status"] == "OPEN"
-
-
-def test_query_alert_with_backend_timestamp_as_range(cbcsdk_mock):
-    """Test an alert query with the creation time specified as a range."""
-
-    def on_post(url, body, **kwargs):
-        assert body == {"query": "Blort", "criteria": {"backend_timestamp": {"range": "-3w"}}, "rows": 2}
-        return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
-                             "workflow": {"status": "OPEN"}}], "num_found": 1}
-
-    cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
-    api = cbcsdk_mock.api
-
-    query = api.select(Alert).where("Blort").add_time_criteria("backend_timestamp", range="-3w")
-    a = query.one()
-    assert a.id == "S0L0"
-    assert a.org_key == "test"
-    assert a.threat_id == "B0RG"
-    assert a.workflow["status"] == "OPEN"
-
-
-def test_query_alert_with_backend_update_timestamp_as_start_end(cbcsdk_mock):
-    """Test an alert query with the backend_update_timestamp specified as a range."""
-    _timestamp = datetime.now()
-
-    def on_post(url, body, **kwargs):
-        nonlocal _timestamp
-        assert body == {"query": "Blort", "criteria": {"backend_update_timestamp": {
-            "start": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            "end": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}},
-            "rows": 2}
+                        "criteria": {"backend_update_timestamp": {"start": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                                                                  "end": _timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}}}
         return {"results": [{"id": "S0L0", "org_key": "test", "threat_id": "B0RG",
                              "workflow": {"status": "OPEN"}}], "num_found": 1}
 
@@ -219,7 +152,7 @@ def test_query_alert_with_backend_update_timestamp_as_start_end(cbcsdk_mock):
 
 
 def test_query_alert_with_backend_update_timestamp_as_range(cbcsdk_mock):
-    """Test an alert query with the backend_update_timestamp specified as a range."""
+    """Test an alert query with the creation time specified as a range."""
 
     def on_post(url, body, **kwargs):
         assert body == {"query": "Blort", "criteria": {"backend_update_timestamp": {"range": "-3w"}}, "rows": 2}
@@ -228,6 +161,7 @@ def test_query_alert_with_backend_update_timestamp_as_range(cbcsdk_mock):
 
     cbcsdk_mock.mock_request('POST', "/api/alerts/v7/orgs/test/alerts/_search", on_post)
     api = cbcsdk_mock.api
+
     query = api.select(Alert).where("Blort").add_time_criteria("backend_update_timestamp", range="-3w")
     a = query.one()
     assert a.id == "S0L0"
@@ -299,17 +233,17 @@ def test_query_alert_facets(cbcsdk_mock):
                                               {"id": "CB_ANALYTICS", "name": "CB_ANALYTICS", "total": 41}]}]
 
 
-def test_query_alert_invalid_backend_timestamp_combinations(cb):
-    """Test invalid backend_timestamp combinations being supplied to alert queries."""
+def test_query_alert_invalid_backend_update_timestamp_combinations(cb):
+    """Test invalid backend_update_timestamp combinations being supplied to alert queries."""
     with pytest.raises(ApiError):
-        cb.select(Alert).add_time_criteria("backend_timestamp")
+        cb.select(Alert).add_time_criteria("backend_update_timestamp")
     with pytest.raises(ApiError):
-        cb.select(Alert).add_time_criteria("backend_timestamp", start="2019-09-30T12:34:56",
+        cb.select(Alert).add_time_criteria("backend_update_timestamp", start="2019-09-30T12:34:56",
                                            end="2019-10-01T12:00:12", range="-3w")
     with pytest.raises(ApiError):
-        cb.select(Alert).add_time_criteria("backend_timestamp", start="2019-09-30T12:34:56", range="-3w")
+        cb.select(Alert).add_time_criteria("backend_update_timestamp", start="2019-09-30T12:34:56", range="-3w")
     with pytest.raises(ApiError):
-        cb.select(Alert).add_time_criteria("backend_timestamp", end="2019-10-01T12:00:12", range="-3w")
+        cb.select(Alert).add_time_criteria("backend_update_timestamp", end="2019-10-01T12:00:12", range="-3w")
 
 
 def test_query_cbanalyticsalert_with_all_bells_and_whistles(cbcsdk_mock):
@@ -805,25 +739,25 @@ def test_query_alert_with_time_range_errors(cbcsdk_mock):
     api = cbcsdk_mock.api
     with pytest.raises(ApiError) as ex:
         api.select(Alert).where("Blort").add_time_criteria("invalid", range="whatever")
-    assert "key must be one of backend_timestamp, backend_update_timestamp, detection_timestamp, " \
+    assert "key must be one of backend_update_timestamp, detection_timestamp, " \
            "first_event_timestamp, last_event_timestamp, mdr_determination_change_timestamp, " \
            "mdr_workflow_change_timestamp, user_update_timestamp, or workflow_change_timestamp" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").add_time_criteria("backend_timestamp",
+        api.select(Alert).where("Blort").add_time_criteria("backend_update_timestamp",
                                                            start="2019-09-30T12:34:56",
                                                            end="2019-10-01T12:00:12",
                                                            range="-3w")
     assert "cannot specify range= in addition to start= and end=" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").add_time_criteria("backend_timestamp",
+        api.select(Alert).where("Blort").add_time_criteria("backend_update_timestamp",
                                                            end="2019-10-01T12:00:12",
                                                            range="-3w")
     assert "cannot specify start= or end= in addition to range=" in str(ex.value)
 
     with pytest.raises(ApiError) as ex:
-        api.select(Alert).where("Blort").add_time_criteria("backend_timestamp")
+        api.select(Alert).where("Blort").add_time_criteria("backend_update_timestamp")
 
     assert "must specify either start= and end= or range=" in str(ex.value)
 


### PR DESCRIPTION
Updated time validation - backend_timestamp is not valid "criteria" Removed some tests - need to revisit, replacements that expect an exception are likely needed to replace them

## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->


## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
the period searched by backend_timestamp is set at the top level time_range element of the request.
Previously, if backend_timestamp was set in the criteria section, it was silently ignored or gave very hard to calculate results.  In mid-october the backend updated to return an error if backend_timestamp was in criteria.
This change updates the SDK to be more strict in line with that change.

- set_time_range(start/end/range) --> sets time_range{} element. Correct v7 use of the method
- set_time_range("create_time",...) --> sets time_range{} element. Correct v6 use of the method
- set_time_range("other valid v6 field",...) --> sets criteria element. . Correct v6 use of the method
- set_time_range("v7 field",...) --> raises exception. Blending v7 fields with v6 legacy method. Must be new code, don't allow it.
- set_time_range("anything else",...) --> relies on API response

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests updated.