### PR TITLE
CBAPI-4581: Asset Groups - Policy Preview

### DIFF
--- a/src/cbc_sdk/platform/__init__.py
+++ b/src/cbc_sdk/platform/__init__.py
@@ -15,7 +15,7 @@ from cbc_sdk.platform.devices import Device, DeviceFacet, DeviceSearchQuery
 
 from cbc_sdk.platform.events import Event, EventFacet
 
-from cbc_sdk.platform.policies import Policy, PolicyRule
+from cbc_sdk.platform.policies import Policy, PolicyRule, PolicyRankChangePreview
 
 from cbc_sdk.platform.policy_ruleconfigs import PolicyRuleConfig
 

--- a/src/cbc_sdk/platform/policies.py
+++ b/src/cbc_sdk/platform/policies.py
@@ -1027,7 +1027,8 @@ class Policy(MutableBaseModel):
         Previews a change in the ranking of this policy, and determines how this will affect asset groups.
 
         Args:
-            new_rank (int): The new rank to give this policy.
+            new_rank (int): The new rank to give this policy.  Ranks are limited to values in the range [1.._N_],
+                            where _N_ is the total number of policies in the organization.
 
         Returns:
             list[PolicyRankChangePreview]: A list of objects containing data previewing the policy changes.
@@ -1206,7 +1207,8 @@ class Policy(MutableBaseModel):
             changes_list (list): The list of proposed changes in the ranking of policies.  Each change may be in
                 the form of a dict, in which case the "id" and "position" members are used to designate the policy ID
                 and the new position, or in the form of a list or tuple, in which case the first element specifies
-                the policy ID, and the second element specifies the new position.
+                the policy ID, and the second element specifies the new position.  In all cases, "position" values are
+                limited to values in the range [1.._N_], where _N_ is the total number of policies in the organization.
 
         Returns:
             list[PolicyRankChangePreview]: A list of objects containing data previewing the policy changes.

--- a/src/cbc_sdk/platform/policies.py
+++ b/src/cbc_sdk/platform/policies.py
@@ -1358,9 +1358,11 @@ class PolicyRule(MutableBaseModel):
 
 class PolicyRankChangePreview:
     """
-    Contains data previewing a change in the ranking of policies. Each one of these objects shows, for a given group
-    of assets, the current policy that is the "effective policy" for those assets, the new policy that will be the
-    "effective policy" for those assets, the number of assets affected, and which assets they are.
+    Contains data previewing a change in the ranking of policies.
+
+    Each one of these objects shows, for a given group of assets, the current policy that is the "effective policy"
+    for those assets, the new policy that will be the "effective policy" for those assets, the number of assets
+    affected, and which assets they are.
     """
     def __init__(self, cb, preview_data):
         """
@@ -1370,7 +1372,7 @@ class PolicyRankChangePreview:
             cb (BaseAPI): Reference to API object used to communicate with the server.
             preview_data (dict): Contains the preview data returned by the server API.
         """
-        self._cb = cb;
+        self._cb = cb
         self._preview_data = preview_data
 
     @property
@@ -1412,13 +1414,14 @@ class PolicyRankChangePreview:
     def asset_query(self):
         """
         A ``Device`` query which looks up the assets that are to be affected by the change in their effective policy.
-        The query can be modified with additional criteria or options before it is executed.
+
+        Once the query is created, it can be modified with additional criteria or options before it is executed.
         """
         return self._cb.select(Device).where(self._preview_data['asset_query'])
 
     @property
-    def assets(self):
-        """The list of assets (``Device`` objects) to be affected by the change in their effective policy."""
+    def assets(self):  # pragma: no cover
+        """The list of assets, i.e. ``Device`` objects, to be affected by the change in their effective policy."""
         return list(self.asset_query)
 
 

--- a/src/cbc_sdk/platform/policies.py
+++ b/src/cbc_sdk/platform/policies.py
@@ -16,6 +16,7 @@ import copy
 import json
 from types import MappingProxyType
 from cbc_sdk.base import MutableBaseModel, BaseQuery, IterableQueryMixin, AsyncQueryMixin
+from cbc_sdk.platform.devices import Device
 from cbc_sdk.platform.policy_ruleconfigs import (PolicyRuleConfig, CorePreventionRuleConfig,
                                                  HostBasedFirewallRuleConfig, DataCollectionRuleConfig)
 from cbc_sdk.errors import ApiError, ServerError, InvalidObjectError
@@ -1021,6 +1022,18 @@ class Policy(MutableBaseModel):
         else:
             raise ApiError(f"rule configuration '{rule_config_id}' not found in policy")
 
+    def preview_rank_change(self, new_rank):
+        """
+        Previews a change in the ranking of this policy, and determines how this will affect asset groups.
+
+        Args:
+            new_rank (int): The new rank to give this policy.
+
+        Returns:
+            list[PolicyRankChangePreview]: A list of objects containing data previewing the policy changes.
+        """
+        return Policy.preview_policy_changes(self._cb, [(self._model_unique_id, new_rank)])
+
     # --- BEGIN policy v1 compatibility methods ---
 
     @property
@@ -1183,6 +1196,31 @@ class Policy(MutableBaseModel):
         """
         return Policy.PolicyBuilder(cb)
 
+    @classmethod
+    def preview_policy_changes(cls, cb, changes_list):
+        """
+        Previews changes in the ranking of policies, and determines how this will affect asset groups.
+
+        Args:
+            cb (BaseAPI): Reference to API object used to communicate with the server.
+            changes_list (list): The list of proposed changes in the ranking of policies.  Each change may be in
+                the form of a dict, in which case the "id" and "position" members are used to designate the policy ID
+                and the new position, or in the form of a list or tuple, in which case the first element specifies
+                the policy ID, and the second element specifies the new position.
+
+        Returns:
+            list[PolicyRankChangePreview]: A list of objects containing data previewing the policy changes.
+        """
+        submit_list = []
+        for change in changes_list:
+            if isinstance(change, dict):
+                submit_list.append({"id": change["id"], "position": change["position"]})
+            elif isinstance(change, list) or isinstance(change, tuple):
+                submit_list.append({"id": change[0], "position": change[1]})
+        ret = cb.post_object(f"/policy-assignment/v1/orgs/{cb.credentials.org_key}/policies/preview",
+                             {"policies": submit_list})
+        return [PolicyRankChangePreview(cb, p) for p in ret.json()["preview"]]
+
 
 class PolicyRule(MutableBaseModel):
     """
@@ -1314,6 +1352,72 @@ class PolicyRule(MutableBaseModel):
         if self._info["operation"] not in PolicyRule.VALID_OPERATIONS:
             raise InvalidObjectError("'operation' field value not valid")
         return True
+
+
+class PolicyRankChangePreview:
+    """
+    Contains data previewing a change in the ranking of policies. Each one of these objects shows, for a given group
+    of assets, the current policy that is the "effective policy" for those assets, the new policy that will be the
+    "effective policy" for those assets, the number of assets affected, and which assets they are.
+    """
+    def __init__(self, cb, preview_data):
+        """
+        Creates a new instance of ``PolicyRankChangePreview``.
+
+        Args:
+            cb (BaseAPI): Reference to API object used to communicate with the server.
+            preview_data (dict): Contains the preview data returned by the server API.
+        """
+        self._cb = cb;
+        self._preview_data = preview_data
+
+    @property
+    def current_policy_id(self):
+        """The ID of the policy that is the current "effective" policy for a group of assets."""
+        return self._preview_data['current_policy']['id']
+
+    @property
+    def current_policy(self):
+        """The ``Policy`` object that is the current "effective" policy for a group of assets."""
+        return self._cb.select(Policy, self._preview_data['current_policy']['id'])
+
+    @property
+    def current_policy_position(self):
+        """The position, or rank, of the policy that is the current "effective" policy for a group of assets."""
+        return self._preview_data['current_policy']['position']
+
+    @property
+    def new_policy_id(self):
+        """The ID of the policy that will become the new "effective" policy for a group of assets."""
+        return self._preview_data['new_policy']['id']
+
+    @property
+    def new_policy(self):
+        """The ``Policy`` object that will become the new "effective" policy for a group of assets."""
+        return self._cb.select(Policy, self._preview_data['new_policy']['id'])
+
+    @property
+    def new_policy_position(self):
+        """The position, or rank, of the policy that will become the new "effective" policy for a group of assets."""
+        return self._preview_data['new_policy']['position']
+
+    @property
+    def asset_count(self):
+        """The number of assets to be affected by the change in their effective policy."""
+        return self._preview_data['asset_count']
+
+    @property
+    def asset_query(self):
+        """
+        A ``Device`` query which looks up the assets that are to be affected by the change in their effective policy.
+        The query can be modified with additional criteria or options before it is executed.
+        """
+        return self._cb.select(Device).where(self._preview_data['asset_query'])
+
+    @property
+    def assets(self):
+        """The list of assets (``Device`` objects) to be affected by the change in their effective policy."""
+        return list(self.asset_query)
 
 
 """Query Class"""

--- a/src/tests/unit/fixtures/platform/mock_policies.py
+++ b/src/tests/unit/fixtures/platform/mock_policies.py
@@ -6,7 +6,7 @@ FULL_POLICY_1 = {
     "org_key": "test",
     "version": 2,
     "priority_level": "HIGH",
-    "position": -1,
+    "position": 3,
     "is_system": False,
     "description": "",
     "auto_deregister_inactive_vdi_interval_ms": 0,
@@ -313,7 +313,7 @@ SUMMARY_POLICY_1 = {
     "id": 65536,
     "name": "A Dummy Policy",
     "priority_level": "HIGH",
-    "position": -1,
+    "position": 3,
     "is_system": False,
     "description": "",
     "num_devices": 0
@@ -325,7 +325,7 @@ SUMMARY_POLICY_2 = {
     "name": "Forescout Policy",
     "description": "Initial Forescout policy, no protection turned on",
     "priority_level": "MEDIUM",
-    "position": -1,
+    "position": 4,
     "num_devices": 0
 }
 
@@ -335,7 +335,7 @@ SUMMARY_POLICY_3 = {
     "name": "Remediant AC Policy",
     "description": "Verifying AC capabilities ",
     "priority_level": "LOW",
-    "position": -1,
+    "position": 5,
     "num_devices": 0
 }
 
@@ -540,6 +540,7 @@ FULL_POLICY_2 = {
     "org_key": "test",
     "priority_level": "MEDIUM",
     "description": "Hoopy Frood",
+    "position": 2,
     "av_settings": {
         "avira_protection_cloud": {
             "enabled": False,
@@ -1539,6 +1540,7 @@ NEW_POLICY_RETURN_1 = {
     "name": "New Policy Name",
     "org_key": "test",
     "priority_level": "HIGH",
+    "position": 6,
     "version": 2,
     "is_system": False,
     "description": "Foobar",
@@ -1949,7 +1951,7 @@ FULL_POLICY_5 = {
     "name": "Crapco",
     "org_key": "test",
     "priority_level": "MEDIUM",
-    "position": -1,
+    "position": 5,
     "is_system": False,
     "description": "If you buy this, you'll buy ANYTHING!",
     "auto_deregister_inactive_vdi_interval_ms": 0,
@@ -2464,4 +2466,80 @@ FULL_POLICY_5 = {
         }
     ],
     "sensor_configs": []
+}
+
+PREVIEW_POLICY_CHANGES_REQUEST1 = {
+    "policies": [
+        {
+            "id": 10240,
+            "position": 1
+        }
+    ]
+}
+
+PREVIEW_POLICY_CHANGES_RESPONSE1 = {
+    "preview": [
+        {
+            "current_policy": {
+                "id": 70722,
+                "position": 2
+            },
+            "new_policy": {
+                "id": 10240,
+                "position": 1
+            },
+            "asset_count": 5,
+            "asset_query": "(-_exists_:ag_agg_key_dynamic AND ag_agg_key_manual:1790b51e683c8a20c2b2bbe3e41eacdc53e3632087bb5a3f2868588e99157b06 AND policy_override:false) OR (-_exists_:ag_agg_key_dynamic AND ag_agg_key_manual:aa8bd7e69c4ee45918bb126a17d90a1c8368b46f9bb5bf430cb0250c317cd1dc AND policy_override:false)"  # noqa: E501
+        },
+        {
+            "current_policy": {
+                "id": 142857,
+                "position": 1
+            },
+            "new_policy": {
+                "id": 10240,
+                "position": 1
+            },
+            "asset_count": 2,
+            "asset_query": "(ag_agg_key_manual:1790b51e683c8a20c2b2bbe3e41eacdc53e3632087bb5a3f2868588e99157b06 AND ag_agg_key_dynamic:51f32868cdd197b491093617b259ea2f4a93550b7c130636df8d48e94d37c4c8 AND policy_override:false)"  # noqa: E501
+        }
+    ]
+}
+
+PREVIEW_POLICY_CHANGES_REQUEST2 = {
+    "policies": [
+        {
+            "id": 65536,
+            "position": 1
+        }
+    ]
+}
+
+PREVIEW_POLICY_CHANGES_RESPONSE2 = {
+    "preview": [
+        {
+            "current_policy": {
+                "id": 1492,
+                "position": 2
+            },
+            "new_policy": {
+                "id": 65536,
+                "position": 1
+            },
+            "asset_count": 5,
+            "asset_query": "(-_exists_:ag_agg_key_dynamic AND ag_agg_key_manual:1790b51e683c8a20c2b2bbe3e41eacdc53e3632087bb5a3f2868588e99157b06 AND policy_override:false) OR (-_exists_:ag_agg_key_dynamic AND ag_agg_key_manual:aa8bd7e69c4ee45918bb126a17d90a1c8368b46f9bb5bf430cb0250c317cd1dc AND policy_override:false)"  # noqa: E501
+        },
+        {
+            "current_policy": {
+                "id": 74656,
+                "position": 1
+            },
+            "new_policy": {
+                "id": 65536,
+                "position": 1
+            },
+            "asset_count": 2,
+            "asset_query": "(ag_agg_key_manual:1790b51e683c8a20c2b2bbe3e41eacdc53e3632087bb5a3f2868588e99157b06 AND ag_agg_key_dynamic:51f32868cdd197b491093617b259ea2f4a93550b7c130636df8d48e94d37c4c8 AND policy_override:false)"  # noqa: E501
+        }
+    ]
 }

--- a/src/tests/unit/platform/test_policies.py
+++ b/src/tests/unit/platform/test_policies.py
@@ -17,14 +17,18 @@ import logging
 import random
 from contextlib import ExitStack as does_not_raise
 from cbc_sdk.rest_api import CBCloudAPI
-from cbc_sdk.platform import Policy, PolicyRule, PolicyRuleConfig
+from cbc_sdk.platform import Policy, PolicyRule, PolicyRuleConfig, PolicyRankChangePreview
+from cbc_sdk.platform.devices import DeviceSearchQuery
 from cbc_sdk.errors import ApiError, InvalidObjectError, ServerError
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from tests.unit.fixtures.platform.mock_policies import (FULL_POLICY_1, SUMMARY_POLICY_1, SUMMARY_POLICY_2,
                                                         SUMMARY_POLICY_3, OLD_POLICY_1, FULL_POLICY_2, OLD_POLICY_2,
                                                         RULE_ADD_1, RULE_ADD_2, RULE_MODIFY_1, NEW_POLICY_CONSTRUCT_1,
                                                         NEW_POLICY_RETURN_1, BASIC_CONFIG_TEMPLATE_RETURN,
-                                                        BUILD_RULECONFIG_1)
+                                                        BUILD_RULECONFIG_1, PREVIEW_POLICY_CHANGES_REQUEST1,
+                                                        PREVIEW_POLICY_CHANGES_RESPONSE1,
+                                                        PREVIEW_POLICY_CHANGES_REQUEST2,
+                                                        PREVIEW_POLICY_CHANGES_RESPONSE2, FULL_POLICY_5)
 
 
 logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
@@ -72,6 +76,7 @@ def test_policy_compatibility_aliases_write(cb):
     policy.policy = copy.deepcopy(OLD_POLICY_2)
     policy.description = "Hoopy Frood"
     policy.name = "default - S1"
+    policy.position = 2
     policy.priorityLevel = "MEDIUM"
     policy.version = 2
     new_policy_data = copy.deepcopy(policy._info)
@@ -540,3 +545,69 @@ def test_policy_builder_error_handling(cb):
         builder.set_on_demand_scan_schedule(["WEDNESDAY", "FRIDAY", "HELLDAY"], 0, 6)
     with pytest.raises(ApiError):
         builder.add_sensor_setting("LONG_RANGE", "true")
+
+
+@pytest.mark.parametrize("element", [
+    {"id": 10240, "position": 1},
+    [10240, 1],
+    (10240, 1)
+])
+def test_preview_policy_changes(cbcsdk_mock, element):
+    """Tests the preview_policy_changes function on the Policy class."""
+    def on_post(uri, body, **kwargs):
+        assert body == PREVIEW_POLICY_CHANGES_REQUEST1
+        return PREVIEW_POLICY_CHANGES_RESPONSE1
+
+    cbcsdk_mock.mock_request('POST', '/policy-assignment/v1/orgs/test/policies/preview', on_post)
+    api = cbcsdk_mock.api
+    results = Policy.preview_policy_changes(api, [element])
+    assert len(results) == 2
+    assert results[0].current_policy_id == 70722
+    assert results[0].current_policy_position == 2
+    assert results[0].new_policy_id == 10240
+    assert results[0].new_policy_position == 1
+    assert results[0].asset_count == 5
+    assert results[1].current_policy_id == 142857
+    assert results[1].current_policy_position == 1
+    assert results[1].new_policy_id == 10240
+    assert results[1].new_policy_position == 1
+    assert results[1].asset_count == 2
+
+
+def test_preview_rank_change(cbcsdk_mock):
+    """Tests the preview_rank_change function on the policy class."""
+    def on_post(uri, body, **kwargs):
+        assert body == PREVIEW_POLICY_CHANGES_REQUEST2
+        return PREVIEW_POLICY_CHANGES_RESPONSE2
+
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65536', FULL_POLICY_1)
+    cbcsdk_mock.mock_request('POST', '/policy-assignment/v1/orgs/test/policies/preview', on_post)
+    api = cbcsdk_mock.api
+    policy = api.select(Policy, 65536)
+    results = policy.preview_rank_change(1)
+    assert results[0].current_policy_id == 1492
+    assert results[0].current_policy_position == 2
+    assert results[0].new_policy_id == 65536
+    assert results[0].new_policy_position == 1
+    assert results[0].asset_count == 5
+    assert results[1].current_policy_id == 74656
+    assert results[1].current_policy_position == 1
+    assert results[1].new_policy_id == 65536
+    assert results[1].new_policy_position == 1
+    assert results[1].asset_count == 2
+
+
+def test_policy_rank_change_preview_helper_methods(cbcsdk_mock):
+    """Tests the helper methods on the PolicyRankChangePreview object."""
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/65536', FULL_POLICY_1)
+    cbcsdk_mock.mock_request('GET', '/policyservice/v1/orgs/test/policies/1492', FULL_POLICY_5)
+    api = cbcsdk_mock.api
+    preview = PolicyRankChangePreview(api, PREVIEW_POLICY_CHANGES_RESPONSE2['preview'][0])
+    policy = preview.current_policy
+    assert policy.id == 1492
+    policy = preview.new_policy
+    assert policy.id == 65536
+    query = preview.asset_query
+    assert isinstance(query, DeviceSearchQuery)
+    request = query._build_request(-1, -1)
+    assert request['query'] == "(-_exists_:ag_agg_key_dynamic AND ag_agg_key_manual:1790b51e683c8a20c2b2bbe3e41eacdc53e3632087bb5a3f2868588e99157b06 AND policy_override:false) OR (-_exists_:ag_agg_key_dynamic AND ag_agg_key_manual:aa8bd7e69c4ee45918bb126a17d90a1c8368b46f9bb5bf430cb0250c317cd1dc AND policy_override:false)"  # noqa: E501


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-4581

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added API for the "preview policy changes" functionality, both as a class method on `Policy` and as a member function that previews changes to the current policy's ranking.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been added for all new functionality; test coverage of `policies.py` stands at 96%.  Log of the code running against `dev01` is here: [preview_policy_changes.log](https://github.com/carbonblack/carbon-black-cloud-sdk-python/files/13606008/preview_policy_changes.log)