### PR TITLE
[PENDING] Grouped alert build request

### DIFF
--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -1586,7 +1586,8 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
         Returns:
             dict: The complete request body.
         """
-        request = super()._build_request(from_row, max_rows, add_sort=True)
+        # request = super()._build_request(from_row, max_rows, add_sort=True)
+        request = super(GroupedAlertSearchQuery, self)._build_request(from_row, max_rows, add_sort=True)
         request["group_by"] = {"field": self._group_by}
         return request
 
@@ -1636,29 +1637,14 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
 
     def close(self, closure_reason=None, determination=None, note=None, ):
         """
-        Close all alerts matching the given query. The alerts will be left in a CLOSED state after this request.
-
-        Args:
-            closure_reason (str): the closure reason for this alert, either "NO_REASON", "RESOLVED", \
-            "RESOLVED_BENIGN_KNOWN_GOOD", "DUPLICATE_CLEANUP", "OTHER"
-            determination (str): The determination status to set for the alert, either "TRUE_POSITIVE", \
-            "FALSE_POSITIVE", or "NONE"
-            note (str): The comment to set for the alert.
-
-        Returns:
-            Job: The Job object for the bulk workflow action.
+        Closing all alerts matching a grouped alert query is not implemented.
 
         Note:
-            - This is an asynchronus call that returns a Job. If you want to wait and block on the results
-              you can call await_completion() to get a Futre then result() on the future object to wait for
-              completion and get the results.
+            - Closing all alerts in all groups returned by a ``GroupedAlertSearchQuery`` can be done by
+            getting the ``AlertSearchQuery`` and using close() on it as shown in the following example.
 
         Example:
-            >>> grouped_alert_query = cb.select(GroupedAlert).set_minimum_severity(1)
-            >>> job = grouped_alert_query.close("RESOLVED", "FALSE_POSITIVE", "Normal behavior")
-            >>> completed_job = job.await_completion().result()
+            >>> alert_query = grouped_alert_query.get_alert_search_query()
+            >>> alert_query.close(closure_reason, note, determination)
         """
-        # Close operates on an Alert Query.  Get that from the Grouped Alert Query.
-        alert_query = self.get_alert_search_query()
-        # Initiate the Close Alert job for the Alert Query.
-        return alert_query._update_status("CLOSED", closure_reason, note, determination)
+        raise NotImplementedError("this method is not implemented")

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -1607,7 +1607,6 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
         still_querying = True
         while still_querying:
             request = self._build_request(current, max_rows)
-            request["group_by"] = {"field": self._group_by}
             resp = self._cb.post_object(url, body=request)
             result = resp.json()
 
@@ -1659,5 +1658,7 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
             >>> job = grouped_alert_query.close("RESOLVED", "FALSE_POSITIVE", "Normal behavior")
             >>> completed_job = job.await_completion().result()
         """
+        # Close operates on an Alert Query.  Get that from the Grouped Alert Query.
         alert_query = self.get_alert_search_query()
+        # Initiate the Close Alert job for the Alert Query.
         return alert_query._update_status("CLOSED", closure_reason, note, determination)

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -1993,3 +1993,76 @@ def test_group_alert_bulk_dismiss_workflow(cbcsdk_mock):
     group_alert_query = api.select(GroupedAlert).add_criteria("type", ["CB_ANALYTICS"])
     job = group_alert_query.close("OTHER", "TRUE_POSITIVE", "Note about the determination")
     assert isinstance(job, Job)
+
+
+def test_grouped_alert_build_query(cbcsdk_mock):
+    """Test that grouped alert builds the query correctly when using len() to get the number of results."""
+
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "group_by": {
+                "field": "THREAT_ID"
+            },
+            "time_range": {
+                "range": "-10d"
+            },
+            "criteria": {
+                "type": [
+                    "WATCHLIST"
+                ],
+                "minimum_severity": 1
+            },
+            "rows": 1,
+            "sort": [
+                {
+                    "field": "count",
+                    "order": "DESC"
+                }
+            ]
+        }
+        return {
+            "num_found": 25,
+            "num_available": 25,
+            "results": [
+                {
+                    "count": 994,
+                    "workflow_states": {
+                        "CLOSED": 1,
+                        "OPEN": 993
+                    },
+                    "determination_values": {
+                        "NONE": 994
+                    },
+                    "ml_classification_final_verdicts": {
+                        "NOT_CLASSIFIED": 4,
+                        "NOT_ANOMALOUS": 982,
+                        "ANOMALOUS": 8
+                    },
+                    "first_alert_timestamp": "2023-11-21T21:24:37.756Z",
+                    "last_alert_timestamp": "2023-12-01T21:00:42.937Z",
+                    "highest_severity": 7,
+                    "policy_applied": "NOT_APPLIED",
+                    "threat_notes_present": False,
+                    "tags": [],
+                    "device_count": 10,
+                    "workload_count": 0,
+                    "most_recent_alert": {
+                        "org_key": "ABCD1234",
+                        "alert_url": "defense.conferdeploy.net/alerts?s[c]"
+                                     "[query_string]=id:9d7f0692-e9cc-4ecc-9983-b063f1455cab&orgKey=ABCD1234",
+                        "id": "9d7f0692-e9cc-4ecc-9983-b063f1455cab",
+                        "type": "WATCHLIST",
+                        "severity": 7,
+                    }
+                }
+            ],
+            "group_by_total_count": 6421
+        }
+
+    cbcsdk_mock.mock_request("POST", "/api/alerts/v7/orgs/test/grouped_alerts/_search", on_post)
+    api = cbcsdk_mock.api
+
+    grouped_alert_query = api.select(GroupedAlert).set_minimum_severity(1).set_time_range(range="-10d")\
+        .add_criteria("type", "WATCHLIST").set_rows(1).sort_by("count", "DESC")
+
+    len(grouped_alert_query)

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -1970,29 +1970,12 @@ def test_group_alert_set_group_by(cbcsdk_mock):
     grouped_alerts.first()
 
 
-def test_group_alert_bulk_dismiss_workflow(cbcsdk_mock):
-    """Test closing a group alert job."""
-    def on_post(url, body, **kwargs):
-        assert body == {
-            "criteria": {
-                "type": ["CB_ANALYTICS"]
-            },
-            "determination": "TRUE_POSITIVE",
-            "closure_reason": "OTHER",
-            "status": "CLOSED",
-            "note": "Note about the determination"
-        }
-        return {
-            "request_id": "666666"
-        }
-
-    cbcsdk_mock.mock_request("POST", "/api/alerts/v7/orgs/test/alerts/workflow", on_post)
-    cbcsdk_mock.mock_request("GET", "/jobs/v1/orgs/test/jobs/666666", GET_CLOSE_WORKFLOW_JOB_RESP)
+def test_group_alert_bulk_close_workflow(cbcsdk_mock):
+    """Test closing a group alert job. Will raise a not implemented exception"""
     api = cbcsdk_mock.api
-
-    group_alert_query = api.select(GroupedAlert).add_criteria("type", ["CB_ANALYTICS"])
-    job = group_alert_query.close("OTHER", "TRUE_POSITIVE", "Note about the determination")
-    assert isinstance(job, Job)
+    group_alert_query = api.select(GroupedAlert)
+    with pytest.raises(NotImplementedError):
+        group_alert_query.close("OTHER", "TRUE_POSITIVE", "Note about the determination")
 
 
 def test_grouped_alert_build_query(cbcsdk_mock):


### PR DESCRIPTION
## Pull request checklist
TESTS WILL NOT PASS UNTIL CBAPI-5088 (and maybe CBAPI-5087) are merged to the feature branch and available for this PR.

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [ ] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [ ] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->


## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added  and close() method to GroupedAlertSearchQuery to override the version inherited from AlertSearchQuery.

_build_request needed to include get group_by field.
This then caused the close() function to incorrectly have group_by, so the close() method also needed to be overridden.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
