### PR TITLE
CBAPI-5079: Add deobfuscate_cmdline() to Observation

### DIFF
--- a/src/cbc_sdk/platform/observations.py
+++ b/src/cbc_sdk/platform/observations.py
@@ -226,6 +226,20 @@ class Observation(NewBaseModel):
         except AttributeError:
             raise ApiError("No available network threat metadata.")
 
+    def deobfuscate_cmdline(self):
+        """
+        Deobfuscates the command line of the process pointed to by the observation and returns the deobfuscated result.
+
+        Required Permissions:
+            script.deobfuscation(EXECUTE)
+
+        Returns:
+             dict: A dict containing information about the obfuscated command line, including the deobfuscated result.
+        """
+        body = {"input": self.process_cmdline[0]}
+        result = self._cb.post_object(f"/tau/v2/orgs/{self._cb.credentials.org_key}/reveal", body)
+        return result.json()
+
     @staticmethod
     def search_suggestions(cb, query, count=None):
         """

--- a/src/tests/unit/fixtures/platform/mock_observations.py
+++ b/src/tests/unit/fixtures/platform/mock_observations.py
@@ -365,9 +365,7 @@ GET_OBSERVATIONS_DETAIL_JOB_RESULTS_FOR_DEOBFUSCATE = {
             "parent_name": "c:\\Windows\\System32\\powershell.exe",
             "parent_pid": 7272,
             "parent_reputation": "NOT_LISTED",
-            "process_cmdline": [
-                "powershell.exe -encodedcommand VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAiAE4AbwAgAG0AYQB0AHQAZQByACAAaABvAHcAIAB0AGgAaQBuACAAeQBvAHUAIABzAGwAaQBjAGUAIABpAHQALAAgAGkAdAAnAHMAIABzAHQAaQBsAGwAIABiAGEAbABvAG4AZQB5AC4AIgA="  # noqa: E501
-            ],
+            "process_cmdline": ["powershell.exe -encodedcommand VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAiAE4AbwAgAG0AYQB0AHQAZQByACAAaABvAHcAIAB0AGgAaQBuACAAeQBvAHUAIABzAGwAaQBjAGUAIABpAHQALAAgAGkAdAAnAHMAIABzAHQAaQBsAGwAIABiAGEAbABvAG4AZQB5AC4AIgA="],  # noqa: E501
             "process_cmdline_length": [268],
             "process_effective_reputation": "NOT_LISTED",
             "process_effective_reputation_source": "AV",

--- a/src/tests/unit/fixtures/platform/mock_observations.py
+++ b/src/tests/unit/fixtures/platform/mock_observations.py
@@ -302,6 +302,114 @@ GET_OBSERVATIONS_DETAIL_JOB_RESULTS_RESP = {
 }
 
 
+GET_OBSERVATIONS_DETAIL_JOB_RESULTS_FOR_DEOBFUSCATE = {
+    "approximate_unaggregated": 2,
+    "completed": 4,
+    "contacted": 4,
+    "num_aggregated": 1,
+    "num_available": 1,
+    "num_found": 1,
+    "results": [
+        {
+            "alert_category": ["OBSERVED"],
+            "alert_id": None,
+            "backend_timestamp": "2023-02-08T03:22:21.570Z",
+            "device_external_ip": "127.0.0.1",
+            "device_group_id": 0,
+            "device_id": 17482451,
+            "device_installed_by": "bit9qa",
+            "device_internal_ip": "127.0.0.1",
+            "device_location": "ONSITE",
+            "device_name": "dev01-39x-1",
+            "device_os": "WINDOWS",
+            "device_os_version": "Windows 10 x64",
+            "device_policy": "lonergan policy",
+            "device_policy_id": 12345,
+            "device_target_priority": "MEDIUM",
+            "device_timestamp": "2023-02-08T03:20:33.751Z",
+            "document_guid": "KBrOYUNlTYe116ADgNvGw",
+            "enriched": True,
+            "enriched_event_type": "NETWORK",
+            "event_description": "The script...",
+            "event_id": "8fbccc2da75f11ed937ae3cb089984c6",
+            "event_network_inbound": False,
+            "event_network_local_ipv4": "127.0.0.1",
+            "event_network_location": "Santa Clara,CA,United States",
+            "event_network_protocol": "TCP",
+            "event_network_remote_ipv4": "127.0.0.1",
+            "event_network_remote_port": 80,
+            "event_report_code": "SUB_RPT_NONE",
+            "event_threat_score": [3],
+            "event_type": "netconn",
+            "ingress_time": 1675826462036,
+            "legacy": True,
+            "netconn_actions": ["ACTION_CONNECTION_ESTABLISHED"],
+            "netconn_domain": "a1887..dscq..akamai..net",
+            "netconn_inbound": False,
+            "netconn_ipv4": 388818410,
+            "netconn_local_ipv4": 11111,
+            "netconn_local_port": 11,
+            "netconn_location": "Santa Clara,CA,United States",
+            "netconn_port": 80,
+            "netconn_protocol": "PROTO_TCP",
+            "observation_description": "The application firefox.exe invoked ",
+            "observation_id": "8fbccc2da75f11ed937ae3cb089984c6:be6ff259-88e3-6286-789f-74defa192d2e",
+            "observation_type": "CB_ANALYTICS",
+            "org_id": "ABCD123456",
+            "parent_effective_reputation": "ADAPTIVE_WHITE_LIST",
+            "parent_effective_reputation_source": "CLOUD",
+            "parent_guid": "TEST-010ac2d3-00001c68-00000000-1d93b6c4d1f20ad",
+            "parent_hash": [
+                "69c8bd1c1dc6103df6bfa9882b5717c0dc4acb8c0c85d8f5c9900db860b6c29b"
+            ],
+            "parent_name": "c:\\Windows\\System32\\powershell.exe",
+            "parent_pid": 7272,
+            "parent_reputation": "NOT_LISTED",
+            "process_cmdline": [
+                "powershell.exe -encodedcommand VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAiAE4AbwAgAG0AYQB0AHQAZQByACAAaABvAHcAIAB0AGgAaQBuACAAeQBvAHUAIABzAGwAaQBjAGUAIABpAHQALAAgAGkAdAAnAHMAIABzAHQAaQBsAGwAIABiAGEAbABvAG4AZQB5AC4AIgA="  # noqa: E501
+            ],
+            "process_cmdline_length": [268],
+            "process_effective_reputation": "NOT_LISTED",
+            "process_effective_reputation_source": "AV",
+            "process_guid": "ABCD123456-010ac2d3-00001cf8-00000000-1d93b6c4d2b16a4",
+            "process_hash": [
+                "9df1ec5e25919660a1b0b85d3965d55797b9aac81e028008428106c4dc"
+            ],
+            "process_name": "c:\\programdata\\mozilla-1de4eec8-1241-4177-a864-e594e8d1fb38\\updates",
+            "process_pid": [2000],
+            "process_reputation": "NOT_LISTED",
+            "process_sha256": "9df1ec5e25919660a1b0b85d3965d55797b9aac81e028008428106c4dc",
+            "process_start_time": "2023-02-08T03:20:32.131Z",
+            "process_username": ["DEV01-39X-1\\bit9qa"],
+            "ttp": [
+                "INTERNATIONAL_SITE",
+                "ACTIVE_CLIENT",
+                "NETWORK_ACCESS",
+                "UNKNOWN_APP",
+            ],
+        }
+    ],
+}
+
+
+OBS_DEOBFUSCATE_CMDLINE_REQUEST = {
+    "input": "powershell.exe -encodedcommand VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAiAE4AbwAgAG0AYQB0AHQAZQByACAAaABvAHcAIAB0AGgAaQBuACAAeQBvAHUAIABzAGwAaQBjAGUAIABpAHQALAAgAGkAdAAnAHMAIABzAHQAaQBsAGwAIABiAGEAbABvAG4AZQB5AC4AIgA="  # noqa: E501
+}
+
+
+OBS_DEOBFUSCATE_CMDLINE_RESPONSE = {
+    "original_code": "Write-Output \"No matter how thin you slice it, it's still baloney.\"\n",
+    "deobfuscated_code": "Write-Output \"No matter how thin you slice it, it's still baloney.\"\n",
+    "identities": [
+        "Write-Output"
+    ],
+    "strings": [
+        "No matter how thin you slice it, it's still baloney."
+    ],
+    "obfuscation_level": 0.0
+}
+
+
 GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ALERTS = {
     "approximate_unaggregated": 2,
     "completed": 4,

--- a/src/tests/unit/platform/test_observations.py
+++ b/src/tests/unit/platform/test_observations.py
@@ -18,6 +18,9 @@ from tests.unit.fixtures.platform.mock_observations import (
     GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_0,
     GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_COMP,
     GET_OBSERVATIONS_DETAIL_JOB_RESULTS_RESP,
+    GET_OBSERVATIONS_DETAIL_JOB_RESULTS_FOR_DEOBFUSCATE,
+    OBS_DEOBFUSCATE_CMDLINE_REQUEST,
+    OBS_DEOBFUSCATE_CMDLINE_RESPONSE,
     GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP,
     GET_OBSERVATIONS_SEARCH_JOB_RESULTS_NO_RULE_ID_RESP,
     POST_OBSERVATIONS_FACET_SEARCH_JOB_RESP,
@@ -660,6 +663,29 @@ def test_observations_still_querying2(cbcsdk_mock):
     api = cbcsdk_mock.api
     obs_list = api.select(Observation).where(process_pid=1000)
     assert obs_list._still_querying() is True
+
+
+def test_observation_deobfuscate_cmdline(cbcsdk_mock):
+    """Test the deobfuscate_cmdline() function."""
+    def on_post_deobfuscate(url, body, **kwargs):
+        assert body == OBS_DEOBFUSCATE_CMDLINE_REQUEST
+        return OBS_DEOBFUSCATE_CMDLINE_RESPONSE
+
+    cbcsdk_mock.mock_request("POST", "/api/investigate/v2/orgs/test/observations/detail_jobs",
+                             POST_OBSERVATIONS_SEARCH_JOB_RESP)
+    cbcsdk_mock.mock_request("GET",
+        "/api/investigate/v2/orgs/test/observations/detail_jobs/08ffa932-b633-4107-ba56-8741e929e48b/results",
+        GET_OBSERVATIONS_DETAIL_JOB_RESULTS_FOR_DEOBFUSCATE)
+    cbcsdk_mock.mock_request("POST", "/tau/v2/orgs/test/reveal", on_post_deobfuscate)
+
+    api = cbcsdk_mock.api
+    obs = Observation(api, initial_data={"observation_id": "test"})
+    observation = obs._get_detailed_results()
+    deobfuscation = observation.deobfuscate_cmdline()
+    assert len(deobfuscation['identities']) == 1
+    assert len(deobfuscation['strings']) == 1
+    assert deobfuscation['deobfuscated_code'] == \
+           "Write-Output \"No matter how thin you slice it, it's still baloney.\"\n"
 
 
 # --------------------- ObservationFacet --------------------------------------

--- a/src/tests/unit/platform/test_observations.py
+++ b/src/tests/unit/platform/test_observations.py
@@ -673,7 +673,8 @@ def test_observation_deobfuscate_cmdline(cbcsdk_mock):
 
     cbcsdk_mock.mock_request("POST", "/api/investigate/v2/orgs/test/observations/detail_jobs",
                              POST_OBSERVATIONS_SEARCH_JOB_RESP)
-    cbcsdk_mock.mock_request("GET",
+    cbcsdk_mock.mock_request(
+        "GET",
         "/api/investigate/v2/orgs/test/observations/detail_jobs/08ffa932-b633-4107-ba56-8741e929e48b/results",
         GET_OBSERVATIONS_DETAIL_JOB_RESULTS_FOR_DEOBFUSCATE)
     cbcsdk_mock.mock_request("POST", "/tau/v2/orgs/test/reveal", on_post_deobfuscate)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-5079

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added the `deobfuscate_cmdline()` helper function to the `Observation` class.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit test added for new function; coverage in `observations.py` is 96%.  Run against an example `Observation` on `prod02`.