### PR TITLE
CBAPI-5148: Asset Groups - Search (bugfix / update)

### DIFF
--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -1656,7 +1656,7 @@ class CriteriaBuilderSupportMixin:
             >>> query = api.select(Alert).add_criteria("type", "CB_ANALYTIC")
         """
         if not isinstance(newlist, list):
-            if not isinstance(newlist, str) and not isinstance(newlist, int):
+            if not isinstance(newlist, str) and not isinstance(newlist, int) and not isinstance(newlist, bool):
                 raise ApiError("Criteria value(s) must be a string, int or list of strings or ints. "
                                f"{newlist} is a {type(newlist)}.")
             self._update_criteria(key, [newlist], overwrite=True)

--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -135,6 +135,13 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
 
     The ``AssetGroupQuery`` is constructed via SDK functions like the ``select()`` method on ``CBCloudAPI``.
     The user would then add a query and/or criteria to it before iterating over the results.
+
+    The following criteria are supported on ``AssetGroupQuery`` via the standard ``add_criteria()`` method:
+
+    * ``discovered: bool`` - Whether the asset group has been discovered or not.
+    * ``name: str`` - The asset group name to be matched.
+    * ``policy_id: int`` - The policy ID to be matched, expressed as an integer.
+    * ``group_id: str`` - The asset group ID to be matched, expressed as a GUID.
     """
     def __init__(self, doc_class, cb):
         """
@@ -153,53 +160,6 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
         self._sortcriteria = {}
         self._count_valid = False
         self._total_results = 0
-
-    def set_discovered(self, discovered):
-        """
-        Set the "discovered" flag in the search criteria.
-
-        Args:
-            discovered (bool): ``True`` to locate only discovered asset groups, ``False`` to locate only undiscovered.
-
-        Returns:
-            AssetGroupQuery: This instance.
-        """
-        if not isinstance(discovered, bool):
-            raise ApiError("discovered flag must be Boolean")
-        self._update_criteria("discovered", [discovered], True)
-        return self
-
-    def set_name(self, name):
-        """
-        Set the name(s) of asset groups to search for.
-
-        Args:
-            name (str|list[str]): Either a single string name or a list of string names.
-
-        Returns:
-            AssetGroupQuery: This instance.
-        """
-        self.update_criteria("name", name)
-        return self
-
-    def set_policy_id(self, policy_id):
-        """
-        Sets the policy ID(s) of asset groups to search for.
-
-        Args:
-            policy_id (int|list[int]): Either a single policy ID or a list of policy IDs.
-
-        Returns:
-            AssetGroupQuery: This instance.
-        """
-        if isinstance(policy_id, list):
-            real_policy_id = policy_id
-        elif isinstance(policy_id, int):
-            real_policy_id = [policy_id]
-        else:
-            raise ApiError("policy id must be int or list of ints")
-        self._update_criteria("policy_id", real_policy_id)
-        return self
 
     def sort_by(self, key, direction="ASC"):
         """

--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -158,8 +158,22 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
         self._query_builder = QueryBuilder()
         self._criteria = {}
         self._sortcriteria = {}
+        self._default_rows = 100
         self._count_valid = False
         self._total_results = 0
+
+    def set_rows(self, rows):
+        """
+        Sets the number of query rows to fetch in each batch from the server.
+
+        Args:
+             rows (int): The number of rows to be fetched fromt hes erver at a time. Default is 100.
+
+        Returns:
+            AssetGroupQuery: This instance.
+        """
+        self._default_rows = rows
+        return self
 
     def sort_by(self, key, direction="ASC"):
         """
@@ -192,8 +206,7 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
         Returns:
             dict: The complete request body.
         """
-        # Fetch 100 rows per page (instead of 10 by default) for better performance
-        request = {"rows": 100}
+        request = {"rows": self._default_rows}
         if len(self._criteria) > 0:
             request["criteria"] = self._criteria
         query = self._query_builder._collapse()

--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -41,8 +41,8 @@ class AssetGroup(MutableBaseModel):
     ``AssetGroup`` objects are typically located via a search (using ``AssetGroupQuery``) before they can be operated
      on. They may also be created on the Carbon Black Cloud by using the ``create_group()`` class method.
     """
-    urlobject = "/asset_groups/v1beta/orgs/{0}/groups"
-    urlobject_single = "/asset_groups/v1beta/orgs/{0}/groups/{1}"
+    urlobject = "/asset_groups/v1/orgs/{0}/groups"
+    urlobject_single = "/asset_groups/v1/orgs/{0}/groups/{1}"
     primary_key = "id"
     swagger_meta_file = "platform/models/asset_group.yaml"
 

--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -233,8 +233,13 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
             dict: The complete request body.
         """
         # Fetch 100 rows per page (instead of 10 by default) for better performance
-        request = {"criteria": self._criteria, "query": self._query_builder._collapse(), "rows": 100}
-        if from_row > 0:
+        request = {"rows": 100}
+        if len(self._criteria) > 0:
+            request["criteria"] = self._criteria
+        query = self._query_builder._collapse()
+        if query:
+            request["query"] = query
+        if from_row >= 0:
             request["start"] = from_row
         if max_rows >= 0:
             request["rows"] = max_rows
@@ -270,7 +275,7 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
 
         return self._total_results
 
-    def _perform_query(self, from_row=1, max_rows=-1):
+    def _perform_query(self, from_row=0, max_rows=-1):
         """
         Performs the query and returns the results of the query in an iterable fashion.
 
@@ -278,7 +283,7 @@ class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
             group-management(READ)
 
         Args:
-            from_row (int): The row to start the query at (default 1).
+            from_row (int): The row to start the query at (default 0).
             max_rows (int): The maximum number of rows to be returned (default -1, meaning "all").
 
         Returns:

--- a/src/tests/unit/fixtures/platform/mock_asset_groups.py
+++ b/src/tests/unit/fixtures/platform/mock_asset_groups.py
@@ -68,6 +68,9 @@ QUERY_REQUEST = {
         ],
         "discovered": [
             False
+        ],
+        "group_id": [
+            "9b8b8d84-4a44-4a94-81ec-1f8ef52d4430"
         ]
     },
     "rows": 100,

--- a/src/tests/unit/fixtures/platform/mock_asset_groups.py
+++ b/src/tests/unit/fixtures/platform/mock_asset_groups.py
@@ -77,7 +77,7 @@ QUERY_REQUEST = {
             "order": "ASC"
         }
     ],
-    "start": 1
+    "start": 0
 }
 
 QUERY_RESPONSE = {

--- a/src/tests/unit/fixtures/platform/mock_asset_groups.py
+++ b/src/tests/unit/fixtures/platform/mock_asset_groups.py
@@ -73,13 +73,18 @@ QUERY_REQUEST = {
             "9b8b8d84-4a44-4a94-81ec-1f8ef52d4430"
         ]
     },
-    "rows": 100,
+    "rows": 42,
     "sort": [
         {
             "field": "name",
             "order": "ASC"
         }
     ],
+    "start": 0
+}
+
+QUERY_REQUEST_DEFAULT = {
+    "rows": 100,
     "start": 0
 }
 

--- a/src/tests/unit/platform/test_asset_groups.py
+++ b/src/tests/unit/platform/test_asset_groups.py
@@ -52,7 +52,7 @@ def test_create_asset_group(cbcsdk_mock):
         posted = True
         return CREATE_AG_RESPONSE
 
-    cbcsdk_mock.mock_request('POST', '/asset_groups/v1beta/orgs/test/groups', on_post)
+    cbcsdk_mock.mock_request('POST', '/asset_groups/v1/orgs/test/groups', on_post)
     api = cbcsdk_mock.api
     group = AssetGroup.create_group(api, "Group Test", "Group Test Description", policy_id=7113785,
                                     query="os_version:Windows")
@@ -75,9 +75,9 @@ def test_find_and_update_asset_group(cbcsdk_mock):
         did_put = True
         return copy.deepcopy(body)
 
-    cbcsdk_mock.mock_request('GET', '/asset_groups/v1beta/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16',
+    cbcsdk_mock.mock_request('GET', '/asset_groups/v1/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16',
                              copy.deepcopy(EXISTING_AG_DATA))
-    cbcsdk_mock.mock_request('PUT', '/asset_groups/v1beta/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16',
+    cbcsdk_mock.mock_request('PUT', '/asset_groups/v1/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16',
                              on_put)
     api = cbcsdk_mock.api
     group = api.select(AssetGroup, 'db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16')
@@ -104,9 +104,9 @@ def test_find_and_delete_asset_group(cbcsdk_mock):
         did_delete = True
         return CBCSDKMock.StubResponse(None, scode=200)
 
-    cbcsdk_mock.mock_request('GET', '/asset_groups/v1beta/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16',
+    cbcsdk_mock.mock_request('GET', '/asset_groups/v1/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16',
                              copy.deepcopy(EXISTING_AG_DATA))
-    cbcsdk_mock.mock_request('DELETE', '/asset_groups/v1beta/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16',
+    cbcsdk_mock.mock_request('DELETE', '/asset_groups/v1/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16',
                              on_delete)
     api = cbcsdk_mock.api
     group = api.select(AssetGroup, 'db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16')
@@ -134,7 +134,7 @@ def test_query_with_all_options(cbcsdk_mock, name, polid):
         assert tbody == QUERY_REQUEST
         return QUERY_RESPONSE
 
-    cbcsdk_mock.mock_request('POST', '/asset_groups/v1beta/orgs/test/groups/_search', on_post)
+    cbcsdk_mock.mock_request('POST', '/asset_groups/v1/orgs/test/groups/_search', on_post)
     api = cbcsdk_mock.api
     query = api.select(AssetGroup).where("test").set_discovered(False).set_name(name).set_policy_id(polid)
     query.sort_by("name", "ASC")
@@ -157,7 +157,7 @@ def test_query_async(cbcsdk_mock):
         assert tbody == QUERY_REQUEST
         return QUERY_RESPONSE
 
-    cbcsdk_mock.mock_request('POST', '/asset_groups/v1beta/orgs/test/groups/_search', on_post)
+    cbcsdk_mock.mock_request('POST', '/asset_groups/v1/orgs/test/groups/_search', on_post)
     api = cbcsdk_mock.api
     query = api.select(AssetGroup).where("test").set_discovered(False).set_name("Group Test").set_policy_id(7113785)
     query.sort_by("name", "ASC")


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-5148

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Bugfixes and enhancements to Asset Groups Search as follows:

* All URLs have been modified to contain `v1` instead of `v1beta` as a version indicator.
* In queries, the `start` parameter defaults to 0 instead of 1.
* `criteria` and `query` are elided from search parameters if they're empty.
* All "discrete" criteria functions have been removed, `add_criteria()` will be used to manage criteria on `AssetGroupQuery` exclusively. Documentation has been added to `AssetGroupQuery` class docstring showing which criteria are valid, including the new `group_id` criteria.
* A `set_rows()` method has been added allowing the default number of rows in a batch to be set (defaults to 100).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
No breaking change since Asset Groups has not yet been released.

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been added and/or modified to cover the updates to the code.