### PR TITLE
CBAPI-5134: Set a default timeout on waiting for search jobs to complete

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -166,6 +166,8 @@ CBAPI, so older files can continue to be used.
 +-------------------------+---------+----------+
 |``integration``          |         | No       |
 +-------------------------+---------+----------+
+|``default_timeout``      | 300000  | No       |
++-------------------------+---------+----------+
 
 **X-AUTH-TOKEN** specific fields
 
@@ -194,13 +196,10 @@ CBAPI, so older files can continue to be used.
 +-------------------------+---------+----------+
 
 
-
-Individual profiles or sections are delimited in the file by placing their name within square brackets: ``[profile_name]``.  Within
-each section, individual credential values are supplied in a ``keyword=value`` format.
-
+Individual profiles or sections are delimited in the file by placing their name within square brackets:
+``[profile_name]``.  Within each section, individual credential values are supplied in a ``keyword=value`` format.
 
 Unrecognized keywords are ignored.
-
 
 By default, the CBC SDK looks for credentials files in the following locations:
 
@@ -267,6 +266,8 @@ be specified:
 +-------------------------+----------------+---------+----------+
 |``integration``          | ``REG_SZ``     |         | No       |
 +-------------------------+----------------+---------+----------+
+|``default_timeout``      | ``REG_DWORD``  | 300000  | No       |
++-------------------------+----------------+---------+----------+
 
 **X-AUTH-TOKEN** specific fields
 
@@ -323,22 +324,22 @@ Note the use of doubled backslashes to properly escape them under Python.
 With an External Credential Provider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Credentials may also be supplied by writing a class that conforms to the ``CredentialProvider`` interface protocol.
-When creating :py:mod:`CBCloudAPI <cbc_sdk.rest_api.CBCloudAPI>`, pass a reference to a ``CredentialProvider`` object in the ``credential_provider`` keyword
-parameter. Then pass the name of the profile you want to retrieve from the provider object using the keyword parameter
-``profile``.
+When creating :py:mod:`CBCloudAPI <cbc_sdk.rest_api.CBCloudAPI>`, pass a reference to a ``CredentialProvider`` object
+in the ``credential_provider`` keyword parameter. Then pass the name of the profile you want to retrieve from the
+provider object using the keyword parameter ``profile``.
 
 **Example:**
 
     >>> provider = MyCredentialProvider()
     >>> cbc_api = CBCloudAPI(credential_provider=provider, profile='default')
 
-Details of writing a credential provider may be found in the :doc:`Developing a Custom Credential Provider <developing-credential-providers>`
-document.
+Details of writing a credential provider may be found in the
+:doc:`Developing a Custom Credential Provider <developing-credential-providers>` document.
 
 At Runtime
 ^^^^^^^^^^
-The credentials may be passed into the :py:mod:`CBCloudAPI <cbc_sdk.rest_api.CBCloudAPI>` object when it is created via the keyword parameters ``url``,
-``token``, ``org_key``, and (optionally) ``ssl_verify`` and ``integration_name``.
+The credentials may be passed into the :py:mod:`CBCloudAPI <cbc_sdk.rest_api.CBCloudAPI>` object when it is created
+via the keyword parameters ``url``, ``token``, ``org_key``, and (optionally) ``ssl_verify`` and ``integration_name``.
 
 **Example:**
 
@@ -348,7 +349,6 @@ The credentials may be passed into the :py:mod:`CBCloudAPI <cbc_sdk.rest_api.CBC
 The ``integration_name`` may be specified even if using another credential provider. If specified as a
 parameter, this overrides any integration name specified by means of the credential provider.
 
-
 With Environmental Variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The credentials may be supplied to CBC SDK via the environment variables ``CBC_URL``, ``CBC_TOKEN``, ``CBC_ORG_KEY``,
@@ -356,9 +356,8 @@ and ``CBC_SSL_VERIFY``. For backwards compatibility with CBAPI, the environment 
 ``CBAPI_TOKEN``, ``CBAPI_ORG_KEY``, and ``CBAPI_SSL_VERIFY`` may also be used; if both are specified, the newer
 ``CBC_xxx`` environment variables override their corresponding ``CBAPI_xxx`` equivalents. To use the environment
 variables, they must be set before the application is run (at least ``CBC_URL`` or ``CBAPI_URL``, and ``CBC_TOKEN`` or
-``CBAPI_TOKEN``), and the ``credential_file`` keyword parameter to :py:mod:`CBCloudAPI <cbc_sdk.rest_api.CBCloudAPI>` must be either ``None`` or left
-unspecified. (The ``profile`` keyword parameter will be ignored.)
-
+``CBAPI_TOKEN``), and the ``credential_file`` keyword parameter to :py:mod:`CBCloudAPI <cbc_sdk.rest_api.CBCloudAPI>`
+must be either ``None`` or left unspecified. (The ``profile`` keyword parameter will be ignored.)
 
 **N.B.:** Passing credentials via the environment can be insecure, and, if this method is used, a warning message to
 that effect will be generated in the log.
@@ -374,12 +373,14 @@ we are going to use JSON to store our other entries, the JSON is going to be sto
     CLI tool(``<SDK_ROOT>/bin/set-macos-keychain.py``) or by manually creating it.
     The tool can:
 
-        * Automatically import all of your profiles set in the ``credentials.cbc`` file. Or by setting a custom path to a file.
+        * Automatically import all of your profiles set in the ``credentials.cbc`` file. Or by setting a custom path
+          to a file.
         * Manually input the values of your credentials via prompt or by using system arguments.
 
     Find out how to use the script in its docstring or by using ``--help``.
 
-You can remove the keys that you won't be using or leave them empty. Reference our :ref:`Explanation of API Credential Components`.
+You can remove the keys that you won't be using or leave them empty. Reference our
+:ref:`Explanation of API Credential Components`.
 
 .. code-block:: javascript
 
@@ -393,7 +394,8 @@ You can remove the keys that you won't be using or leave them empty. Reference o
         "ssl_force_tls_1_2": true,
         "proxy": "<NAME_OF_THE_PROXY_HOST>",
         "ignore_system_proxy": true,
-        "integration": "<INTEGRATION_NAME>"
+        "integration": "<INTEGRATION_NAME>",
+        "default_timeout": 300000
     }
 
 .. note::
@@ -424,16 +426,19 @@ With Amazon Secrets Manger
 Configure the AWS credentials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A full and comprehensive guide configuring the files and credentials regarding AWS can be found in their `official documentation. <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html>`_
+A full and comprehensive guide configuring the files and credentials regarding AWS can be found in their
+`official documentation. <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html>`_
 
 Adding a secret to the AWS Secrets Manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There is an official `guide for creating a secret <https://docs.aws.amazon.com/secretsmanager/latest/userguide/manage_create-basic-secret.html>`_ by AWS.
+There is an official
+`guide for creating a secret <https://docs.aws.amazon.com/secretsmanager/latest/userguide/manage_create-basic-secret.html>`_
+by AWS.
 
 .. note::
-    Add your secrets as a key/value pairs. In the :ref:`Explanation of API Credential Components` you can find full information on required fields and their purpose.
-
+    Add your secrets as a key/value pairs. In the :ref:`Explanation of API Credential Components` you can find full
+    information on required fields and their purpose.
 
 Using our credential provider for the SDK
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -450,7 +455,9 @@ the credential provider.
 AWS Single Sign-On Provider (SSO)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you wish to set the SSO provider follow this `tutorial <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#aws-single-sign-on-provider-sso>`_ for setting the config.
+If you wish to set the SSO provider follow this
+`tutorial <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#aws-single-sign-on-provider-sso>`_
+for setting the config.
 
 Then you can use the ``profile_name`` attribute in the ``AWSCredentialProvider`` like so:
 
@@ -504,6 +511,10 @@ or :ref:`with Windows Registry <With Windows Registry>`, the credentials include
 |                         | followed by the integration's version number.  Passed|         |          |
 |                         | as part of the ``User-Agent:`` HTTP header on all    |         |          |
 |                         | requests made by the SDK.                            |         |          |
++-------------------------+------------------------------------------------------+---------+----------+
+|``default_timeout``      | The default timeout for search queries, specified in |300000   | No       |
+|                         | milliseconds. This value may never be greater than   |         |          |
+|                         | the default of 300000 milliseconds.                  |         |          |
 +-------------------------+------------------------------------------------------+---------+----------+
 
 **X-AUTH-TOKEN** specific fields

--- a/docs/searching.rst
+++ b/docs/searching.rst
@@ -346,6 +346,26 @@ search result weighted as per the criteria provided::
     >>> print(synchronous_result.ranges)
     [{'start': '2020-10-16T00:00:00Z', 'end': '2020-11-16T00:00:00Z', 'bucket_size': '+1DAY', 'field': 'device_timestamp', 'values': None}]
 
+Query Timeouts
+--------------
+
+Some search queries make use of a timeout value, specified in milliseconds, which may be specified wither through
+a ``timeout`` parameter to a method, or via a ``timeout()`` setter method on a query class.  These timeouts follow a
+specific set of rules.
+
+The *absolute maximum* timeout value is 300,000 milliseconds (5 minutes).  No search may have a timeout longer
+than this.
+
+An application may specify a *shorter* maximum timeout value for all searches by including it in the credentials,
+under the key name ``default_timeout``.  This default timeout value may not be greater than the absolute maximum
+timeout.  If this value is specified, no search may have a timeout longer than this value.
+
+This means that, for any given search, the timeout will be the *smallest* of these values:
+
+* The value specified via a parameter to the search, if one was specified.
+* The value configured in the credentials, if one is so configured.
+* The absolute maximum timeout value, as defined above.
+
 Search Suggestions
 ------------------
 

--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -60,9 +60,9 @@ def construct_include(loader, node):
     with open(filename, 'rb') as f:
         if extension in ('yaml', 'yml'):
             return yaml.load(f, SwaggerLoader)
-        elif extension in ('json', ):
+        elif extension in ('json', ):  # pragma: no cover
             return json.load(f)
-        else:
+        else:  # pragma: no cover
             return ''.join(f.readlines())
 
 
@@ -97,7 +97,7 @@ class CbMetaModel(type):
 
         class_docstr = clsdict.get('__doc__', None)
         if not class_docstr:
-            class_docstr = f"Represents a {name} object in the Carbon Black Cloud."
+            class_docstr = f"Represents a {name} object in the Carbon Black Cloud."  # pragma: no cover
         need_header = True
         for field_name, field_info in iter(model_data.get("properties", {}).items()):
             docstring = field_info.get("description", None)
@@ -235,7 +235,7 @@ class ObjectFieldDescriptor(FieldDescriptor):
         return ret or {}
 
 
-class IsoDateTimeFieldDescriptor(FieldDescriptor):
+class IsoDateTimeFieldDescriptor(FieldDescriptor):  # pragma: no cover
     """Field descriptor for fields of 'iso-date-time' type."""
     def __init__(self, field_name):
         """
@@ -272,7 +272,7 @@ class IsoDateTimeFieldDescriptor(FieldDescriptor):
         super(IsoDateTimeFieldDescriptor, self).__set__(instance, parsed_date)
 
 
-class EpochDateTimeFieldDescriptor(FieldDescriptor):
+class EpochDateTimeFieldDescriptor(FieldDescriptor):  # pragma: no cover
     """Field descriptor for fields of 'epoch-ms-date-time' type."""
     def __init__(self, field_name, multiplier=1.0):
         """
@@ -318,7 +318,7 @@ class EpochDateTimeFieldDescriptor(FieldDescriptor):
         super(EpochDateTimeFieldDescriptor, self).__set__(instance, new_value)
 
 
-class ForeignKeyFieldDescriptor(FieldDescriptor):
+class ForeignKeyFieldDescriptor(FieldDescriptor):  # pragma: no cover
     """Field descriptor for fields that are foreign keys."""
     def __init__(self, field_name, join_model, join_field=None):
         """
@@ -364,7 +364,7 @@ class ForeignKeyFieldDescriptor(FieldDescriptor):
             setattr(self, self.join_field, value)
 
 
-class BinaryFieldDescriptor(FieldDescriptor):
+class BinaryFieldDescriptor(FieldDescriptor):  # pragma: no cover
     """Field descriptor for fields of 'byte' type."""
     def __get__(self, instance, instance_type=None):
         """
@@ -502,11 +502,11 @@ class NewBaseModel(object, metaclass=CbMetaModel):
             return self._info[item]
 
         # if we're still here, let's load the object if we haven't done so already.
-        if not self._full_init:
+        if not self._full_init:  # pragma: no cover
             self._refresh()
 
         # try one more time.
-        if item in self._info:
+        if item in self._info:  # pragma: no cover
             return self._info[item]
         else:
             raise AttributeError("'{0}' object has no attribute '{1}'".format(self.__class__.__name__,
@@ -541,7 +541,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
         """
         return getattr(self, attrname, default_val)
 
-    def _set(self, attrname, new_value):
+    def _set(self, attrname, new_value):  # pragma: no cover
         pass
 
     def refresh(self):
@@ -582,7 +582,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
         if self._model_unique_id is not None:
             return "<%s.%s: id %s> @ %s" % (self.__class__.__module__, self.__class__.__name__, self._model_unique_id,
                                             self._cb.session.server)
-        else:
+        else:  # pragma: no cover
             return "<%s.%s object at %s> @ %s" % (self.__class__.__module__, self.__class__.__name__, hex(id(self)),
                                                   self._cb.session.server)
 
@@ -618,7 +618,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
         """
         try:
             string_value = str(value)
-        except UnicodeDecodeError:
+        except UnicodeDecodeError:  # pragma: no cover
             string_value = repr(value)
         if len(string_value) > NewBaseModel.MAX_VALUE_WIDTH:
             string_value = string_value[:NewBaseModel.MAX_VALUE_WIDTH - 3] + "..."
@@ -762,7 +762,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
 
         return "\n".join(lines)
 
-    def _join(self, join_cls, field_name):
+    def _join(self, join_cls, field_name):  # pragma: no cover
         try:
             field_value = getattr(self, field_name)
         except AttributeError:
@@ -777,7 +777,7 @@ class NewBaseModel(object, metaclass=CbMetaModel):
 class UnrefreshableModel(NewBaseModel):
     """Represents a model that can't be refreshed, i.e. for which ``reset()`` is not a valid operation."""
 
-    def refresh(self):
+    def refresh(self):  # pragma: no cover
         """Reload this object from the server."""
         raise ApiError("refresh() called on an unrefreshable model")
 
@@ -802,7 +802,7 @@ class MutableBaseModel(NewBaseModel):
             return propobj.fset(self, val)
 
         if not attrname.startswith("_") and attrname not in self.__class__._valid_fields:
-            if attrname in self._info:
+            if attrname in self._info:  # pragma: no cover
                 log.warning("Changing field not included in Swagger definition: {0:s}".format(attrname))
                 self._set(attrname, val)
             else:
@@ -2087,7 +2087,7 @@ class FacetQuery(BaseQuery, AsyncQueryMixin, QueryBuilderSupportMixin, CriteriaB
         self._query_token = None
         # whether self._total_results is a valid value
         self._count_valid = False
-        # seconds to wait for num_contacted == num_completed until timing out
+        # milliseconds to wait for num_contacted == num_completed until timing out
         self._timeout = cb.credentials.default_timeout
         # whether the query timed-out
         self._timed_out = False
@@ -2102,7 +2102,8 @@ class FacetQuery(BaseQuery, AsyncQueryMixin, QueryBuilderSupportMixin, CriteriaB
         self._default_args = {}
 
     def timeout(self, msecs):
-        """Sets the timeout on an AsyncQuery. By default, there is no timeout.
+        """
+        Sets the timeout on an AsyncQuery.
 
         Arguments:
             msecs (int): Timeout duration, in milliseconds.  This value can never be greater than the configured

--- a/src/cbc_sdk/connection.py
+++ b/src/cbc_sdk/connection.py
@@ -418,7 +418,7 @@ class BaseAPI(object):
                 Uses the profile named 'default' when not specified.
             proxy_session (requests.session.Session): Proxy session to be used for cookie persistence, connection
                 pooling, and configuration.  Default is ``None`` (use the standard session).
-            timeout (float): The timeout to use for for API requests.  Default is ``None`` (no timeout).
+            timeout (float): The timeout to use for API request connections.  Default is ``None`` (no timeout).
             token (str): The API token to use when accessing the Carbon Black Cloud.
             url (str): The URL of the Carbon Black Cloud provider to use.
         """

--- a/src/cbc_sdk/credential_providers/registry_credential_provider.py
+++ b/src/cbc_sdk/credential_providers/registry_credential_provider.py
@@ -162,6 +162,27 @@ class RegistryCredentialProvider(CredentialProvider):
             return val[0] != 0
         return None
 
+    def _read_int(self, key, value_name):
+        """
+        Read an integer value from the registry key specified.
+
+        Args:
+            key (PyHKEY): The key to read a value from.
+            value_name (str): The name of the value to be returned.
+
+        Returns:
+            int: The value read in. May return None if the value was not found.
+
+        Raises:
+            CredentialError: If there was an error reading the value, or if the value was of the wrong type.
+        """
+        val = self._read_value(key, value_name)
+        if val:
+            if val[1] != REG_DWORD:
+                raise CredentialError(f"value '{value_name}` is not of integer type")
+            return val[0]
+        return None
+
     def _read_credentials(self, key):
         """
         Read in a complete credentials set from a registry key.
@@ -179,6 +200,10 @@ class RegistryCredentialProvider(CredentialProvider):
         for cv in list(CredentialValue):
             if cv.requires_boolean_value():
                 value = self._read_bool(key, cv.name.lower())
+                if value is not None:
+                    input[cv] = value
+            elif cv.requires_integer_value():
+                value = self._read_int(key, cv.name.lower())
                 if value is not None:
                     input[cv] = value
             else:

--- a/src/cbc_sdk/credential_providers/registry_credential_provider.py
+++ b/src/cbc_sdk/credential_providers/registry_credential_provider.py
@@ -28,7 +28,7 @@ try:
     HKEY_LOCAL_MACHINE = winreg.HKEY_LOCAL_MACHINE
     OpenKey = winreg.OpenKey
     QueryValueEx = winreg.QueryValueEx
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover
     HKEY_CURRENT_USER = object()
     HKEY_LOCAL_MACHINE = object()
 
@@ -79,7 +79,7 @@ class RegistryCredentialProvider(CredentialProvider):
         """
         return HKEY_CURRENT_USER if self._userkey else HKEY_LOCAL_MACHINE
 
-    def _open_key(self, basekey, path):
+    def _open_key(self, basekey, path):  # pragma: no cover
         """
         Open a key for use.  This is a "test point" intended to be monkeypatched.
 
@@ -98,7 +98,7 @@ class RegistryCredentialProvider(CredentialProvider):
         except OSError as e:
             raise CredentialError(f"Unable to open registry subkey: {path}") from e
 
-    def _read_value(self, key, value_name):
+    def _read_value(self, key, value_name):  # pragma: no cover
         """
         Read a value from the registry key specified.  This is a "test point" intended to be monkeypatched.
 

--- a/src/cbc_sdk/credentials.py
+++ b/src/cbc_sdk/credentials.py
@@ -273,7 +273,7 @@ class Credentials(object):
 class CredentialProvider:
     """The interface implemented by a credential provider."""
 
-    def get_credentials(self, section=None):
+    def get_credentials(self, section=None):  # pragma: no cover
         """
         Return a Credentials object containing the configured credentials.
 

--- a/src/cbc_sdk/endpoint_standard/base.py
+++ b/src/cbc_sdk/endpoint_standard/base.py
@@ -104,7 +104,7 @@ class EnrichedEvent(UnrefreshableModel):
             force_init (bool): True to force object initialization.
             full_doc (bool): True to mark the object as fully initialized.
         """
-        self._details_timeout = 0
+        self._details_timeout = cb.credentials.default_timeout
         self._info = None
         if model_unique_id is not None and initial_data is None:
             enriched_event_future = cb.select(EnrichedEvent).where(event_id=model_unique_id).execute_async()
@@ -130,14 +130,18 @@ class EnrichedEvent(UnrefreshableModel):
         """Requests detailed results.
 
         Args:
-            timeout (int): Event details request timeout in milliseconds.
+            timeout (int): Event details request timeout in milliseconds.  This value can never be greater than
+                the configured default timeout.  If this value is 0, the configured default timeout is used.
             async_mode (bool): True to request details in an asynchronous manner.
 
         Note:
             - When using asynchronous mode, this method returns a python future.
               You can call result() on the future object to wait for completion and get the results.
         """
-        self._details_timeout = timeout
+        if timeout <= 0:
+            self._details_timeout = self._cb.credentials.default_timeout
+        else:
+            self._details_timeout = min(timeout, self._cb.credentials.default_timeout)
         if not self.event_id:
             raise ApiError("Trying to get event details on an invalid event_id")
         if async_mode:
@@ -147,6 +151,7 @@ class EnrichedEvent(UnrefreshableModel):
 
     def _get_detailed_results(self):
         """Actual search details implementation"""
+        assert self._details_timeout > 0
         args = {"event_ids": [self.event_id]}
         url = "/api/investigate/v2/orgs/{}/enriched_events/detail_jobs".format(self._cb.credentials.org_key)
         query_start = self._cb.post_object(url, body=args)
@@ -167,7 +172,7 @@ class EnrichedEvent(UnrefreshableModel):
                 time.sleep(.5)
                 continue
             if searchers_completed < searchers_contacted:
-                if self._details_timeout != 0 and (time.time() * 1000) - submit_time > self._details_timeout:
+                if (time.time() * 1000) - submit_time > self._details_timeout:
                     timed_out = True
                     break
             else:
@@ -337,7 +342,7 @@ class EnrichedEventQuery(BaseEventQuery):
         super(EnrichedEventQuery, self).__init__(doc_class, cb)
         self._default_args["rows"] = self._batch_size
         self._query_token = None
-        self._timeout = 0
+        self._timeout = cb.credentials.default_timeout
         self._timed_out = False
         self._aggregation = False
         self._aggregation_field = None
@@ -383,16 +388,19 @@ class EnrichedEventQuery(BaseEventQuery):
         """Sets the timeout on a event query.
 
         Arguments:
-            msecs (int): Timeout duration, in milliseconds.
+            msecs (int): Timeout duration, in milliseconds.  This value can cever be greater than the configured
+                default timeout.  If this value is 0, the configured default timeout is used.
 
         Returns:
-            Query (EnrichedEventQuery): The Query object with new milliseconds
-                parameter.
+            Query (EnrichedEventQuery): The Query object with new milliseconds parameter.
 
         Example:
             >>> cb.select(EnrichedEvent).where(process_name="foo.exe").timeout(5000)
         """
-        self._timeout = msecs
+        if msecs <= 0:
+            self._timeout = self._cb.credentials.default_timeout
+        else
+            self._timeout = min(msecs, self._cb.credentials.default_timeout)
         return self
 
     def _submit(self):
@@ -412,6 +420,7 @@ class EnrichedEventQuery(BaseEventQuery):
         self._submit_time = time.time() * 1000
 
     def _still_querying(self):
+        assert self._timeout > 0
         if not self._query_token:
             self._submit()
 
@@ -429,7 +438,7 @@ class EnrichedEventQuery(BaseEventQuery):
         if searchers_contacted == 0:
             return True
         if searchers_completed < searchers_contacted:
-            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:
+            if (time.time() * 1000) - self._submit_time > self._timeout:
                 self._timed_out = True
                 return False
             return True

--- a/src/cbc_sdk/endpoint_standard/base.py
+++ b/src/cbc_sdk/endpoint_standard/base.py
@@ -399,7 +399,7 @@ class EnrichedEventQuery(BaseEventQuery):
         """
         if msecs <= 0:
             self._timeout = self._cb.credentials.default_timeout
-        else
+        else:
             self._timeout = min(msecs, self._cb.credentials.default_timeout)
         return self
 

--- a/src/cbc_sdk/enterprise_edr/auth_events.py
+++ b/src/cbc_sdk/enterprise_edr/auth_events.py
@@ -55,7 +55,7 @@ class AuthEvent(NewBaseModel):
             >>> events = cb.select(AuthEvent).where("auth_username:SYSTEM")
             >>> print(*events)
         """
-        self._details_timeout = 0
+        self._details_timeout = 0  # FIXPOINT
         self._info = None
         if model_unique_id is not None and initial_data is None:
             auth_events_future = (
@@ -121,7 +121,7 @@ class AuthEvent(NewBaseModel):
             >>> events = cb.select(AuthEvent).where(process_pid=2000)
             >>> print(events[0].get_details())
         """
-        self._details_timeout = timeout
+        self._details_timeout = timeout  # FIXPOINT
         if not self.event_id:
             raise ApiError(
                 "Trying to get auth_event details on an invalid auth_event_id"
@@ -137,7 +137,7 @@ class AuthEvent(NewBaseModel):
         obj = AuthEvent._helper_get_details(
             self._cb,
             event_ids=[self.event_id],
-            timeout=self._details_timeout,
+            timeout=self._details_timeout,  # FIXPOINT
         )
         if obj:
             self._info = deepcopy(obj._info)
@@ -189,7 +189,7 @@ class AuthEvent(NewBaseModel):
                 time.sleep(0.5)
                 continue
             if completed < contacted:
-                if timeout != 0 and (time.time() * 1000) - submit_time > timeout:
+                if timeout != 0 and (time.time() * 1000) - submit_time > timeout:  # FIXPOINT
                     timed_out = True
                     break
             else:
@@ -305,7 +305,7 @@ class AuthEvent(NewBaseModel):
             alert_id=alert_id,
             event_ids=event_ids,
             bulk=True,
-            timeout=timeout
+            timeout=timeout  # FIXPOINT
         )
 
 
@@ -520,7 +520,7 @@ class AuthEventQuery(Query):
         super(AuthEventQuery, self).__init__(doc_class, cb)
         self._default_args["rows"] = self._batch_size
         self._query_token = None
-        self._timeout = 0
+        self._timeout = 0  # FIXPOINT
         self._timed_out = False
 
     def or_(self, **kwargs):
@@ -574,7 +574,7 @@ class AuthEventQuery(Query):
             >>> events = cb.select(AuthEvent).where(process_name="chrome.exe").timeout(5000)
             >>> print(*events)
         """
-        self._timeout = msecs
+        self._timeout = msecs  # FIXPOINT
         return self
 
     def _submit(self):
@@ -613,7 +613,7 @@ class AuthEventQuery(Query):
         if contacted == 0:
             return True
         if completed < contacted:
-            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:
+            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:  # FIXPOINT
                 self._timed_out = True
                 return False
             return True

--- a/src/cbc_sdk/enterprise_edr/auth_events.py
+++ b/src/cbc_sdk/enterprise_edr/auth_events.py
@@ -29,14 +29,7 @@ class AuthEvent(NewBaseModel):
     validation_url = "/api/investigate/v2/orgs/{}/auth_events/search_validation"
     swagger_meta_file = "enterprise_edr/models/auth_events.yaml"
 
-    def __init__(
-        self,
-        cb,
-        model_unique_id=None,
-        initial_data=None,
-        force_init=False,
-        full_doc=False,
-    ):
+    def __init__(self, cb, model_unique_id=None, initial_data=None, force_init=False, full_doc=False):
         """
         Initialize the AuthEvent object.
 
@@ -55,7 +48,7 @@ class AuthEvent(NewBaseModel):
             >>> events = cb.select(AuthEvent).where("auth_username:SYSTEM")
             >>> print(*events)
         """
-        self._details_timeout = 0  # FIXPOINT
+        self._details_timeout = cb.credentials.default_timeout
         self._info = None
         if model_unique_id is not None and initial_data is None:
             auth_events_future = (
@@ -105,7 +98,8 @@ class AuthEvent(NewBaseModel):
         """Requests detailed results.
 
         Args:
-            timeout (int): AuthEvent details request timeout in milliseconds.
+            timeout (int): AuthEvent details request timeout in milliseconds.  This can never be greater than the
+                configured default timeout.  If this is 0, the configured default timeout is used.
             async_mode (bool): True to request details in an asynchronous manner.
 
         Returns:
@@ -121,7 +115,10 @@ class AuthEvent(NewBaseModel):
             >>> events = cb.select(AuthEvent).where(process_pid=2000)
             >>> print(events[0].get_details())
         """
-        self._details_timeout = timeout  # FIXPOINT
+        if timeout <= 0 or timeout > self._cb.credentials.default_timeout:
+            self._details_timeout = self._cb.credentials.default_timeout
+        else:
+            self._details_timeout = timeout
         if not self.event_id:
             raise ApiError(
                 "Trying to get auth_event details on an invalid auth_event_id"
@@ -137,7 +134,7 @@ class AuthEvent(NewBaseModel):
         obj = AuthEvent._helper_get_details(
             self._cb,
             event_ids=[self.event_id],
-            timeout=self._details_timeout,  # FIXPOINT
+            timeout=self._details_timeout,
         )
         if obj:
             self._info = deepcopy(obj._info)
@@ -153,7 +150,8 @@ class AuthEvent(NewBaseModel):
             alert_id (str):  An alert id to fetch associated auth_events
             event_ids (list): A list of auth_event ids to fetch
             bulk (bool): Whether it is a bulk request
-            timeout (int): AuthEvents details request timeout in milliseconds.
+            timeout (int): AuthEvents details request timeout in milliseconds.  This can never be greater than the
+                configured default timeout.  If this value is 0, the configured default timeout is used.
 
         Returns:
             AuthEvent or list(AuthEvent): if it is a bulk operation a list, otherwise AuthEvent
@@ -161,6 +159,8 @@ class AuthEvent(NewBaseModel):
         Raises:
             ApiError: if cb is not instance of CBCloudAPI
         """
+        if timeout <= 0 or timeout > cb.credentials.default_timeout:
+            timeout = cb.credentials.default_timeout
         if cb.__class__.__name__ != "CBCloudAPI":
             raise ApiError("cb argument should be instance of CBCloudAPI.")
         if (alert_id and event_ids) or not (alert_id or event_ids):
@@ -189,7 +189,7 @@ class AuthEvent(NewBaseModel):
                 time.sleep(0.5)
                 continue
             if completed < contacted:
-                if timeout != 0 and (time.time() * 1000) - submit_time > timeout:  # FIXPOINT
+                if (time.time() * 1000) - submit_time > timeout:
                     timed_out = True
                     break
             else:
@@ -282,7 +282,8 @@ class AuthEvent(NewBaseModel):
             cb (CBCloudAPI): A reference to the CBCloudAPI object.
             alert_id (str):  An alert id to fetch associated events
             event_ids (list): A list of event ids to fetch
-            timeout (int): AuthEvent details request timeout in milliseconds.
+            timeout (int): AuthEvent details request timeout in milliseconds.  This can never be greater than the
+                configured default timeout.  If this value is 0, the configured default timeout is used.
 
         Returns:
             list: list of Auth Events
@@ -305,7 +306,7 @@ class AuthEvent(NewBaseModel):
             alert_id=alert_id,
             event_ids=event_ids,
             bulk=True,
-            timeout=timeout  # FIXPOINT
+            timeout=timeout
         )
 
 
@@ -520,7 +521,7 @@ class AuthEventQuery(Query):
         super(AuthEventQuery, self).__init__(doc_class, cb)
         self._default_args["rows"] = self._batch_size
         self._query_token = None
-        self._timeout = 0  # FIXPOINT
+        self._timeout = cb.credentials.default_timeout
         self._timed_out = False
 
     def or_(self, **kwargs):
@@ -563,18 +564,21 @@ class AuthEventQuery(Query):
         """Sets the timeout on a Auth Event query.
 
         Arguments:
-            msecs (int): Timeout duration, in milliseconds.
+            msecs (int): Timeout duration, in milliseconds.  This value can never be greater than the configured
+                default timeout.  If this value is 0, the configured default timeout is used.
 
         Returns:
-            Query (AuthEventQuery): The Query object with new milliseconds
-                parameter.
+            Query (AuthEventQuery): The Query object with new milliseconds parameter.
 
         Example:
             >>> cb = CBCloudAPI(profile="example_profile")
             >>> events = cb.select(AuthEvent).where(process_name="chrome.exe").timeout(5000)
             >>> print(*events)
         """
-        self._timeout = msecs  # FIXPOINT
+        if msecs <= 0:
+            self._timeout = self._cb.credentials.default_timeout
+        else
+            self._timeout = min(msecs, self._cb.credentials.default_timeout)
         return self
 
     def _submit(self):
@@ -596,6 +600,7 @@ class AuthEventQuery(Query):
 
     def _still_querying(self):
         """Check whether there are still records to be collected."""
+        assert self._timeout > 0
         if not self._query_token:
             self._submit()
 
@@ -613,7 +618,7 @@ class AuthEventQuery(Query):
         if contacted == 0:
             return True
         if completed < contacted:
-            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:  # FIXPOINT
+            if (time.time() * 1000) - self._submit_time > self._timeout:
                 self._timed_out = True
                 return False
             return True

--- a/src/cbc_sdk/enterprise_edr/auth_events.py
+++ b/src/cbc_sdk/enterprise_edr/auth_events.py
@@ -577,7 +577,7 @@ class AuthEventQuery(Query):
         """
         if msecs <= 0:
             self._timeout = self._cb.credentials.default_timeout
-        else
+        else:
             self._timeout = min(msecs, self._cb.credentials.default_timeout)
         return self
 

--- a/src/cbc_sdk/platform/observations.py
+++ b/src/cbc_sdk/platform/observations.py
@@ -457,7 +457,7 @@ class ObservationQuery(Query):
         """
         if msecs <= 0:
             self._timeout = self._cb.credentials.default_timeout
-        else
+        else:
             self._timeout = min(msecs, self._cb.credentials.default_timeout)
         return self
 

--- a/src/cbc_sdk/platform/observations.py
+++ b/src/cbc_sdk/platform/observations.py
@@ -51,7 +51,7 @@ class Observation(NewBaseModel):
             force_init (bool): True to force object initialization.
             full_doc (bool): False to mark the object as not fully initialized.
         """
-        self._details_timeout = 0
+        self._details_timeout = 0  # FIXPOINT
         self._info = None
         if model_unique_id is not None and initial_data is None:
             observations_future = (
@@ -118,7 +118,7 @@ class Observation(NewBaseModel):
             >>> observations = api.select(Observation).where(process_pid=2000)
             >>> observations[0].get_details()
         """
-        self._details_timeout = timeout
+        self._details_timeout = timeout  # FIXPOINT
         if not self.observation_id:
             raise ApiError(
                 "Trying to get observation details on an invalid observation_id"
@@ -135,7 +135,7 @@ class Observation(NewBaseModel):
         obj = Observation._helper_get_details(
             self._cb,
             observation_ids=[self.observation_id],
-            timeout=self._details_timeout,
+            timeout=self._details_timeout,  # FIXPOINT
         )
         if obj:
             self._info = deepcopy(obj._info)
@@ -186,7 +186,7 @@ class Observation(NewBaseModel):
                 time.sleep(0.5)
                 continue
             if completed < contacted:
-                if timeout != 0 and (time.time() * 1000) - submit_time > timeout:
+                if timeout != 0 and (time.time() * 1000) - submit_time > timeout:  # FIXPOINT
                     timed_out = True
                     break
             else:
@@ -288,7 +288,7 @@ class Observation(NewBaseModel):
             alert_id=alert_id,
             observation_ids=observation_ids,
             bulk=True,
-            timeout=timeout
+            timeout=timeout  # FIXPOINT
         )
 
 
@@ -408,7 +408,7 @@ class ObservationQuery(Query):
         super(ObservationQuery, self).__init__(doc_class, cb)
         self._default_args["rows"] = self._batch_size
         self._query_token = None
-        self._timeout = 0
+        self._timeout = 0  # FIXPOINT
         self._timed_out = False
 
     def or_(self, **kwargs):
@@ -453,7 +453,7 @@ class ObservationQuery(Query):
         Example:
             >>> cb.select(Observation).where(process_name="foo.exe").timeout(5000)
         """
-        self._timeout = msecs
+        self._timeout = msecs  # FIXPOINT
         return self
 
     def _submit(self):
@@ -492,7 +492,7 @@ class ObservationQuery(Query):
         if contacted == 0:
             return True
         if completed < contacted:
-            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:
+            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:  # FIXPOINT
                 self._timed_out = True
                 return False
             return True

--- a/src/cbc_sdk/platform/observations.py
+++ b/src/cbc_sdk/platform/observations.py
@@ -30,14 +30,7 @@ class Observation(NewBaseModel):
     validation_url = "/api/investigate/v2/orgs/{}/observations/search_validation"
     swagger_meta_file = "platform/models/observation.yaml"
 
-    def __init__(
-        self,
-        cb,
-        model_unique_id=None,
-        initial_data=None,
-        force_init=False,
-        full_doc=False,
-    ):
+    def __init__(self, cb, model_unique_id=None, initial_data=None, force_init=False, full_doc=False):
         """
         Initialize the Observation object.
 
@@ -51,7 +44,7 @@ class Observation(NewBaseModel):
             force_init (bool): True to force object initialization.
             full_doc (bool): False to mark the object as not fully initialized.
         """
-        self._details_timeout = 0  # FIXPOINT
+        self._details_timeout = cb.credentials.default_timeout
         self._info = None
         if model_unique_id is not None and initial_data is None:
             observations_future = (
@@ -101,7 +94,8 @@ class Observation(NewBaseModel):
         """Requests detailed results.
 
         Args:
-            timeout (int): Observations details request timeout in milliseconds.
+            timeout (int): Observations details request timeout in milliseconds.  This may never be greater than the
+                configured default timeout.  If this value is 0, the configured default timeout is used.
             async_mode (bool): True to request details in an asynchronous manner.
 
         Returns:
@@ -118,7 +112,10 @@ class Observation(NewBaseModel):
             >>> observations = api.select(Observation).where(process_pid=2000)
             >>> observations[0].get_details()
         """
-        self._details_timeout = timeout  # FIXPOINT
+        if timeout <= 0:
+            self._details_timeout = self._cb.credentials.default_timeout
+        else:
+            self._details_timeout = min(timeout, self._cb.credentials.default_timeout)
         if not self.observation_id:
             raise ApiError(
                 "Trying to get observation details on an invalid observation_id"
@@ -135,7 +132,7 @@ class Observation(NewBaseModel):
         obj = Observation._helper_get_details(
             self._cb,
             observation_ids=[self.observation_id],
-            timeout=self._details_timeout,  # FIXPOINT
+            timeout=self._details_timeout,
         )
         if obj:
             self._info = deepcopy(obj._info)
@@ -150,7 +147,8 @@ class Observation(NewBaseModel):
             alert_id (str):  An alert id to fetch associated observations
             observation_ids (list): A list of observation ids to fetch
             bulk (bool): Whether it is a bulk request
-            timeout (int): Observations details request timeout in milliseconds.
+            timeout (int): Observations details request timeout in milliseconds.  This may never be greater than
+                the configured default timeout.  If this value is 0, the configured default timeout is used.
 
         Returns:
             Observation or list(Observation): if it is a bulk operation a list, otherwise Observation
@@ -158,6 +156,8 @@ class Observation(NewBaseModel):
         Raises:
             ApiError: if cb is not instance of CBCloudAPI
         """
+        if timeout <= 0 or timeout > cb.credentials.default_timeout:
+            timeout = cb.credentials.default_timeout
         if cb.__class__.__name__ != "CBCloudAPI":
             raise ApiError("cb argument should be instance of CBCloudAPI.")
         if (alert_id and observation_ids) or not (alert_id or observation_ids):
@@ -186,7 +186,7 @@ class Observation(NewBaseModel):
                 time.sleep(0.5)
                 continue
             if completed < contacted:
-                if timeout != 0 and (time.time() * 1000) - submit_time > timeout:  # FIXPOINT
+                if (time.time() * 1000) - submit_time > timeout:
                     timed_out = True
                     break
             else:
@@ -273,7 +273,8 @@ class Observation(NewBaseModel):
             cb (CBCloudAPI): A reference to the CBCloudAPI object.
             alert_id (str):  An alert id to fetch associated observations
             observation_ids (list): A list of observation ids to fetch
-            timeout (int): Observations details request timeout in milliseconds.
+            timeout (int): Observations details request timeout in milliseconds.  This may never be greater than
+                the configured default timeout.  If this value is 0, the configured default timeout is used.
 
         Returns:
             list: list of Observations
@@ -288,7 +289,7 @@ class Observation(NewBaseModel):
             alert_id=alert_id,
             observation_ids=observation_ids,
             bulk=True,
-            timeout=timeout  # FIXPOINT
+            timeout=timeout
         )
 
 
@@ -408,7 +409,7 @@ class ObservationQuery(Query):
         super(ObservationQuery, self).__init__(doc_class, cb)
         self._default_args["rows"] = self._batch_size
         self._query_token = None
-        self._timeout = 0  # FIXPOINT
+        self._timeout = cb.credentials.default_timeout
         self._timed_out = False
 
     def or_(self, **kwargs):
@@ -441,19 +442,23 @@ class ObservationQuery(Query):
         return self
 
     def timeout(self, msecs):
-        """Sets the timeout on a observation query.
+        """
+        Sets the timeout on a observation query.
 
         Arguments:
-            msecs (int): Timeout duration, in milliseconds.
+            msecs (int): Timeout duration, in milliseconds.  This may never be greater than the configured default
+                timeout.  If this value is 0, the configured default timeout is used.
 
         Returns:
-            Query (ObservationQuery): The Query object with new milliseconds
-                parameter.
+            Query (ObservationQuery): The Query object with new milliseconds parameter.
 
         Example:
             >>> cb.select(Observation).where(process_name="foo.exe").timeout(5000)
         """
-        self._timeout = msecs  # FIXPOINT
+        if msecs <= 0:
+            self._timeout = self._cb.credentials.default_timeout
+        else
+            self._timeout = min(msecs, self._cb.credentials.default_timeout)
         return self
 
     def _submit(self):
@@ -475,6 +480,7 @@ class ObservationQuery(Query):
 
     def _still_querying(self):
         """Check whether there are still records to be collected."""
+        assert self._timeout > 0
         if not self._query_token:
             self._submit()
 
@@ -492,7 +498,7 @@ class ObservationQuery(Query):
         if contacted == 0:
             return True
         if completed < contacted:
-            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:  # FIXPOINT
+            if (time.time() * 1000) - self._submit_time > self._timeout:
                 self._timed_out = True
                 return False
             return True

--- a/src/cbc_sdk/platform/processes.py
+++ b/src/cbc_sdk/platform/processes.py
@@ -240,7 +240,7 @@ class Process(UnrefreshableModel):
 
     def _retrieve_cb_info(self):
         """Retrieve the detailed information about this object."""
-        self._details_timeout = 0
+        self._details_timeout = 0   # FIXPOINT
         return self._get_detailed_results()._info
 
     @property
@@ -381,7 +381,7 @@ class Process(UnrefreshableModel):
                 retrieve the results.
             dict: If ``async_mode`` is ``False``.
         """
-        self._details_timeout = timeout
+        self._details_timeout = timeout  # FIXPOINT
         if not self.process_guid:
             raise ApiError("Trying to get process details on an invalid process_guid")
         if async_mode:
@@ -411,7 +411,7 @@ class Process(UnrefreshableModel):
                 time.sleep(.5)
                 continue
             if searchers_completed < searchers_contacted:
-                if self._details_timeout != 0 and (time.time() * 1000) - submit_time > self._details_timeout:
+                if self._details_timeout != 0 and (time.time() * 1000) - submit_time > self._details_timeout:  # FIXPOINT
                     timed_out = True
                     break
             else:
@@ -617,7 +617,7 @@ class AsyncProcessQuery(Query):
         """
         super(AsyncProcessQuery, self).__init__(doc_class, cb)
         self._query_token = None
-        self._timeout = 0
+        self._timeout = 0  # FIXPOINT
         self._timed_out = False
 
     def timeout(self, msecs):
@@ -699,7 +699,7 @@ class AsyncProcessQuery(Query):
         if searchers_contacted == 0:
             return True
         if searchers_completed < searchers_contacted:
-            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:
+            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:  # FIXPOINT
                 self._timed_out = True
                 return False
             return True
@@ -846,7 +846,7 @@ class SummaryQuery(BaseQuery, AsyncQueryMixin, QueryBuilderSupportMixin):
         self._query_builder = QueryBuilder()
         self._query_token = None
         self._full_init = False
-        self._timeout = 0
+        self._timeout = 0  # FIXPOINT
         self._timed_out = False
         self._time_range = {}
 
@@ -962,7 +962,7 @@ class SummaryQuery(BaseQuery, AsyncQueryMixin, QueryBuilderSupportMixin):
         if searchers_contacted == 0:
             return True
         if searchers_completed < searchers_contacted:
-            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:
+            if self._timeout != 0 and (time.time() * 1000) - self._submit_time > self._timeout:  # FIXPOINT
                 self._timed_out = True
                 return False
             return True

--- a/src/cbc_sdk/platform/processes.py
+++ b/src/cbc_sdk/platform/processes.py
@@ -127,7 +127,7 @@ class Process(UnrefreshableModel):
                             if attr in self.SHOW_ATTR[top_level]['fields']:
                                 try:
                                     val = str(self._info[top_level][attr])
-                                except UnicodeDecodeError:
+                                except UnicodeDecodeError:  # pragma: no cover
                                     val = repr(self._info[top_level][attr])
                                 lines.append(u"{0:s} {1:>20s}: {2:s}".format("    ", attr, val))
                     else:
@@ -136,7 +136,7 @@ class Process(UnrefreshableModel):
                                 if attr in self.SHOW_ATTR[top_level]['fields']:
                                     try:
                                         val = str(item[attr])
-                                    except UnicodeDecodeError:
+                                    except UnicodeDecodeError:  # pragma: no cover
                                         val = repr(item[attr])
                                     lines.append(u"{0:s} {1:>20s}: {2:s}".format("    ", attr, val))
                             lines.append('')
@@ -193,7 +193,7 @@ class Process(UnrefreshableModel):
                 if attr in self.SHOW_ATTR['top']:
                     try:
                         val = str(self._info[attr])
-                    except UnicodeDecodeError:
+                    except UnicodeDecodeError:  # pragma: no cover
                         val = repr(self._info[attr])
                     lines.append(u"{0:s} {1:>20s}: {2:s}".format("    ", attr, val))
 
@@ -203,7 +203,7 @@ class Process(UnrefreshableModel):
                     if attr in self.SHOW_ATTR['children']:
                         try:
                             val = str(child[attr])
-                        except UnicodeDecodeError:
+                        except UnicodeDecodeError:  # pragma: no cover
                             val = repr(child[attr])
                         lines.append(u"{0:s} {1:>20s}: {2:s}".format("    ", attr, val))
                 lines.append('')
@@ -238,7 +238,7 @@ class Process(UnrefreshableModel):
         super(Process, self).__init__(cb, model_unique_id=model_unique_id, initial_data=initial_data,
                                       force_init=force_init, full_doc=full_doc)
 
-    def _retrieve_cb_info(self):
+    def _retrieve_cb_info(self):  # pragma: no cover
         """Retrieve the detailed information about this object."""
         self._details_timeout = self._cb.credentials.default_timeout
         return self._get_detailed_results()._info

--- a/src/cbc_sdk/rest_api.py
+++ b/src/cbc_sdk/rest_api.py
@@ -68,7 +68,7 @@ class CBCloudAPI(BaseAPI):
             proxy_session (requests.session.Session): Proxy session to be used for cookie persistence, connection
                 pooling, and configuration.  Default is ``None`` (use the standard session).
             thread_pool_count (int): The number of threads to create for asynchronous queries. Defaults to 3.
-            timeout (float): The timeout to use for for API requests.  Default is ``None`` (no timeout).
+            timeout (float): The timeout to use for for API connection requests.  Default is ``None`` (no timeout).
             token (str): The API token to use when accessing the Carbon Black Cloud.
             url (str): The URL of the Carbon Black Cloud provider to use.
         """

--- a/src/tests/unit/credential_providers/test_aws_secrets_manager.py
+++ b/src/tests/unit/credential_providers/test_aws_secrets_manager.py
@@ -52,7 +52,8 @@ def test_aws_getting_credentials(monkeypatch):
         'csp_api_token': None,
         'csp_oauth_app_id': None,
         'csp_oauth_app_secret': None,
-        'csp_url_override': 'https://console.cloud.vmware.com'
+        'csp_url_override': 'https://console.cloud.vmware.com',
+        'default_timeout': 256000
     }
 
     monkeypatch.setattr(Session, "client", ClientMock)

--- a/src/tests/unit/credential_providers/test_registry.py
+++ b/src/tests/unit/credential_providers/test_registry.py
@@ -164,10 +164,10 @@ def test_read_int_exceptions(monkeypatch, mox):
     sut._read_value(stub_key, "Bravo").AndRaise(CredentialError("Unable to read"))
     mox.ReplayAll()
     with pytest.raises(CredentialError) as e1:
-        sut._read_bool(stub_key, "Alpha")
+        sut._read_int(stub_key, "Alpha")
     assert "not of integer type" in str(e1.value)
     with pytest.raises(CredentialError) as e2:
-        sut._read_bool(stub_key, "Bravo")
+        sut._read_int(stub_key, "Bravo")
     assert "Unable to read" in str(e2.value)
     mox.VerifyAll()
 

--- a/src/tests/unit/credential_providers/test_registry.py
+++ b/src/tests/unit/credential_providers/test_registry.py
@@ -137,6 +137,41 @@ def test_read_bool_exceptions(monkeypatch, mox):
     mox.VerifyAll()
 
 
+@pytest.mark.parametrize('key, return_val, check_val', [
+    ('Alpha', (0, REG_DWORD), 0),
+    ('Bravo', (5, REG_DWORD), 5),
+    ('Charlie', None, None)
+])
+def test_read_int(monkeypatch, mox, key, return_val, check_val):
+    """Test reading integer values from the registry."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    sut = RegistryCredentialProvider()
+    mox.StubOutWithMock(sut, '_read_value')
+    stub_key = StubKeyObject()
+    sut._read_value(stub_key, key).AndReturn(return_val)
+    mox.ReplayAll()
+    assert sut._read_int(stub_key, key) == check_val
+    mox.VerifyAll()
+
+
+def test_read_int_exceptions(monkeypatch, mox):
+    """Test reading integer values from the registry, in ways that generate exceptions."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    sut = RegistryCredentialProvider()
+    mox.StubOutWithMock(sut, '_read_value')
+    stub_key = StubKeyObject()
+    sut._read_value(stub_key, "Alpha").AndReturn(("!Funky!Stuff!", REG_SZ))
+    sut._read_value(stub_key, "Bravo").AndRaise(CredentialError("Unable to read"))
+    mox.ReplayAll()
+    with pytest.raises(CredentialError) as e1:
+        sut._read_bool(stub_key, "Alpha")
+    assert "not of integer type" in str(e1.value)
+    with pytest.raises(CredentialError) as e2:
+        sut._read_bool(stub_key, "Bravo")
+    assert "Unable to read" in str(e2.value)
+    mox.VerifyAll()
+
+
 def test_read_credentials(monkeypatch, mox):
     """Test reading an entire Credentials object from the registry."""
     monkeypatch.setattr(sys, "platform", "win32")
@@ -157,6 +192,7 @@ def test_read_credentials(monkeypatch, mox):
     sut._read_value(stub_key, "csp_oauth_app_secret").AndReturn(("SECRET", REG_SZ))
     sut._read_value(stub_key, "csp_api_token").AndReturn(("API TOKEN", REG_SZ))
     sut._read_value(stub_key, "csp_url_override").AndReturn(("http://csp.com", REG_SZ))
+    sut._read_value(stub_key, "default_timeout").AndReturn((256000, REG_DWORD))
     mox.ReplayAll()
     creds = sut._read_credentials(stub_key)
     mox.VerifyAll()
@@ -174,6 +210,7 @@ def test_read_credentials(monkeypatch, mox):
     assert creds.csp_oauth_app_secret == "SECRET"
     assert creds.csp_api_token == "API TOKEN"
     assert creds.csp_url_override == "http://csp.com"
+    assert creds.default_timeout == 256000
 
 
 def test_read_credentials_defaults(monkeypatch, mox):
@@ -196,6 +233,7 @@ def test_read_credentials_defaults(monkeypatch, mox):
     sut._read_value(stub_key, "csp_oauth_app_secret").AndReturn(None)
     sut._read_value(stub_key, "csp_api_token").AndReturn(None)
     sut._read_value(stub_key, "csp_url_override").AndReturn(None)
+    sut._read_value(stub_key, "default_timeout").AndReturn(None)
     mox.ReplayAll()
     creds = sut._read_credentials(stub_key)
     mox.VerifyAll()
@@ -239,6 +277,7 @@ def test_get_credentials(monkeypatch, mox):
     sut._read_value(key2, "csp_oauth_app_secret").AndReturn(("SECRET", REG_SZ))
     sut._read_value(key2, "csp_api_token").AndReturn(("API-TOKEN", REG_SZ))
     sut._read_value(key2, "csp_url_override").AndReturn(("http://csp.com", REG_SZ))
+    sut._read_value(key2, "default_timeout").AndReturn((256000, REG_DWORD))
     mox.ReplayAll()
     creds = sut.get_credentials('default')
     assert creds.url == "http://example.com"
@@ -255,6 +294,7 @@ def test_get_credentials(monkeypatch, mox):
     assert creds.csp_oauth_app_secret == "SECRET"
     assert creds.csp_api_token == "API-TOKEN"
     assert creds.csp_url_override == "http://csp.com"
+    assert creds.default_timeout == 256000
     creds2 = sut.get_credentials('default')
     assert creds2 is creds
     mox.VerifyAll()

--- a/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events.py
+++ b/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events.py
@@ -274,9 +274,15 @@ def test_enriched_event_timeout(cbcsdk_mock):
     """Testing EnrichedEventQuery.timeout()."""
     api = cbcsdk_mock.api
     query = api.select(EnrichedEvent).where("event_id:some_id")
-    assert query._timeout == 0
+    assert query._timeout == 300000
     query.timeout(msecs=500)
     assert query._timeout == 500
+    query.timeout(msecs=999999)
+    assert query._timeout == 300000
+    query.timeout(msecs=700)
+    assert query._timeout == 700
+    query.timeout(msecs=0)
+    assert query._timeout == 300000
 
 
 def test_enriched_event_timeout_error(cbcsdk_mock):

--- a/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events_facet.py
+++ b/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events_facet.py
@@ -109,9 +109,15 @@ def test_enriched_event_facet_timeout(cbcsdk_mock):
     """Testing EnrichedEventQuery.timeout()."""
     api = cbcsdk_mock.api
     query = api.select(EnrichedEventFacet).where("process_name:some_name").add_facet_field("process_name")
-    assert query._timeout == 0
+    assert query._timeout == 300000
     query.timeout(msecs=500)
     assert query._timeout == 500
+    query.timeout(msecs=999999)
+    assert query._timeout == 300000
+    query.timeout(msecs=700)
+    assert query._timeout == 700
+    query.timeout(msecs=0)
+    assert query._timeout == 300000
 
 
 def test_enriched_event_facet_timeout_error(cbcsdk_mock):

--- a/src/tests/unit/enterprise_edr/test_auth_events.py
+++ b/src/tests/unit/enterprise_edr/test_auth_events.py
@@ -411,9 +411,15 @@ def test_auth_event_timeout(cbcsdk_mock):
     """Testing AuthEventQuery.timeout()."""
     api = cbcsdk_mock.api
     query = api.select(AuthEvent).where("event_id:some_id")
-    assert query._timeout == 0
+    assert query._timeout == 300000
     query.timeout(msecs=500)
     assert query._timeout == 500
+    query.timeout(msecs=999999)
+    assert query._timeout == 300000
+    query.timeout(msecs=700)
+    assert query._timeout == 700
+    query.timeout(msecs=0)
+    assert query._timeout == 300000
 
 
 def test_auth_event_timeout_error(cbcsdk_mock):
@@ -739,9 +745,15 @@ def test_auth_event_facet_timeout(cbcsdk_mock):
         .where("process_name:some_name")
         .add_facet_field("process_name")
     )
-    assert query._timeout == 0
+    assert query._timeout == 300000
     query.timeout(msecs=500)
     assert query._timeout == 500
+    query.timeout(msecs=999999)
+    assert query._timeout == 300000
+    query.timeout(msecs=700)
+    assert query._timeout == 700
+    query.timeout(msecs=0)
+    assert query._timeout == 300000
 
 
 def test_auth_event_facet_timeout_error(cbcsdk_mock):

--- a/src/tests/unit/platform/test_observations.py
+++ b/src/tests/unit/platform/test_observations.py
@@ -444,9 +444,15 @@ def test_observations_timeout(cbcsdk_mock):
     )
     api = cbcsdk_mock.api
     query = api.select(Observation).where("observation_id:some_id")
-    assert query._timeout == 0
+    assert query._timeout == 300000
     query.timeout(msecs=500)
     assert query._timeout == 500
+    query.timeout(msecs=999999)
+    assert query._timeout == 300000
+    query.timeout(msecs=700)
+    assert query._timeout == 700
+    query.timeout(msecs=0)
+    assert query._timeout == 300000
 
 
 def test_observations_timeout_error(cbcsdk_mock):
@@ -813,9 +819,15 @@ def test_observation_facet_timeout(cbcsdk_mock):
         .where("process_name:some_name")
         .add_facet_field("process_name")
     )
-    assert query._timeout == 0
+    assert query._timeout == 300000
     query.timeout(msecs=500)
     assert query._timeout == 500
+    query.timeout(msecs=999999)
+    assert query._timeout == 300000
+    query.timeout(msecs=700)
+    assert query._timeout == 700
+    query.timeout(msecs=0)
+    assert query._timeout == 300000
 
 
 def test_observation_facet_timeout_error(cbcsdk_mock):
@@ -1216,16 +1228,16 @@ def test_observations_search_suggestions_api_error():
         Observation.search_suggestions("", "device_id", 10)
 
 
-def test_bulk_get_details_api_error():
-    """Tests bulk_get_details - no CBCloudAPI arg"""
+def test_bulk_get_details_api_error(cb):
+    """Tests bulk_get_details"""
     with pytest.raises(ApiError):
-        Observation.bulk_get_details("", alert_id="xx")
+        Observation.bulk_get_details(cb, alert_id="xx")
 
 
-def test_helper_get_details_api_error():
-    """Tests _helper_get_details - no CBCloudAPI arg"""
+def test_helper_get_details_api_error(cb):
+    """Tests _helper_get_details"""
     with pytest.raises(ApiError):
-        Observation._helper_get_details("", alert_id="xx")
+        Observation._helper_get_details(cb, alert_id="xx")
 
 
 def test_bulk_get_details_neither(cbcsdk_mock):

--- a/src/tests/unit/platform/test_platform_process.py
+++ b/src/tests/unit/platform/test_platform_process.py
@@ -269,6 +269,20 @@ def test_summary_select_set_time_range_failures(cbcsdk_mock):
     assert 'Window must be a string.' in ex.value.message
 
 
+def test_summary_query_timeout(cb):
+    """Tests the timeout setting on SummaryQuery."""
+    query = cb.select(Process.Summary).where("process_guid:WNEXFKQ7-0002b226-000015bd-00000000-1d6225bbba74c00")
+    assert query._timeout == 300000
+    query.timeout(500)
+    assert query._timeout == 500
+    query.timeout(999999)
+    assert query._timeout == 300000
+    query.timeout(700)
+    assert query._timeout == 700
+    query.timeout(0)
+    assert query._timeout == 300000
+
+
 def test_process_deobfuscate_cmdline(cbcsdk_mock):
     """Test the deobfuscate_cmdline() method."""
     def on_validation_post(url, body, **kwargs):

--- a/src/tests/unit/platform/test_platform_query.py
+++ b/src/tests/unit/platform/test_platform_query.py
@@ -194,9 +194,15 @@ def test_async_timeout(cbcsdk_mock):
     """Testing AsyncProcessQuery.timeout()."""
     api = cbcsdk_mock.api
     async_query = api.select(Process).where("process_guid:someguid")
-    assert async_query._timeout == 0
+    assert async_query._timeout == 300000
     async_query.timeout(msecs=500)
     assert async_query._timeout == 500
+    async_query.timeout(msecs=999999)
+    assert async_query._timeout == 300000
+    async_query.timeout(msecs=700)
+    assert async_query._timeout == 700
+    async_query.timeout(msecs=0)
+    assert async_query._timeout == 300000
 
 
 def test_async_submit(cbcsdk_mock):
@@ -243,9 +249,15 @@ def test_async_facet_query_timeout(cbcsdk_mock):
     """Testing AsyncFacetQuery timeout()"""
     api = cbcsdk_mock.api
     facet_query = api.select(ProcessFacet).where("process_name:svchost.exe")
-    assert facet_query._timeout == 0
+    assert facet_query._timeout == 300000
     facet_query.timeout(5000)
     assert facet_query._timeout == 5000
+    facet_query.timeout(999999)
+    assert facet_query._timeout == 300000
+    facet_query.timeout(2000)
+    assert facet_query._timeout == 2000
+    facet_query.timeout(0)
+    assert facet_query._timeout == 300000
 
 
 def test_async_facet_limit(cbcsdk_mock):

--- a/src/tests/unit/test_credentials.py
+++ b/src/tests/unit/test_credentials.py
@@ -31,6 +31,7 @@ def test_credential_default_values():
     assert creds.proxy is None
     assert not creds.ignore_system_proxy
     assert creds.integration is None
+    assert creds.default_timeout == 300000
     with pytest.raises(AttributeError):
         assert creds.notexist is None
 
@@ -40,10 +41,11 @@ def test_credential_default_values():
       CredentialValue.ORG_KEY: "A1B2C3D4", CredentialValue.SSL_VERIFY: False,
       CredentialValue.SSL_VERIFY_HOSTNAME: False, CredentialValue.SSL_CERT_FILE: "foo.certs",
       CredentialValue.SSL_FORCE_TLS_1_2: True, CredentialValue.PROXY: "proxy.example",
-      CredentialValue.IGNORE_SYSTEM_PROXY: True, CredentialValue.INTEGRATION: 'Bronski'}, ),
+      CredentialValue.IGNORE_SYSTEM_PROXY: True, CredentialValue.INTEGRATION: 'Bronski',
+      CredentialValue.DEFAULT_TIMEOUT: 200000}, ),
     ({"url": "http://example.com", "token": "ABCDEFGH", "org_key": "A1B2C3D4", "ssl_verify": "false",
       "ssl_verify_hostname": "no", "ssl_cert_file": "foo.certs", "ssl_force_tls_1_2": "1",
-      "proxy": "proxy.example", "ignore_system_proxy": "on", "integration": 'Bronski'}, )
+      "proxy": "proxy.example", "ignore_system_proxy": "on", "integration": 'Bronski', "default_timeout": "200000"}, )
 ])
 def test_credential_dict_value_load(input_dict):
     """Test loading credentials from a dict, and also access through both attributes and get_value."""
@@ -58,6 +60,7 @@ def test_credential_dict_value_load(input_dict):
     assert creds.proxy == "proxy.example"
     assert creds.ignore_system_proxy
     assert creds.integration == 'Bronski'
+    assert creds.default_timeout == 200000
     assert creds.get_value(CredentialValue.URL) == "http://example.com"
     assert creds.get_value(CredentialValue.TOKEN) == "ABCDEFGH"
     assert creds.get_value(CredentialValue.ORG_KEY) == "A1B2C3D4"
@@ -68,11 +71,12 @@ def test_credential_dict_value_load(input_dict):
     assert creds.get_value(CredentialValue.PROXY) == "proxy.example"
     assert creds.get_value(CredentialValue.IGNORE_SYSTEM_PROXY)
     assert creds.get_value(CredentialValue.INTEGRATION) == 'Bronski'
+    assert creds.get_value(CredentialValue.DEFAULT_TIMEOUT) == 200000
 
 
 def test_credential_partial_loads():
     """Test that we can have credentials with some values from dict and some default."""
-    init_dict = {"url": "http://example.com", "ssl_verify": 0}
+    init_dict = {"url": "http://example.com", "ssl_verify": 0, "default_timeout": 999999}
     creds = Credentials(init_dict)
     assert creds.url == "http://example.com"
     assert creds.token is None
@@ -84,6 +88,7 @@ def test_credential_partial_loads():
     assert creds.proxy is None
     assert not creds.ignore_system_proxy
     assert creds.integration is None
+    assert creds.default_timeout == 300000
 
 
 def test_credential_boolean_parsing_failure():
@@ -98,10 +103,11 @@ def test_credential_boolean_parsing_failure():
       CredentialValue.ORG_KEY: "A1B2C3D4", CredentialValue.SSL_VERIFY: False,
       CredentialValue.SSL_VERIFY_HOSTNAME: False, CredentialValue.SSL_CERT_FILE: "foo.certs",
       CredentialValue.SSL_FORCE_TLS_1_2: True, CredentialValue.PROXY: "proxy.example",
-      CredentialValue.IGNORE_SYSTEM_PROXY: True, CredentialValue.INTEGRATION: 'Bronski'}, ),
+      CredentialValue.IGNORE_SYSTEM_PROXY: True, CredentialValue.INTEGRATION: 'Bronski',
+      CredentialValue.DEFAULT_TIMEOUT: 200000}, ),
     ({"url": "http://example.com", "token": "ABCDEFGH", "org_key": "A1B2C3D4", "ssl_verify": "false",
       "ssl_verify_hostname": "no", "ssl_cert_file": "foo.certs", "ssl_force_tls_1_2": "1",
-      "proxy": "proxy.example", "ignore_system_proxy": "on", "integration": 'Bronski'}, )
+      "proxy": "proxy.example", "ignore_system_proxy": "on", "integration": 'Bronski', "default_timeout": 200000}, )
 ])
 def test_credential_get_dict(input_dict):
     """Tests if we get the correct dictionary."""
@@ -115,6 +121,7 @@ def test_credential_get_dict(input_dict):
     assert creds["ssl_force_tls_1_2"]
     assert creds["proxy"] == "proxy.example"
     assert creds["ignore_system_proxy"]
+    assert creds["default_timeout"] == 200000
 
 
 def test_get_token_api_key():


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-5134

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added behavior that all search queries that have timeout values respect the configured default timeout value, which defaults to 300000 milliseconds (5 minutes) and is configured as part of the credentials.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Customers that have been submitting extra-long searches and having them hang will now start seeing `TimeoutError` being thrown. This has always been a documented response from those searches, though, so they will get better feedback on searches that are too long. In that sense, it isn't really a "breaking" change, but it is a difference in behavior.

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Test coverage has been verified for anything that references timeouts. Overall test coverage should have improved.