### PR TITLE
New methods to convert an alertSearchQuery to a groupedAlertSearchQue…

### DIFF
--- a/examples/platform/alerts_common_scenarios.py
+++ b/examples/platform/alerts_common_scenarios.py
@@ -230,6 +230,12 @@ def main():
     alert_search_query = group_alert.get_alerts()
     print([alert for alert in alert_search_query])
 
+    # to convert an AlertSearchQuery to a GroupAlertSearchQuery, will not preserve sort order
+    group_alert_search_query = alert_search_query.set_group_by("threat_id")
+
+    # to convert a GroupAlertSearchQuery to an AlertSearchQuery, will not preserve sort order
+    alert_search_query = group_alert_search_query.get_alert_search_query()
+
 
 if __name__ == "__main__":
     # Trap keyboard interrupts while running the script.

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -986,8 +986,11 @@ class GroupedAlert(PlatformModel):
 
         Returns:
             AlertSearchQuery: for all alerts associated with the calling group alert.
+
+        Note:
+            Does not preserve sort criterion
         """
-        ignored_keys = ["_doc_class", "_cb", "_count_valid", "_total_results"]
+        ignored_keys = ["_doc_class", "_cb", "_count_valid", "_total_results", "_sortcriteria", "_query_builder"]
         alert_search_query = self._cb.select(Alert)
         for key, value in vars(alert_search_query).items():
             if hasattr(self._request, key) and key not in ignored_keys:
@@ -1585,6 +1588,31 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
             self._exclusions["remote_is_private"] = is_private
         return self
 
+    def set_group_by(self, field):
+        """
+        Converts the AlertSearchQuery to a GroupAlertSearchQuery grouped by the argument
+
+        Args:
+            field (string): The field to group by, defaults to "threat_id"
+
+        Returns:
+            AlertSearchQuery
+
+        Note:
+            Does not preserve sort criterion
+        """
+        ignored_keys = ["_doc_class", "_cb", "_count_valid", "_total_results", "_query_builder", "_sortcriteria"]
+        grouped_alert_search_query = self._cb.select(GroupedAlert)
+        for key, value in vars(grouped_alert_search_query).items():
+            if hasattr(self, key) and key not in ignored_keys:
+                setattr(grouped_alert_search_query, key, self.__getattribute__(key))
+        key = "_time_range"
+        if hasattr(self, key):
+            setattr(grouped_alert_search_query, key, self.__getattribute__(key))
+        grouped_alert_search_query.set_group_by(field)
+
+        return grouped_alert_search_query
+
 
 class GroupedAlertSearchQuery(AlertSearchQuery):
     """Represents a query that is used to group Alert objects by a given field."""
@@ -1618,6 +1646,25 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
         request = super(GroupedAlertSearchQuery, self)._build_request(from_row, max_rows, add_sort=True)
         request["group_by"] = {"field": self._group_by}
         return request
+
+    def get_alert_search_query(self):
+        """
+        Converts the GroupedAlertSearchQuery into a nongrouped AlertSearchQuery
+
+        Returns: AlertSearchQuery
+
+        Note: Does not preserve sort criterion
+        """
+        ignored_keys = ["_doc_class", "_cb", "_count_valid", "_total_results", "_query_builder", "_sortcriteria"]
+        alert_search_query = self._cb.select(Alert)
+        for key, value in vars(alert_search_query).items():
+            if hasattr(self, key) and key not in ignored_keys:
+                setattr(alert_search_query, key, self.__getattribute__(key))
+        key = "_time_range"
+        if hasattr(self, key):
+            setattr(alert_search_query, key, self.__getattribute__(key))
+
+        return alert_search_query
 
     def _perform_query(self, from_row=1, max_rows=-1):
         """

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -27,9 +27,7 @@ from cbc_sdk.platform import (
     DeviceControlAlert,
     GroupedAlert,
     Process,
-    Job,
-    AlertSearchQuery,
-    GroupedAlertSearchQuery
+    Job
 )
 from cbc_sdk.rest_api import CBCloudAPI
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
@@ -2121,7 +2119,8 @@ def test_grouped_alert_search_query_to_alert_search_query(cbcsdk_mock):
     delattr(alert_search_query, "_query_builder")
     delattr(expected_alert_search_query, "_query_builder")
 
-    assert isinstance(alert_search_query, AlertSearchQuery)
+    assert alert_search_query.__module__ == "cbc_sdk.platform.alerts" and type(alert_search_query).__name__ == \
+           "AlertSearchQuery"
     assert vars(alert_search_query) == vars(expected_alert_search_query)
 
 
@@ -2140,5 +2139,6 @@ def test_alert_search_query_to_grouped_alert_search_query(cbcsdk_mock):
     delattr(grouped_alert_search_query, "_query_builder")
     delattr(expected_grouped_alert_search_query, "_query_builder")
 
-    assert isinstance(grouped_alert_search_query, GroupedAlertSearchQuery)
+    assert grouped_alert_search_query.__module__ == "cbc_sdk.platform.alerts" and type(grouped_alert_search_query).\
+        __name__ == "GroupedAlertSearchQuery"
     assert vars(grouped_alert_search_query) == vars(expected_grouped_alert_search_query)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ x] Tests have been added that prove the fix is effective or that the feature works.
- [ x] New and existing tests pass locally with the changes.
- [ x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [ x] A self-review of the code has been done.

## What is the ticket or issue number?
[CBAPI_5088](https://jira.carbonblack.local/browse/CBAPI-5088)

## Pull Request Description
adds methods to convert from alertSearchQuery to GroupAlertSearchQuery and vice versa 


## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
example code and unit tests