### PR TITLE
Add deployment_type as part of DeviceSearchQuery facets

### DIFF
--- a/src/cbc_sdk/platform/devices.py
+++ b/src/cbc_sdk/platform/devices.py
@@ -395,6 +395,8 @@ class DeviceFacet(UnrefreshableModel):
                 query.set_auto_scaling_group_name([self.id])
             elif self._outer.field == "virtual_private_cloud_id":
                 query.set_virtual_private_cloud_id([self.id])
+            elif self._outer.field == "deployment_type":
+                query.set_deployment_type([self.id])
             return query
 
     @classmethod
@@ -447,7 +449,7 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
     VALID_PRIORITIES = ["LOW", "MEDIUM", "HIGH", "MISSION_CRITICAL"]
     VALID_DEPLOYMENT_TYPES = ["ENDPOINT", "WORKLOAD", "VDI", "AWS", "AZURE", "GCP"]
     VALID_FACET_FIELDS = ["policy_id", "status", "os", "ad_group_id", "cloud_provider_account_id",
-                          "auto_scaling_group_name", "virtual_private_cloud_id"]
+                          "auto_scaling_group_name", "virtual_private_cloud_id", "deployment_type"]
 
     def __init__(self, doc_class, cb):
         """


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
#397


## Pull Request Description
Add deployment_type field to the facets for DeviceSearchQuery. This will help to get numbers for the different deployment types easily.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Not at the CBC SDK level, but yes at API backend level. Since, as you can see below, the response of the API is HTTP 400.

## How Has This Been Tested?
With this small code snippet:

```
from cbc_sdk import CBCloudAPI
from cbc_sdk.platform import Device, DeviceFacet

import logging
import requests

cb_api = CBCloudAPI(profile='devices')
 
try:
    device_facets = cb_api.select(Device).set_status(["ALL"]).facets(['deployment_type'])
    print(device_facets)
except Exception as er:
    logging.error(er)
```

Response from backend:
```
ERROR:root:Received error code 400 from API: {"error_code":"MALFORMED_JSON","message":"Malformed JSON input: Cannot deserialize value of type `com.scargo.domainmodel.entity.support.DeviceFacetType` from String \"deployment_type\": not one of the values accepted for Enum class: [OS, GOLDEN_DEVICE_STATUS, POLICY_ID, VCENTER_HOST_URL, INFRASTRUCTURE_PROVIDER, GOLDEN_DEVICE_ID, SENSOR_GATEWAY_URL, CLOUD_PROVIDER_ACCOUNT_ID, STATUS, AUTO_SCALING_GROUP_NAME, SUB_DEPLOYMENT_TYPE, VIRTUALIZATION_PROVIDER, SIGNATURE_STATUS, CLOUD_PROVIDER_TAGS, HOST_BASED_FIREWALL_STATUS, SENSOR_VERSION, VIRTUAL_PRIVATE_CLOUD_ID, AD_GROUP_ID, OS_VERSION]\n at [Source: (org.springframework.util.StreamUtils$NonClosingInputStream); line: 1, column: 56] (through reference chain: com.scargo.domainmodel.v6.request.device.DeviceStatsFacetRequest[\"terms\"]->com.carbonblack.psc.apicore.request.facet.FacetTerm[\"fields\"]->java.util.ArrayList[0])","field":"terms.fields.null"}
```
