### PR TITLE
Updated build_request to set group_by and overrode close

### DIFF
--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -1603,6 +1603,22 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
         self._group_by = field
         return self
 
+    def _build_request(self, from_row, max_rows, add_sort=True):
+        """
+        Creates the request body for an API call.
+
+        Args:
+            from_row (int): The row to start the query at.
+            max_rows (int): The maximum number of rows to be returned.
+            add_sort (bool): If True(default), the sort criteria will be added as part of the request.
+
+        Returns:
+            dict: The complete request body.
+        """
+        request = super(GroupedAlertSearchQuery, self)._build_request(from_row, max_rows, add_sort=True)
+        request["group_by"] = {"field": self._group_by}
+        return request
+
     def _perform_query(self, from_row=1, max_rows=-1):
         """
         Performs the query and returns the results of the query in an iterable fashion.
@@ -1620,7 +1636,6 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
         still_querying = True
         while still_querying:
             request = self._build_request(current, max_rows)
-            request["group_by"] = {"field": self._group_by}
             resp = self._cb.post_object(url, body=request)
             result = resp.json()
 
@@ -1648,3 +1663,17 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
             if current >= self._total_results:
                 still_querying = False
                 break
+
+    def close(self, closure_reason=None, determination=None, note=None, ):
+        """
+        Closing all alerts matching a grouped alert query is not implemented.
+
+        Note:
+            - Closing all alerts in all groups returned by a ``GroupedAlertSearchQuery`` can be done by
+            getting the ``AlertSearchQuery`` and using close() on it as shown in the following example.
+
+        Example:
+            >>> alert_query = grouped_alert_query.get_alert_search_query()
+            >>> alert_query.close(closure_reason, note, determination)
+        """
+        raise NotImplementedError("this method is not implemented")

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -1971,29 +1971,12 @@ def test_group_alert_set_group_by(cbcsdk_mock):
     grouped_alerts.first()
 
 
-def test_group_alert_bulk_dismiss_workflow(cbcsdk_mock):
-    """Test closing a group alert job."""
-    def on_post(url, body, **kwargs):
-        assert body == {
-            "criteria": {
-                "type": ["CB_ANALYTICS"]
-            },
-            "determination": "TRUE_POSITIVE",
-            "closure_reason": "OTHER",
-            "status": "CLOSED",
-            "note": "Note about the determination"
-        }
-        return {
-            "request_id": "666666"
-        }
-
-    cbcsdk_mock.mock_request("POST", "/api/alerts/v7/orgs/test/alerts/workflow", on_post)
-    cbcsdk_mock.mock_request("GET", "/jobs/v1/orgs/test/jobs/666666", GET_CLOSE_WORKFLOW_JOB_RESP)
+def test_group_alert_bulk_close_workflow(cbcsdk_mock):
+    """Test closing a group alert job. Will raise a not implemented exception"""
     api = cbcsdk_mock.api
-
-    group_alert_query = api.select(GroupedAlert).add_criteria("type", ["CB_ANALYTICS"])
-    job = group_alert_query.close("OTHER", "TRUE_POSITIVE", "Note about the determination")
-    assert isinstance(job, Job)
+    group_alert_query = api.select(GroupedAlert)
+    with pytest.raises(NotImplementedError):
+        group_alert_query.close("OTHER", "TRUE_POSITIVE", "Note about the determination")
 
 
 def test_group_alert_to_get_alert_search_query(cbcsdk_mock):
@@ -2040,3 +2023,75 @@ def test_group_alert_to_get_alerts(cbcsdk_mock):
     assert isinstance(alerts, list)
     assert alert.get("type") == "WATCHLIST"
     assert alert.get("threat_id") == group_alert.most_recent_alert.get("threat_id")
+
+
+def test_grouped_alert_build_query(cbcsdk_mock):
+    """Test that grouped alert builds the query correctly when using len() to get the number of results."""
+
+    def on_post(url, body, **kwargs):
+        assert body == {
+            "group_by": {
+                "field": "THREAT_ID"
+            },
+            "time_range": {
+                "range": "-10d"
+            },
+            "criteria": {
+                "type": [
+                    "WATCHLIST"
+                ],
+                "minimum_severity": 1
+            },
+            "rows": 1,
+            "sort": [
+                {
+                    "field": "count",
+                    "order": "DESC"
+                }
+            ]
+        }
+        return {
+            "num_found": 25,
+            "num_available": 25,
+            "results": [
+                {
+                    "count": 994,
+                    "workflow_states": {
+                        "CLOSED": 1,
+                        "OPEN": 993
+                    },
+                    "determination_values": {
+                        "NONE": 994
+                    },
+                    "ml_classification_final_verdicts": {
+                        "NOT_CLASSIFIED": 4,
+                        "NOT_ANOMALOUS": 982,
+                        "ANOMALOUS": 8
+                    },
+                    "first_alert_timestamp": "2023-11-21T21:24:37.756Z",
+                    "last_alert_timestamp": "2023-12-01T21:00:42.937Z",
+                    "highest_severity": 7,
+                    "policy_applied": "NOT_APPLIED",
+                    "threat_notes_present": False,
+                    "tags": [],
+                    "device_count": 10,
+                    "workload_count": 0,
+                    "most_recent_alert": {
+                        "org_key": "ABCD1234",
+                        "alert_url": "defense.conferdeploy.net/alerts?s[c]"
+                                     "[query_string]=id:9d7f0692-e9cc-4ecc-9983-b063f1455cab&orgKey=ABCD1234",
+                        "id": "9d7f0692-e9cc-4ecc-9983-b063f1455cab",
+                        "type": "WATCHLIST",
+                        "severity": 7,
+                    }
+                }
+            ],
+            "group_by_total_count": 6421
+        }
+
+    cbcsdk_mock.mock_request("POST", "/api/alerts/v7/orgs/test/grouped_alerts/_search", on_post)
+    api = cbcsdk_mock.api
+
+    grouped_alert_query = api.select(GroupedAlert).set_minimum_severity(1).set_time_range(range="-10d")\
+        .add_criteria("type", "WATCHLIST").set_rows(1).sort_by("count", "DESC")
+    assert(len(grouped_alert_query) == 25)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests have been added that prove the fix is effective or that the feature works.
- [X] New and existing tests pass locally with the changes.
- [X] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [X] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->


## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
* _build_request for GroupedAlertSearchQuery needed to be overridden to set the group_by field.  Without this getting the length of the GroupedAlertResultSet fails.
* the Close method needed to be overridden from AlertSearchQuery to raise a not implemented exception.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Run locally and added unit tests