### PR TITLE
CBAPI-5078: Add deobfuscate_cmdline() to Process

### DIFF
--- a/src/cbc_sdk/platform/processes.py
+++ b/src/cbc_sdk/platform/processes.py
@@ -326,9 +326,9 @@ class Process(UnrefreshableModel):
         Returns:
              dict: A dict containing information about the obfuscated command line, including the deobfuscated result.
         """
-        body = {"input": self.process_cmdline}
+        body = {"input": self.process_cmdline[0]}
         if not body['input']:
-            body['input'] = self.get_details()['process_cmdline']
+            body['input'] = self.get_details()['process_cmdline'][0]
         result = self._cb.post_object(f"/tau/v2/orgs/{self._cb.credentials.org_key}/reveal", body)
         return result.json()
 

--- a/src/cbc_sdk/platform/processes.py
+++ b/src/cbc_sdk/platform/processes.py
@@ -238,6 +238,11 @@ class Process(UnrefreshableModel):
         super(Process, self).__init__(cb, model_unique_id=model_unique_id, initial_data=initial_data,
                                       force_init=force_init, full_doc=full_doc)
 
+    def _retrieve_cb_info(self):
+        """Retrieve the detailed information about this object."""
+        self._details_timeout = 0
+        return self._get_detailed_results()._info
+
     @property
     def summary(self):
         """Returns organization-specific information about this process."""

--- a/src/cbc_sdk/platform/processes.py
+++ b/src/cbc_sdk/platform/processes.py
@@ -316,6 +316,19 @@ class Process(UnrefreshableModel):
         else:
             return None
 
+    def deobfuscate_cmdline(self):
+        """
+        Deobfuscates the command line of the process and returns the deobfuscated result.
+
+        Required Permissions:
+            script.deobfuscation(EXECUTE)
+
+        Returns:
+             dict: A dict containing information about the obfuscated command line, including the deobfuscated result.
+        """
+        body = {"input": self.process_cmdline}
+        return self._cb.post_object(f"/tau/v2/orgs/{self._cb.credentials.org_key}/reveal", body)
+
     def events(self, **kwargs):
         """
         Returns a query for events associated with this process's process GUID.

--- a/src/cbc_sdk/platform/processes.py
+++ b/src/cbc_sdk/platform/processes.py
@@ -55,10 +55,10 @@ class Process(UnrefreshableModel):
     ``AsyncProcessQuery``.
 
     Examples:
-        # use the Process GUID directly
+        >>> # use the Process GUID directly
         >>> process = api.select(Process, "WNEXFKQ7-00050603-0000066c-00000000-1d6c9acb43e29bb")
 
-        # use the Process GUID in a where() clause
+        >>> # use the Process GUID in a where() clause
         >>> process_query = api.select(Process).where(process_guid=
         ...    "WNEXFKQ7-00050603-0000066c-00000000-1d6c9acb43e29bb")
         >>> process_query_results = list(process_query)
@@ -327,6 +327,8 @@ class Process(UnrefreshableModel):
              dict: A dict containing information about the obfuscated command line, including the deobfuscated result.
         """
         body = {"input": self.process_cmdline}
+        if not body['input']:
+            body['input'] = self.get_details()['process_cmdline']
         result = self._cb.post_object(f"/tau/v2/orgs/{self._cb.credentials.org_key}/reveal", body)
         return result.json()
 

--- a/src/cbc_sdk/platform/processes.py
+++ b/src/cbc_sdk/platform/processes.py
@@ -327,7 +327,8 @@ class Process(UnrefreshableModel):
              dict: A dict containing information about the obfuscated command line, including the deobfuscated result.
         """
         body = {"input": self.process_cmdline}
-        return self._cb.post_object(f"/tau/v2/orgs/{self._cb.credentials.org_key}/reveal", body)
+        result = self._cb.post_object(f"/tau/v2/orgs/{self._cb.credentials.org_key}/reveal", body)
+        return result.json()
 
     def events(self, **kwargs):
         """

--- a/src/tests/unit/fixtures/platform/mock_process.py
+++ b/src/tests/unit/fixtures/platform/mock_process.py
@@ -2987,3 +2987,17 @@ GET_FACET_SEARCH_RESULTS_RESP_NOT_COMPLETE = {
     "contacted": 10,
     "completed": 2
 }
+
+PROCESS_OBFUSCATED_CMDLINE = "powershell.exe -encodedcommand VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAiAE4AbwAgAG0AYQB0AHQAZQByACAAaABvAHcAIAB0AGgAaQBuACAAeQBvAHUAIABzAGwAaQBjAGUAIABpAHQALAAgAGkAdAAnAHMAIABzAHQAaQBsAGwAIABiAGEAbABvAG4AZQB5AC4AIgA="  # noqa: E501
+
+PROCESS_DEOBFUSCATE_CMDLINE_RESPONSE = {
+    "original_code": "Write-Output \"No matter how thin you slice it, it's still baloney.\"\n",
+    "deobfuscated_code": "Write-Output \"No matter how thin you slice it, it's still baloney.\"\n",
+    "identities": [
+        "Write-Output"
+    ],
+    "strings": [
+        "No matter how thin you slice it, it's still baloney."
+    ],
+    "obfuscation_level": 0.0
+}

--- a/src/tests/unit/platform/test_platform_process.py
+++ b/src/tests/unit/platform/test_platform_process.py
@@ -297,7 +297,7 @@ def test_process_deobfuscate_cmdline(cbcsdk_mock):
     api = cbcsdk_mock.api
     process = api.select(Process, 'WNEXFKQ7-0002b226-000015bd-00000000-1d6225bbba74c00')
     # poke the command line so we have something to deobfuscate
-    process._info['process_cmdline'] = PROCESS_OBFUSCATED_CMDLINE
+    process._info['process_cmdline'] = [PROCESS_OBFUSCATED_CMDLINE]
     deobfuscation = process.deobfuscate_cmdline()
     assert len(deobfuscation['identities']) == 1
     assert len(deobfuscation['strings']) == 1

--- a/src/tests/unit/platform/test_platform_process.py
+++ b/src/tests/unit/platform/test_platform_process.py
@@ -38,7 +38,9 @@ from tests.unit.fixtures.platform.mock_process import (GET_PROCESS_SUMMARY_RESP,
                                                        EXPECTED_PROCESS_RANGES_FACETS,
                                                        GET_PROCESS_TREE_STR,
                                                        GET_PROCESS_SUMMARY_STR,
-                                                       GET_PROCESS_DETAILS_JOB_RESULTS_RESP_ZERO)
+                                                       GET_PROCESS_DETAILS_JOB_RESULTS_RESP_ZERO,
+                                                       PROCESS_OBFUSCATED_CMDLINE,
+                                                       PROCESS_DEOBFUSCATE_CMDLINE_RESPONSE)
 
 log = logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
 
@@ -265,6 +267,42 @@ def test_summary_select_set_time_range_failures(cbcsdk_mock):
     with pytest.raises(ApiError) as ex:
         summary.set_time_range(window=20)
     assert 'Window must be a string.' in ex.value.message
+
+
+def test_process_deobfuscate_cmdline(cbcsdk_mock):
+    """Test the deobfuscate_cmdline() method."""
+    def on_validation_post(url, body, **kwargs):
+        assert body == {"query": "process_guid:WNEXFKQ7\\-0002b226\\-000015bd\\-00000000\\-1d6225bbba74c00"}
+        return POST_PROCESS_VALIDATION_RESP
+
+    def on_post_deobfuscate(url, body, **kwargs):
+        assert body == {"input": PROCESS_OBFUSCATED_CMDLINE}
+        return PROCESS_DEOBFUSCATE_CMDLINE_RESPONSE
+
+    # mock the search validation
+    cbcsdk_mock.mock_request("POST", "/api/investigate/v2/orgs/test/processes/search_validation", on_validation_post)
+    # mock the POST of a search
+    cbcsdk_mock.mock_request("POST", "/api/investigate/v2/orgs/test/processes/search_jobs",
+                             POST_PROCESS_SEARCH_JOB_RESP)
+    # mock the GET to check search status
+    cbcsdk_mock.mock_request("GET", ("/api/investigate/v2/orgs/test/processes/"
+                                     "search_jobs/2c292717-80ed-4f0d-845f-779e09470920/results?start=0&rows=0"),
+                             GET_PROCESS_SEARCH_JOB_RESP)
+    # mock the GET to get search results
+    cbcsdk_mock.mock_request("GET", ("/api/investigate/v2/orgs/test/processes/search_jobs/"
+                                     "2c292717-80ed-4f0d-845f-779e09470920/results?start=0&rows=500"),
+                             GET_PROCESS_SEARCH_JOB_RESULTS_RESP)
+    cbcsdk_mock.mock_request("POST", "/tau/v2/orgs/test/reveal", on_post_deobfuscate)
+
+    api = cbcsdk_mock.api
+    process = api.select(Process, 'WNEXFKQ7-0002b226-000015bd-00000000-1d6225bbba74c00')
+    # poke the command line so we have something to deobfuscate
+    process._info['process_cmdline'] = PROCESS_OBFUSCATED_CMDLINE
+    deobfuscation = process.deobfuscate_cmdline()
+    assert len(deobfuscation['identities']) == 1
+    assert len(deobfuscation['strings']) == 1
+    assert deobfuscation['deobfuscated_code'] == \
+        "Write-Output \"No matter how thin you slice it, it's still baloney.\"\n"
 
 
 def test_process_events(cbcsdk_mock):
@@ -506,6 +544,17 @@ def test_process_start_rows(cbcsdk_mock):
                        }
     assert process_q_params == expected_params
     assert process._batch_size == 102
+
+
+def test_process_search_set_rows_failure(cbcsdk_mock):
+    """Test what happens when we set rows to something nonsensical."""
+    api = cbcsdk_mock.api
+    process = api.select(Process).where("event_type:modload").add_criteria("device_id", [1234]).add_exclusions(
+        "crossproc_effective_reputation", ["REP_WHITE"])
+    with pytest.raises(ApiError):
+        process.set_rows('Bogus')
+    with pytest.raises(ApiError):
+        process.set_rows(65536)
 
 
 def test_process_sort(cbcsdk_mock):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-5078

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Add `deobfuscate_cmdline()` helper function to `Process`, which calls the Script Deobfuscation API.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
New unit test has been added for the function, and an additional one added to help bring up code coverage in the `processes.py` file.  Code coverage is at 93%, mainly because of other bits of process support that aren't easily testable.