### PR TITLE
Updated build request and overrode close for GroupedAlertSearchQuery

### DIFF
--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -1668,6 +1668,9 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
         """
         Closing all alerts matching a grouped alert query is not implemented.
 
+        Raises:
+            NotImplementedError: Close has not been implemented on GroupedAlertSearchQuery
+
         Note:
             - Closing all alerts in all groups returned by a ``GroupedAlertSearchQuery`` can be done by
             getting the ``AlertSearchQuery`` and using close() on it as shown in the following example.

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -1574,6 +1574,22 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
         self._group_by = field
         return self
 
+    def _build_request(self, from_row, max_rows, add_sort=True):
+        """
+        Creates the request body for an API call.
+
+        Args:
+            from_row (int): The row to start the query at.
+            max_rows (int): The maximum number of rows to be returned.
+            add_sort (bool): If True(default), the sort criteria will be added as part of the request.
+
+        Returns:
+            dict: The complete request body.
+        """
+        request = super(GroupedAlertSearchQuery, self)._build_request(from_row, max_rows, add_sort=True)
+        request["group_by"] = {"field": self._group_by}
+        return request
+
     def _perform_query(self, from_row=1, max_rows=-1):
         """
         Performs the query and returns the results of the query in an iterable fashion.
@@ -1591,7 +1607,6 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
         still_querying = True
         while still_querying:
             request = self._build_request(current, max_rows)
-            request["group_by"] = {"field": self._group_by}
             resp = self._cb.post_object(url, body=request)
             result = resp.json()
 
@@ -1618,3 +1633,17 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
             if current >= self._total_results:
                 still_querying = False
                 break
+
+    def close(self, closure_reason=None, determination=None, note=None, ):
+        """
+        Closing all alerts matching a grouped alert query is not implemented.
+
+        Note:
+            - Closing all alerts in all groups returned by a ``GroupedAlertSearchQuery`` can be done by
+            getting the ``AlertSearchQuery`` and using close() on it as shown in the following example.
+
+        Example:
+            >>> alert_query = grouped_alert_query.get_alert_search_query()
+            >>> alert_query.close(closure_reason, note, determination)
+        """
+        raise NotImplementedError("this method is not implemented")

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -2048,7 +2048,8 @@ def test_grouped_alert_build_query(cbcsdk_mock):
 
     grouped_alert_query = api.select(GroupedAlert).set_minimum_severity(1).set_time_range(range="-10d")\
         .add_criteria("type", "WATCHLIST").set_rows(1).sort_by("count", "DESC")
-    assert(len(grouped_alert_query) == 25)
+    assert len(grouped_alert_query) == 25
+
 
 def test_group_alert_to_get_alert_search_query(cbcsdk_mock):
     """Test the helper function get_alert_search_query creates the proper request."""


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests have been added that prove the fix is effective or that the feature works.
- [X] New and existing tests pass locally with the changes.
- [X] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [X] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->


## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
* _build_request for GroupedAlertSearchQuery needed to be overridden to set the group_by field.
* the Close method needed to be overridden from AlertSearchQuery to raise a not implemented exception.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Run locally and unit tests added.