### PR TITLE
CBAPI-5091 - Put Python 3.7 back in the test pipeline

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,3 +1,7 @@
+testingpython37:
+  build:
+    dockerfile: ./docker/python3.7/Dockerfile
+
 testingpython38:
   build:
     dockerfile: ./docker/python3.8/Dockerfile

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -5,6 +5,9 @@
 - name: Tests
   type: parallel
   steps:
+  - name: testing python 3.7
+    service: testingpython37
+    command: pytest
   - name: testing python 3.8
     service: testingpython38
     command: bin/tests_n_reports.sh

--- a/docker/python3.7/Dockerfile
+++ b/docker/python3.7/Dockerfile
@@ -1,0 +1,7 @@
+from python:3.7
+MAINTAINER cb-developer-network@vmware.com
+
+COPY . /app
+WORKDIR /app
+
+RUN pip3 install -r requirements.txt


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-5091

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Re-added Python 3.7 to the automated Codeship tests. (We can't get rid of that version after all, despite it having been officially end-of-lifed, since Splunk still uses it. _mrrmee mrrmee mrrmee..._ )

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
No new tests required, this just changes the Codeship configuration and the associated Dockerfile.