### PR TITLE
CBAPI-5208: Asset Groups - modify group

### DIFF
--- a/src/cbc_sdk/platform/asset_groups.py
+++ b/src/cbc_sdk/platform/asset_groups.py
@@ -222,7 +222,7 @@ class AssetGroup(MutableBaseModel):
         return self._cb.get_object(self._build_api_request_uri() + "/membership_summary")
 
     @classmethod
-    def create_group(cls, cb, name, description, **kwargs):
+    def create_group(cls, cb, name, description=None, policy_id=None, query=None):
         """
         Create a new asset group.
 
@@ -232,10 +232,7 @@ class AssetGroup(MutableBaseModel):
         Args:
             cb (BaseAPI): Reference to API object used to communicate with the server.
             name (str): Name for the new asset group.
-            description (str): Description for the new asset group.
-            kwargs (dict): Keyword arguments, as defined below.
-
-        Keyword Args:
+            description (str): Description for the new asset group. Default is ``None``.
             policy_id (int): ID of the policy to be associated with this asset group. Default is ``None``.
             query (str): Query string to be used to dynamically populate this group. Default is ``None``,
                 which means devices _must_ be manually assigned to the group.
@@ -243,11 +240,11 @@ class AssetGroup(MutableBaseModel):
         Returns:
             AssetGroup: The new asset group.
         """
-        group_data = {"name": name, "description": description, "member_type": "DEVICE"}
-        policy_id = kwargs.get("policy_id", None)
+        group_data = {"name": name, "member_type": "DEVICE"}
+        if description:
+            group_data["description"] = description
         if policy_id:
             group_data["policy_id"] = policy_id
-        query = kwargs.get("query", None)
         if query:
             group_data["query"] = query
         group = AssetGroup(cb, None, group_data, False, True)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-5208

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Changed the behavior of `create_group()` function so that all parameters except `name` for the new group are optional.  Documentation also changed accordingly.

(The request for modifiability as specified in the original JIRA ticket was mostly supported already. This detail needed to be fixed up, through.)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Existing tests cover this new case adequately; test coverage of `asset_groups.py` is still 98%. Log of a group being created without a description and then having one added afterwards is here: [description-null.log](https://github.com/carbonblack/carbon-black-cloud-sdk-python/files/13847381/description-null.log)