### PR TITLE
updated device search to be default and moved device criteria setters…

### DIFF
--- a/src/cbc_sdk/platform/legacy_alerts.py
+++ b/src/cbc_sdk/platform/legacy_alerts.py
@@ -14,7 +14,6 @@
 """Model and Query Classes for Legacy Alerts and Workflows used Alert API v6 and SDK 1.4.3 or earlier"""
 
 from cbc_sdk.errors import ApiError, FunctionalityDecommissioned
-from cbc_sdk.platform.devices import DeviceSearchQuery
 from cbc_sdk.base import CriteriaBuilderSupportMixin
 import logging
 
@@ -161,8 +160,6 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         Returns:
             AlertSearchQuery: This instance.
         """
-        if not all((osval in DeviceSearchQuery.VALID_OS) for osval in device_os):
-            raise ApiError("One or more invalid operating systems")
         self._update_criteria("device_os", device_os)
         return self
 
@@ -384,8 +381,6 @@ class LegacyAlertSearchQueryCriterionMixin(CriteriaBuilderSupportMixin):
         Returns:
             AlertSearchQuery: This instance.
         """
-        if not all((prio in DeviceSearchQuery.VALID_PRIORITIES) for prio in priorities):
-            raise ApiError("One or more invalid priority values")
         self._update_criteria("device_target_value", priorities)
         return self
 

--- a/src/tests/unit/platform/test_alertsv6_api.py
+++ b/src/tests/unit/platform/test_alertsv6_api.py
@@ -281,7 +281,6 @@ def test_query_basealert_invalid_create_time_combinations(cb):
 @pytest.mark.parametrize("method, arg", [
     ("set_device_ids", ["Bogus"]),
     ("set_device_names", [42]),
-    ("set_device_os", ["TI994A"]),
     ("set_device_os_versions", [8808]),
     ("set_device_username", [-1]),
     ("set_alert_ids", [9001]),
@@ -291,7 +290,6 @@ def test_query_basealert_invalid_create_time_combinations(cb):
     ("set_process_names", [7071]),
     ("set_process_sha256", [123456789]),
     ("set_tags", [-1]),
-    ("set_target_priorities", ["DOGWASH"]),
     ("set_threat_ids", [4096]),
     ("set_types", ["ERBOSOFT"]),
     ("set_workflows", ["IN_LIMBO"])

--- a/src/tests/unit/platform/test_devicev6_api.py
+++ b/src/tests/unit/platform/test_devicev6_api.py
@@ -212,9 +212,6 @@ def test_query_device_invalid_last_contact_time_combinations(cb):
 @pytest.mark.parametrize("method, arg", [
     ("set_ad_group_ids", ["Bogus"]),
     ("set_policy_ids", ["Bogus"]),
-    ("set_os", ["COMMODORE_64"]),
-    ("set_status", ["Bogus"]),
-    ("set_target_priorities", ["Bogus"]),
     ("set_exclude_sensor_versions", [12703])
 ])
 def test_query_device_invalid_criteria_values(cb, method, arg):
@@ -240,8 +237,6 @@ def test_query_device_facet(cbcsdk_mock):
     assert len(facets) == 1
     assert facets[0].field == 'policy_id'
     assert len(facets[0].values_) == 10
-    with pytest.raises(ApiError):
-        query.facets(['notexist'])
     with pytest.raises(ApiError):
         query.facets([])
 
@@ -365,7 +360,7 @@ def test_query_device_do_update_sensor_version(cbcsdk_mock):
 
 
 def test_query_deployment_type(cbcsdk_mock):
-    """Test deployment type query with correct and incorrect params."""
+    """Test deployment type query with params."""
     def on_query(url, body, **kwargs):
         assert body == {"rows": 2,
                         "criteria": {"deployment_type": ["ENDPOINT"]}}
@@ -373,8 +368,6 @@ def test_query_deployment_type(cbcsdk_mock):
 
     cbcsdk_mock.mock_request('POST', "/appservices/v6/orgs/test/devices/_search", on_query)
     api = cbcsdk_mock.api
-    with pytest.raises(ApiError):
-        api.select(Device).set_deployment_type(["BOGUS"])
     query = api.select(Device).set_deployment_type(["ENDPOINT"])
     d = query.one()
     assert d.deployment_type[0] in ["ENDPOINT", "WORKLOAD"]

--- a/src/tests/unit/platform/test_platform_devices.py
+++ b/src/tests/unit/platform/test_platform_devices.py
@@ -165,8 +165,7 @@ def test_device_get_asset_group_ids_bogus_value(cbcsdk_mock):
     cbcsdk_mock.mock_request("GET", "/appservices/v6/orgs/test/devices/98765", GET_DEVICE_RESP)
     api = cbcsdk_mock.api
     device = api.select(Device, 98765)
-    with pytest.raises(ApiError):
-        device.get_asset_group_ids("BOGUS")
+    assert device.get_asset_group_ids("BOGUS") is None
 
 
 def test_device_get_asset_groups(cbcsdk_mock):

--- a/src/tests/unit/platform/test_vulnerability_assessment.py
+++ b/src/tests/unit/platform/test_vulnerability_assessment.py
@@ -17,7 +17,7 @@ import copy
 import pytest
 import logging
 from cbc_sdk.rest_api import CBCloudAPI
-from cbc_sdk.errors import ApiError, ObjectNotFoundError, MoreThanOneResultError
+from cbc_sdk.errors import ApiError, ObjectNotFoundError, MoreThanOneResultError, ServerError
 from tests.unit.fixtures.CBCSDKMock import CBCSDKMock
 from cbc_sdk.platform import Device, Vulnerability, Job
 from tests.unit.fixtures.platform.mock_vulnerabilities import (GET_VULNERABILITY_SUMMARY_ORG_LEVEL,
@@ -482,14 +482,16 @@ def test_device_vulnerability_summary_get_category(cbcsdk_mock):
 
 def test_device_vulnerability_summary_get_category_fail(cbcsdk_mock):
     """Test Get an Operating System or Application Vulnerability Summary for a specific device"""
-    cbcsdk_mock.mock_request("GET", "/vulnerability/assessment/api/v1/orgs/test/devices/98765/vulnerabilities/summary",
-                             GET_DEVICE_VULNERABILITY_SUMMARY_RESP)
+    cbcsdk_mock.mock_request("GET",
+                             "/vulnerability/assessment/api/v1/orgs/test/devices/98765/vulnerabilities/summary"
+                             "?category=WRONG", ServerError(error_code=400, message='blah'))
     cbcsdk_mock.mock_request("GET", "/appservices/v6/orgs/test/devices/98765", GET_DEVICE_RESP)
     api = cbcsdk_mock.api
     device = api.select(Device, 98765)
-    with pytest.raises(ApiError) as ex:
+    with pytest.raises(ServerError) as ex:
         device.get_vulnerability_summary(category='WRONG')
-    assert ex.value.message == 'Invalid category provided'
+    assert ex.value.error_code == 400
+    assert ex.value.message == "blah"
 
 
 def test_device_vulnerability_search(cbcsdk_mock):


### PR DESCRIPTION
… to legacy mixin, removed validations, updated related tests

## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
[CBAPI-5220](https://jira.carbonblack.local/browse/CBAPI-5220)

## Pull Request Description
Moves set type criterion features to a legacy module to keep style inline with how alerts were reworked.
Removes device validations (suggest ticket to implement error messaging on the API end)
Updates unit tests that make use of Device module



## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Introduces potential breaking changes on error response for device validations. Now on the user to verify they are passing valid parameters to the sdk.
 
## How Has This Been Tested?
Unit tests