### PR TITLE
CBAPI-4254: Asset Group Support in CBC SDK p4 - Additional Member Functions

### DIFF
--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -208,7 +208,7 @@ class AssetGroup(MutableBaseModel):
         belong to groups without policy association.
 
         See
-        `this page <https://developer.carbonblack.com/reference/carbon-black-cloud/platform/latest/asset-groups-api/#get-asset-group-stats>`  # noqa: E501 W505
+        `this page <https://developer.carbonblack.com/reference/carbon-black-cloud/platform/latest/asset-groups-api/#get-asset-group-stats>`_
         for more details on the structure of the return value from this method.
 
         Required Permissions:
@@ -218,7 +218,7 @@ class AssetGroup(MutableBaseModel):
              dict: A dict with two elements. The "intersections" element contains elements detailing which groups share
                    members with this group, and which members they are.  The "unassigned_properties" element contains
                    elements showing which members belong to groups without policy association.
-        """
+        """    # noqa: E501 W505
         return self._cb.get_object(self._build_api_request_uri() + "/membership_summary")
 
     @classmethod

--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -269,7 +269,7 @@ class AssetGroup(MutableBaseModel):
             list[AssetGroup]: List of ``AssetGroup`` objects corresponding to the asset groups in the organization.
         """
         return_data = cb.get_object(AssetGroup.urlobject.format(cb.credentials.org_key))
-        return [AssetGroup(cb, v['id'], v, False, False) for v in return_data['results']]
+        return [AssetGroup(cb, v['id'], v) for v in return_data['results']]
 
 
 class AssetGroupQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, CriteriaBuilderSupportMixin,

--- a/src/tests/unit/fixtures/platform/mock_asset_groups.py
+++ b/src/tests/unit/fixtures/platform/mock_asset_groups.py
@@ -181,3 +181,64 @@ LIST_MEMBERS_RESPONSE2 = {
         }
     ]
 }
+
+GET_ALL_RESPONSE = {
+    "num_found": 2,
+    "results": [
+        {
+            "id": "db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16",
+            "name": "Existing Group",
+            "description": "Some Description",
+            "org_key": "test",
+            "status": "OK",
+            "member_type": "DEVICE",
+            "discovered": False,
+            "create_time": "2022-11-09T06:27:30.734Z",
+            "update_time": "2022-11-09T06:27:30.734Z",
+            "member_count": 0,
+        },
+        {
+            "id": "509f437f-6b9a-4b8e-996e-9183b35f9069",
+            "name": "Another Group",
+            "description": "Some new description",
+            "org_key": "test",
+            "status": "OK",
+            "member_type": "DEVICE",
+            "discovered": False,
+            "create_time": "2022-11-09T06:27:30.734Z",
+            "update_time": "2022-11-09T06:27:30.734Z",
+            "member_count": 0,
+        }
+    ]
+}
+
+GET_STATS_RESPONSE = {
+    "intersections": [
+        {
+            "count": 2,
+            "ids": [
+                "12345678",
+                "66760099"
+            ],
+            "group_id": "509f437f-6b9a-4b8e-996e-9183b35f9069",
+            "group_name": "Another Group",
+            "group_description": "Some new description"
+        },
+        {
+            "count": 1,
+            "ids": [
+                "66760099"
+            ],
+            "group_id": "8e0e3714-fece-4c76-9728-6ad2713cde72",
+            "group_name": "Secure Access Group",
+            "group_description": "More secure than usual"
+        },
+    ],
+    "unassigned_properties": [
+        {
+            "type": "POLICY",
+            "count": 0,
+            "ids": []
+        }
+    ]
+}

--- a/src/tests/unit/platform/test_asset_groups.py
+++ b/src/tests/unit/platform/test_asset_groups.py
@@ -346,12 +346,4 @@ def test_get_statistics(cbcsdk_mock):
     api = cbcsdk_mock.api
     group = api.select(AssetGroup, 'db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16')
     rc = group.get_statistics()
-    sub = rc["unassigned_properties"]
-    assert len(sub) == 1
-    assert sub[0]["type"] == "POLICY"
-    sub = rc["intersections"]
-    assert len(sub) == 2
-    assert sub[0]["count"] == 2
-    assert sub[0]["group_id"] == "509f437f-6b9a-4b8e-996e-9183b35f9069"
-    assert sub[1]["count"] == 1
-    assert sub[1]["group_id"] == "8e0e3714-fece-4c76-9728-6ad2713cde72"
+    assert rc == GET_STATS_RESPONSE

--- a/src/tests/unit/platform/test_asset_groups.py
+++ b/src/tests/unit/platform/test_asset_groups.py
@@ -21,7 +21,8 @@ from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from tests.unit.fixtures.platform.mock_asset_groups import (CREATE_AG_REQUEST, CREATE_AG_RESPONSE, EXISTING_AG_DATA,
                                                             UPDATE_AG_REQUEST, QUERY_REQUEST, QUERY_REQUEST_DEFAULT,
                                                             QUERY_RESPONSE, LIST_MEMBERS_RESPONSE1,
-                                                            LIST_MEMBERS_OUTPUT1, LIST_MEMBERS_RESPONSE2)
+                                                            LIST_MEMBERS_OUTPUT1, LIST_MEMBERS_RESPONSE2,
+                                                            GET_ALL_RESPONSE, GET_STATS_RESPONSE)
 from tests.unit.fixtures.platform.mock_devices import GET_DEVICE_RESP
 
 
@@ -321,3 +322,36 @@ def test_remove_members_with_device(cbcsdk_mock):
     device = api.select(Device, 98765)
     group.remove_members(device)
     group.remove_members([device])
+
+
+def test_get_all_groups(cbcsdk_mock):
+    """Tests the get_all_groups class method."""
+    cbcsdk_mock.mock_request('GET', '/asset_groups/v1/orgs/test/groups', copy.deepcopy(GET_ALL_RESPONSE))
+    api = cbcsdk_mock.api
+    rc = AssetGroup.get_all_groups(api)
+    assert len(rc) == 2
+    assert isinstance(rc[0], AssetGroup)
+    assert isinstance(rc[1], AssetGroup)
+    assert rc[0].id == "db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16"
+    assert rc[1].id == "509f437f-6b9a-4b8e-996e-9183b35f9069"
+
+
+def test_get_statistics(cbcsdk_mock):
+    """Tests the get_statistics method."""
+    cbcsdk_mock.mock_request('GET', '/asset_groups/v1/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16',
+                             copy.deepcopy(EXISTING_AG_DATA))
+    cbcsdk_mock.mock_request('GET',
+                             '/asset_groups/v1/orgs/test/groups/db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16/membership_summary',  # noqa: E501
+                             GET_STATS_RESPONSE)
+    api = cbcsdk_mock.api
+    group = api.select(AssetGroup, 'db416fa2-d5f2-4fb5-8a5e-cd89f6ecda16')
+    rc = group.get_statistics()
+    sub = rc["unassigned_properties"]
+    assert len(sub) == 1
+    assert sub[0]["type"] == "POLICY"
+    sub = rc["intersections"]
+    assert len(sub) == 2
+    assert sub[0]["count"] == 2
+    assert sub[0]["group_id"] == "509f437f-6b9a-4b8e-996e-9183b35f9069"
+    assert sub[1]["count"] == 1
+    assert sub[1]["group_id"] == "8e0e3714-fece-4c76-9728-6ad2713cde72"


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-4254

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added `get_all_groups()` (class method) and `get_statistics()` methods to `AssetGroup`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been added for the two new methods; overall coverage in `asset_groups.py` stands at 98%.  Log file of run of the new functions against DEV01 is here: [misc_functions_asset_groups.log](https://github.com/carbonblack/carbon-black-cloud-sdk-python/files/13719162/misc_functions_asset_groups.log)