### PR TITLE
CBAPI-4251: Add Dynamic Criteria support to Asset Groups

### DIFF
--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -75,7 +75,7 @@ class AssetGroup(MutableBaseModel):
         return AssetGroupQuery(cls, cb)
 
     @classmethod
-    def create_group(cls, cb, name, description, policy_id):
+    def create_group(cls, cb, name, description, policy_id, query=None):
         """
         Create a new asset group.
 
@@ -87,11 +87,13 @@ class AssetGroup(MutableBaseModel):
             name (str): Name for the new asset group.
             description (str): Description for the new asset group.
             policy_id (int): ID of the policy to be associated with this asset group.
+            query (str): Query string to be used to dynamically populate this group. Default is ``None``.
 
         Returns:
             AssetGroup: The new asset group.
         """
-        group_data = {"name": name, "description": description, "member_type": "DEVICE", "policy_id": policy_id}
+        group_data = {"name": name, "description": description, "member_type": "DEVICE",
+                      "query": "" if query is None else query, "policy_id": policy_id}
         group = AssetGroup(cb, None, group_data, False, True)
         group.save()
         return group

--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -11,7 +11,22 @@
 # * WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
 # * NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
 
-"""Asset groups implementation as part of Platform API"""
+"""
+The model and query classes for referencing asset groups.
+
+An *asset group* represents a group of devices (endpoints, VM workloads, and/or VDIs) that can have a single policy
+applied to it so the protections of all similar assets are synchronized with one another.  Policies carry a "position"
+value as one of their attributes, so that, between the policy attached directly to the device, and the policies
+attached to any asset groups the device is a member of, the one with the highest "position" is the one that applies to
+that device.  Devices may be added to an asset group either explicitly, or implicitly by specifying a query on the
+asset group, such that all devices matching that search criteria are considered part of the asset group.
+
+Typical usage example:
+
+    # assume "cb" is an instance of CBCloudAPI
+    query = cb.select(AssetGroup).where('name:"HQ Devices"')
+    group = query.first()
+"""
 
 from cbc_sdk.base import (MutableBaseModel, BaseQuery, QueryBuilder, QueryBuilderSupportMixin, IterableQueryMixin,
                           CriteriaBuilderSupportMixin, AsyncQueryMixin)
@@ -20,7 +35,12 @@ from cbc_sdk.platform.devices import DeviceSearchQuery
 
 
 class AssetGroup(MutableBaseModel):
-    """Represents an asset group within the organization."""
+    """
+    Represents an asset group within the current organization in the Carbon Black Cloud.
+
+    ``AssetGroup`` objects are typically located via a search (using ``AssetGroupQuery``) before they can be operated
+     on. They may also be created on the Carbon Black Cloud by using the ``create_group()`` class method.
+    """
     urlobject = "/asset_groups/v1beta/orgs/{0}/groups"
     urlobject_single = "/asset_groups/v1beta/orgs/{0}/groups/{1}"
     primary_key = "id"
@@ -28,10 +48,10 @@ class AssetGroup(MutableBaseModel):
 
     def __init__(self, cb, model_unique_id=None, initial_data=None, force_init=False, full_doc=False):
         """
-        Initialize the AssetGroup object.
+        Initialize the ``AssetGroup`` object.
 
         Required Permissions:
-            gm.group-set (READ)
+            gm.group-set(READ)
 
         Args:
             cb (BaseAPI): Reference to API object used to communicate with the server.
@@ -80,7 +100,7 @@ class AssetGroup(MutableBaseModel):
         Create a new asset group.
 
         Required Permissions:
-            gm.group-set (CREATE)
+            gm.group-set(CREATE)
 
         Args:
             cb (BaseAPI): Reference to API object used to communicate with the server.
@@ -101,10 +121,15 @@ class AssetGroup(MutableBaseModel):
 
 class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, CriteriaBuilderSupportMixin,
                       AsyncQueryMixin):
-    """Represents a query used to locate AssetGroup objects."""
+    """
+    Query object that is used to locate ``AssetGroup`` objects.
+
+    The ``AssetGroupQuery`` is constructed via SDK functions like the ``select()`` method on ``CBCloudAPI``.
+    The user would then add a query and/or criteria to it before iterating over the results.
+    """
     def __init__(self, doc_class, cb):
         """
-        Initialize the AssetGroupQuery.
+        Initialize the ``AssetGroupQuery``.
 
         Args:
             doc_class (class): The model class that will be returned by this query.
@@ -125,7 +150,7 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
         Set the "discovered" flag in the search criteria.
 
         Args:
-            discovered (bool): True to locate only discovered asset groups, False to locate only undiscovered.
+            discovered (bool): ``True`` to locate only discovered asset groups, ``False`` to locate only undiscovered.
 
         Returns:
             AssetGroupQuery: This instance.
@@ -193,7 +218,7 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
         Args:
             from_row (int): The row to start the query at.
             max_rows (int): The maximum number of rows to be returned.
-            add_sort (bool): If True(default), the sort criteria will be added as part of the request.
+            add_sort (bool): If ``True`` (default), the sort criteria will be added as part of the request.
 
         Returns:
             dict: The complete request body.
@@ -222,12 +247,7 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
         return url
 
     def _count(self):
-        """
-        Returns the number of results from the run of this query.
-
-        Returns:
-            int: The number of results from the run of this query.
-        """
+        """Returns the number of results from the run of this query."""
         if self._count_valid:
             return self._total_results
 
@@ -244,6 +264,9 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
     def _perform_query(self, from_row=1, max_rows=-1):
         """
         Performs the query and returns the results of the query in an iterable fashion.
+
+        Required Permissions:
+            group-management(READ)
 
         Args:
             from_row (int): The row to start the query at (default 1).
@@ -284,13 +307,13 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
         Executed in the background to run an asynchronous query.
 
         Required Permissions:
-
+            group-management(READ)
 
         Args:
-            context (object): Not used; always None.
+            context (object): Not used; always ``None``.
 
         Returns:
-            list[AssetGroup]: Result of the async query, as a list of AssetGroup objects.
+            list[AssetGroup]: Result of the async query, as a list of ``AssetGroup`` objects.
         """
         url = self._build_url("/_search")
         request = self._build_request(0, -1)

--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -21,7 +21,7 @@ attached to any asset groups the device is a member of, the one with the highest
 that device.  Devices may be added to an asset group either explicitly, or implicitly by specifying a query on the
 asset group, such that all devices matching that search criteria are considered part of the asset group.
 
-Typical usage example:
+Typical usage example::
 
     # assume "cb" is an instance of CBCloudAPI
     query = cb.select(AssetGroup).where('name:"HQ Devices"')
@@ -51,7 +51,7 @@ class AssetGroup(MutableBaseModel):
         Initialize the ``AssetGroup`` object.
 
         Required Permissions:
-            gm.group-set(READ)
+            group-management(READ)
 
         Args:
             cb (BaseAPI): Reference to API object used to communicate with the server.
@@ -95,26 +95,34 @@ class AssetGroup(MutableBaseModel):
         return AssetGroupQuery(cls, cb)
 
     @classmethod
-    def create_group(cls, cb, name, description, policy_id, query=None):
+    def create_group(cls, cb, name, description, **kwargs):
         """
         Create a new asset group.
 
         Required Permissions:
-            gm.group-set(CREATE)
+            group-management(CREATE)
 
         Args:
             cb (BaseAPI): Reference to API object used to communicate with the server.
             name (str): Name for the new asset group.
             description (str): Description for the new asset group.
-            policy_id (int): ID of the policy to be associated with this asset group.
+            kwargs (dict): Keyword arguments, as defined below.
+
+        Keyword Args:
+            policy_id (int): ID of the policy to be associated with this asset group. Default is ``None``.
             query (str): Query string to be used to dynamically populate this group. Default is ``None``,
                 which means devices _must_ be manually assigned to the group.
 
         Returns:
             AssetGroup: The new asset group.
         """
-        group_data = {"name": name, "description": description, "member_type": "DEVICE",
-                      "query": "" if query is None else query, "policy_id": policy_id}
+        group_data = {"name": name, "description": description, "member_type": "DEVICE"}
+        policy_id = kwargs.get("policy_id", None)
+        if policy_id:
+            group_data["policy_id"] = policy_id
+        query = kwargs.get("query", None)
+        if query:
+            group_data["query"] = query
         group = AssetGroup(cb, None, group_data, False, True)
         group.save()
         return group

--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -107,7 +107,8 @@ class AssetGroup(MutableBaseModel):
             name (str): Name for the new asset group.
             description (str): Description for the new asset group.
             policy_id (int): ID of the policy to be associated with this asset group.
-            query (str): Query string to be used to dynamically populate this group. Default is ``None``.
+            query (str): Query string to be used to dynamically populate this group. Default is ``None``,
+                which means devices _must_ be manually assigned to the group.
 
         Returns:
             AssetGroup: The new asset group.

--- a/src/cbc_sdk/platform/models/asset_group.yaml
+++ b/src/cbc_sdk/platform/models/asset_group.yaml
@@ -2,41 +2,44 @@ type: object
 properties:
   id:
     type: string
-    description: The asset group identifier
+    description: The asset group identifier.
   name:
     type: string
-    description: The asset group name
+    description: The asset group name.
   description:
     type: string
-    description: The asset group description
+    description: The asset group description.
   org_key:
     type: string
-    description: The organization key of the owning organization
+    description: The organization key of the owning organization.
   status:
     type: string
-    description: Status of the group
+    description: Status of the group.
   member_type:
     type: string
-    description: The type of objects this asset group contains
+    description: The type of objects this asset group contains.
     enum:
       - DEVICE
   discovered:
     type: boolean
-    description: Whether this group has been discovered
+    description: Whether this group has been discovered.
   create_time:
     type: string
     format: date-time
-    description: Date and time the group was created
+    description: Date and time the group was created.
   update_time:
     type: string
     format: date-time
-    description: Date and time the group was last updated
+    description: Date and time the group was last updated.
   member_count:
     type: integer
-    description: Number of members in this group
+    description: Number of members in this group.
   policy_id:
     type: integer
-    description: ID of the policy associated with this group
+    description: ID of the policy associated with this group.
   policy_name:
     type: string
-    description: Name of the policy associated with this group
+    description: Name of the policy associated with this group.
+  query:
+    type: string
+    description: Search query used to determine which assets are included in the group membership.

--- a/src/tests/unit/fixtures/platform/mock_asset_groups.py
+++ b/src/tests/unit/fixtures/platform/mock_asset_groups.py
@@ -5,7 +5,8 @@ CREATE_AG_REQUEST = {
     "description": "Group Test Description",
     "member_type": "DEVICE",
     "name": "Group Test",
-    "policy_id": 7113785
+    "policy_id": 7113785,
+    "query": "os_version:Windows"
 }
 
 CREATE_AG_RESPONSE = {
@@ -18,6 +19,7 @@ CREATE_AG_RESPONSE = {
     "discovered": False,
     "create_time": "2022-11-09T06:27:30.734Z",
     "update_time": "2022-11-09T06:27:30.734Z",
+    "query": "os_version:Windows",
     "member_count": 0,
     "policy_id": 7113785,
     "policy_name": "Monitored"
@@ -33,6 +35,7 @@ EXISTING_AG_DATA = {
     "discovered": False,
     "create_time": "2022-11-09T06:27:30.734Z",
     "update_time": "2022-11-09T06:27:30.734Z",
+    "query": None,
     "member_count": 0,
     "policy_id": 8675309,
     "policy_name": "Jenny"
@@ -48,6 +51,7 @@ UPDATE_AG_REQUEST = {
     "discovered": False,
     "create_time": "2022-11-09T06:27:30.734Z",
     "update_time": "2022-11-09T06:27:30.734Z",
+    "query": None,
     "member_count": 0,
     "policy_id": 9001,
     "policy_name": "Jenny"
@@ -89,6 +93,7 @@ QUERY_RESPONSE = {
             "discovered": False,
             "create_time": "2022-09-05T13:12:31.848Z",
             "update_time": "2022-09-05T13:12:31.848Z",
+            "query": None,
             "member_count": 0,
             "policy_id": 7113785,
             "policy_name": "Monitored"

--- a/src/tests/unit/platform/test_asset_groups.py
+++ b/src/tests/unit/platform/test_asset_groups.py
@@ -54,7 +54,8 @@ def test_create_asset_group(cbcsdk_mock):
 
     cbcsdk_mock.mock_request('POST', '/asset_groups/v1beta/orgs/test/groups', on_post)
     api = cbcsdk_mock.api
-    group = AssetGroup.create_group(api, "Group Test", "Group Test Description", 7113785, "os_version:Windows")
+    group = AssetGroup.create_group(api, "Group Test", "Group Test Description", policy_id=7113785,
+                                    query="os_version:Windows")
     assert posted
     assert group is not None
     assert group.id == '4b48a403-e371-4e3d-ae6c-8eb9080fe7ad'

--- a/src/tests/unit/platform/test_asset_groups.py
+++ b/src/tests/unit/platform/test_asset_groups.py
@@ -54,13 +54,14 @@ def test_create_asset_group(cbcsdk_mock):
 
     cbcsdk_mock.mock_request('POST', '/asset_groups/v1beta/orgs/test/groups', on_post)
     api = cbcsdk_mock.api
-    group = AssetGroup.create_group(api, "Group Test", "Group Test Description", 7113785)
+    group = AssetGroup.create_group(api, "Group Test", "Group Test Description", 7113785, "os_version:Windows")
     assert posted
     assert group is not None
     assert group.id == '4b48a403-e371-4e3d-ae6c-8eb9080fe7ad'
     assert group.name == 'Group Test'
     assert group.description == 'Group Test Description'
     assert group.policy_id == 7113785
+    assert group.query == "os_version:Windows"
 
 
 def test_find_and_update_asset_group(cbcsdk_mock):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-4251

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added dynamic criteria support (the `query` attribute) to the asset groups.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been modified to use the `query` attribute throughout, especially when testing `create_group()`. Coverage for the file stands at 97%.