### PR TITLE
CBAPI-5116: Helper Method - Set XDR and Auth Event Data Collection policy on/off

### DIFF
--- a/src/cbc_sdk/platform/policies.py
+++ b/src/cbc_sdk/platform/policies.py
@@ -1042,7 +1042,7 @@ class Policy(MutableBaseModel):
                   "/rule_configs/data_collection"
             for rconf_block in rconf_blocks:
                 if type(rconf_block['parameters'][parameter]) is type(value):
-                    body = {"id": rconf_block['id'], "parameters": {parameter, value}}
+                    body = {"id": rconf_block['id'], "parameters": {parameter: value}}
                     return_data = self._cb.put_object(url, body)
                     fail_blocks = [block for block in return_data.json()['failed'] if block['id'] == rconf_block['id']]
                     if len(fail_blocks) > 0:

--- a/src/tests/unit/fixtures/platform/mock_policies.py
+++ b/src/tests/unit/fixtures/platform/mock_policies.py
@@ -201,6 +201,16 @@ FULL_POLICY_1 = {
             }
         },
         {
+            "id": "cc075469-8d1e-4056-84b6-0e6f437c4010",
+            "name": "XDR",
+            "description": "Turns on XDR network data collection at the sensor",
+            "inherited_from": "",
+            "category": "data_collection",
+            "parameters": {
+                "enable_network_data_collection": False
+            }
+        },
+        {
             "id": "1f8a5e4b-34f2-4d31-9f8f-87c56facaec8",
             "name": "Advanced Scripting Prevention",
             "description": "Addresses malicious fileless and file-backed scripts that leverage native programs [...]",
@@ -2464,4 +2474,61 @@ FULL_POLICY_5 = {
         }
     ],
     "sensor_configs": []
+}
+
+SET_XDR_COLLECTION_REQUEST = {
+    "id": "cc075469-8d1e-4056-84b6-0e6f437c4010",
+    "parameters": {
+        "enable_network_data_collection": True
+    }
+}
+
+SET_XDR_COLLECTION_RESPONSE = {
+    "successful": [
+        {
+            "id": "cc075469-8d1e-4056-84b6-0e6f437c4010",
+            "name": "XDR",
+            "description": "Turns on XDR network data collection at the sensor",
+            "inherited_from": "",
+            "category": "data_collection",
+            "parameters": {
+                "enable_network_data_collection": True
+            }
+        }
+    ],
+    "failed": []
+}
+
+SET_AUTH_EVENT_COLLECTION_REQUEST = {
+    "id": "91c919da-fb90-4e63-9eac-506255b0a0d0",
+    "parameters": {
+        "enable_auth_events": False
+    }
+}
+
+SET_AUTH_EVENT_COLLECTION_RESPONSE = {
+    "successful": [
+        {
+            "id": "91c919da-fb90-4e63-9eac-506255b0a0d0",
+            "name": "Authentication Events",
+            "description": "Authentication Events",
+            "inherited_from": "",
+            "category": "data_collection",
+            "parameters": {
+                "enable_auth_events": False
+            }
+        }
+    ],
+    "failed": []
+}
+
+SET_AUTH_EVENT_COLLECTION_RESPONSE_ERROR = {
+    "successful": [],
+    "failed": [
+        {
+            "id": "91c919da-fb90-4e63-9eac-506255b0a0d0",
+            "error_code": "TESTING_ERROR",
+            "message": "Test error"
+        }
+    ]
 }

--- a/src/tests/unit/fixtures/platform/mock_policy_ruleconfigs.py
+++ b/src/tests/unit/fixtures/platform/mock_policy_ruleconfigs.py
@@ -1185,6 +1185,16 @@ DATA_COLLECTION_RETURNS = {
             "parameters": {
                 "enable_auth_events": True
             }
+        },
+        {
+            "id": "cc075469-8d1e-4056-84b6-0e6f437c4010",
+            "name": "XDR",
+            "description": "Turns on XDR network data collection at the sensor",
+            "inherited_from": "",
+            "category": "data_collection",
+            "parameters": {
+                "enable_network_data_collection": False
+            }
         }
     ]
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-5116

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added helper methods to `Policy`, `set_xdr_collection` and `set_auth_event_collection`, that allow XDR data collection and auth event data collection to be quickly turned on and off for a policy.  This would allow someone to do it easily for _all_ policies in an organization by using a simple for loop.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit tests have been written to cover all the new code. Coverage for `policies.py` stands at 96%.  Log of run against PROD02 is here: [set_policy_shortcuts.log](https://github.com/carbonblack/carbon-black-cloud-sdk-python/files/14028928/set_policy_shortcuts.log)