### PR TITLE
CBAPI-5303: Fix SDK bugs as reported by Kyle at Aplura

### DIFF
--- a/src/cbc_sdk/audit_remediation/base.py
+++ b/src/cbc_sdk/audit_remediation/base.py
@@ -1000,13 +1000,13 @@ class RunHistoryQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
 
         return self._total_results
 
-    def _perform_query(self, start=0, rows=0):
+    def _perform_query(self, from_row=0, max_rows=0):
         """
         Performs the query and returns the results of the query in an iterable fashion.
 
         Args:
-            start (int): The row to start the query at (default 0).
-            rows (int): The maximum number of rows to be returned (default 0, meaning "all").
+            from_row (int): The row to start the query at (default 0).
+            max_rows (int): The maximum number of rows to be returned (default 0, meaning "all").
 
         Returns:
             Iterable: The iterated query.
@@ -1014,11 +1014,11 @@ class RunHistoryQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
         url = self._doc_class.urlobject_history.format(
             self._cb.credentials.org_key
         )
-        current = start
+        current = from_row
         numrows = 0
         still_querying = True
         while still_querying:
-            request = self._build_request(start, rows)
+            request = self._build_request(from_row, max_rows)
             resp = self._cb.post_object(url, body=request)
             result = resp.json()
 
@@ -1031,11 +1031,11 @@ class RunHistoryQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, C
                 current += 1
                 numrows += 1
 
-                if rows and numrows == rows:
+                if max_rows and numrows == max_rows:
                     still_querying = False
                     break
 
-            start = current
+            from_row = current
             if current >= self._total_results:
                 still_querying = False
                 break
@@ -1312,13 +1312,13 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
 
         return self._total_results
 
-    def _perform_query(self, start=0, rows=0):
+    def _perform_query(self, from_row=0, max_rows=0):
         """
         Performs the query and returns the results of the query in an iterable fashion.
 
         Args:
-            start (int): The row to start the query at (default 0).
-            rows (int): The maximum number of rows to be returned (default 0, meaning "all").
+            from_row (int): The row to start the query at (default 0).
+            max_rows (int): The maximum number of rows to be returned (default 0, meaning "all").
 
         Returns:
             Iterable: The iterated query.
@@ -1329,11 +1329,11 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
         url = self._doc_class.urlobject.format(
             self._cb.credentials.org_key, self._run_id
         )
-        current = start
+        current = from_row
         numrows = 0
         still_querying = True
         while still_querying:
-            request = self._build_request(start, rows)
+            request = self._build_request(from_row, max_rows)
             resp = self._cb.post_object(url, body=request)
             result = resp.json()
 
@@ -1348,11 +1348,11 @@ class ResultQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Crite
                 current += 1
                 numrows += 1
 
-                if rows and numrows == rows:
+                if max_rows and numrows == max_rows:
                     still_querying = False
                     break
 
-            start = current
+            from_row = current
             if current >= self._total_results:
                 still_querying = False
                 break
@@ -1722,12 +1722,13 @@ class FacetQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Criter
             request["criteria"] = self._criteria
         return request
 
-    def _perform_query(self, rows=0):
+    def _perform_query(self, from_row=0, max_rows=0):
         """
         Performs the query and returns the results of the query in an iterable fashion.
 
         Args:
-            rows (int): The maximum number of rows to be returned (default 0, meaning "all").
+            from_row (int): Not used, inserted for compatibility.
+            max_rows (int): The maximum number of rows to be returned (default 0, meaning "all").
 
         Returns:
             Iterable: The iterated query.
@@ -1738,7 +1739,7 @@ class FacetQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, Criter
         url = self._doc_class.urlobject.format(
             self._cb.credentials.org_key, self._run_id
         )
-        request = self._build_request(rows)
+        request = self._build_request(max_rows)
         resp = self._cb.post_object(url, body=request)
         result = resp.json()
         results = result.get("terms", [])
@@ -1857,13 +1858,13 @@ class TemplateHistoryQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMix
 
         return self._total_results
 
-    def _perform_query(self, start=0, rows=0):
+    def _perform_query(self, from_row=0, max_rows=0):
         """
         Performs the query and returns the results of the query in an iterable fashion.
 
         Args:
-            start (int): The row to start the query at (default 0).
-            rows (int): The maximum number of rows to be returned (default 0, meaning "all").
+            from_row (int): The row to start the query at (default 0).
+            max_rows (int): The maximum number of rows to be returned (default 0, meaning "all").
 
         Returns:
             Iterable: The iterated query.
@@ -1871,11 +1872,11 @@ class TemplateHistoryQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMix
         url = self._doc_class.urlobject_history.format(
             self._cb.credentials.org_key
         )
-        current = start
+        current = from_row
         numrows = 0
         still_querying = True
         while still_querying:
-            request = self._build_request(start, rows)
+            request = self._build_request(from_row, max_rows)
             resp = self._cb.post_object(url, body=request)
             result = resp.json()
 
@@ -1888,11 +1889,11 @@ class TemplateHistoryQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMix
                 current += 1
                 numrows += 1
 
-                if rows and numrows == rows:
+                if max_rows and numrows == max_rows:
                     still_querying = False
                     break
 
-            start = current
+            from_row = current
             if current >= self._total_results:
                 still_querying = False
                 break

--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -1026,7 +1026,7 @@ class BaseQuery(object):
     def _clone(self):
         return self.__class__(self._query)
 
-    def _perform_query(self):
+    def _perform_query(self, from_row=0, max_rows=-1):
         # This has the effect of generating an empty iterator.
         yield from ()
 
@@ -1050,10 +1050,7 @@ class IterableQueryMixin:
         Returns:
             obj: First query item
         """
-        res = self[:1]
-        if res is None or not len(res):
-            return None
-        return res[0]
+        return self.__getitem__(0)
 
     def one(self):
         """
@@ -1066,9 +1063,7 @@ class IterableQueryMixin:
             MoreThanOneResultError: If the query returns more than one item
             ObjectNotFoundError: If the query returns zero items
         """
-        res = self[:2]
-        if res is None:
-            return None
+        res = list(self._perform_query(from_row=0, max_rows=2))
         label = str(self._query) if self._query else "<unspecified>"
         if len(res) == 0:
             raise ObjectNotFoundError("query_uri", message="0 results for query {0:s}".format(label))
@@ -1115,7 +1110,7 @@ class IterableQueryMixin:
             return [results[ii] for ii in range(*item.indices(len(results)))]
         elif isinstance(item, int):
             results = list(self._perform_query(from_row=item, max_rows=1))
-            return results[item]
+            return results[0]
         else:
             raise TypeError("Invalid argument type")
 
@@ -1262,9 +1257,15 @@ class SimpleQuery(BaseQuery, IterableQueryMixin):
             raise ApiError("Cannot have multiple 'where' clauses")
         return self.where(new_query)
 
-    def _perform_query(self):
-        for item in self.results:
+    def _perform_query(self, from_row=0, max_rows=-1):
+        returned_rows = 0
+        for index, item in enumerate(self.results):
+            if index < from_row:
+                continue
             yield item
+            returned_rows += 1
+            if 0 < max_rows <= returned_rows:
+                break
 
     def sort(self, new_sort):
         """
@@ -1373,8 +1374,8 @@ class PaginatedQuery(BaseQuery, IterableQueryMixin):
         else:
             raise TypeError("invalid type")
 
-    def _perform_query(self, start=0, numrows=0):
-        for item in self._search(start=start, rows=numrows):
+    def _perform_query(self, from_row=0, max_rows=0):
+        for item in self._search(start=from_row, rows=max_rows):
             yield self._doc_class._new_object(self._cb, item)
 
     def batch_size(self, new_batch_size):
@@ -2412,8 +2413,13 @@ class FacetQuery(BaseQuery, AsyncQueryMixin, QueryBuilderSupportMixin, CriteriaB
         result = self._cb.get_object(result_url, query_parameters=query_parameters)
         return self._doc_class(self._cb, model_unique_id=self._query_token, initial_data=result)
 
-    def _perform_query(self):
-        return self.results
+    def _perform_query(self, from_row=0, max_rows=-1):
+        if max_rows > 0:
+            return self.results[from_row:from_row + max_rows]
+        elif from_row > 0:
+            return self.results[from_row:]
+        else:
+            return self.results
 
     @property
     def results(self):

--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -147,7 +147,7 @@ class CbMetaModel(type):
                 setattr(cls, field_name, FieldDescriptor(field_name))
 
         for fk_name, fk_info in iter(foreign_keys.items()):
-            setattr(cls, fk_name, ForeignKeyFieldDescriptor(fk_name, fk_info[0], fk_info[1]))
+            setattr(cls, fk_name, ForeignKeyFieldDescriptor(fk_name, fk_info[0], fk_info[1]))  # pragma: no cover
 
         return cls
 
@@ -1067,7 +1067,7 @@ class IterableQueryMixin:
         label = str(self._query) if self._query else "<unspecified>"
         if len(res) == 0:
             raise ObjectNotFoundError("query_uri", message="0 results for query {0:s}".format(label))
-        if len(res) > 1:
+        if len(res) > 1:  # pragma: no cover
             raise MoreThanOneResultError(
                 message="{0:d} results found for query {1:s}".format(len(self), label),
                 results=self.all()
@@ -1111,7 +1111,7 @@ class IterableQueryMixin:
         elif isinstance(item, int):
             results = list(self._perform_query(from_row=item, max_rows=1))
             return results[0]
-        else:
+        else:  # pragma: no cover
             raise TypeError("Invalid argument type")
 
     def __iter__(self):

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -1392,21 +1392,21 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
 
         return self._total_results
 
-    def _perform_query(self, from_row=1, max_rows=-1):
+    def _perform_query(self, from_row=0, max_rows=-1):
         """
         Performs the query and returns the results of the query in an iterable fashion.
 
         Alerts v6 API uses base 1 instead of 0.
 
         Args:
-            from_row (int): The row to start the query at (default 1).
+            from_row (int): The row to start the query at (default 0).
             max_rows (int): The maximum number of rows to be returned (default -1, meaning "all").
 
         Returns:
             Iterable: The iterated query.
         """
         url = self._build_url("/_search")
-        current = from_row
+        current = from_row + 1
         numrows = 0
         still_querying = True
         while still_querying:
@@ -1449,7 +1449,7 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
                     still_querying = False
                     break
 
-            from_row = current
+            from_row = current - 1
             if current >= self._total_results:
                 still_querying = False
                 break
@@ -1704,19 +1704,19 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
 
         return alert_search_query
 
-    def _perform_query(self, from_row=1, max_rows=-1):
+    def _perform_query(self, from_row=0, max_rows=-1):
         """
         Performs the query and returns the results of the query in an iterable fashion.
 
         Args:
-            from_row (int): The row to start the query at (default 1).
+            from_row (int): The row to start the query at (default 0).
             max_rows (int): The maximum number of rows to be returned (default -1, meaning "all").
 
         Returns:
             Iterable: The iterated query.
         """
         url = self._build_url("/_search")
-        current = from_row
+        current = from_row + 1
         numrows = 0
         still_querying = True
         while still_querying:
@@ -1744,7 +1744,7 @@ class GroupedAlertSearchQuery(AlertSearchQuery):
                     still_querying = False
                     break
 
-            from_row = current
+            from_row = current - 1
             if current >= self._total_results:
                 still_querying = False
                 break

--- a/src/cbc_sdk/platform/devices.py
+++ b/src/cbc_sdk/platform/devices.py
@@ -999,25 +999,22 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
 
         return self._total_results
 
-    def _perform_query(self, from_row=1, max_rows=-1):
+    def _perform_query(self, from_row=0, max_rows=-1):
         """
         Performs the query and returns the results of the query in an iterable fashion.
-
-        Note:
-            Device v6 API uses base 1 instead of 0.
 
         Required Permissions:
             device(READ)
 
         Args:
-            from_row (int): The row to start the query at (default 1).
+            from_row (int): The row to start the query at (default 0).
             max_rows (int): The maximum number of rows to be returned (default -1, meaning "all").
 
         Yields:
             Device: The individual devices which match the query.
         """
         url = self._build_url("/_search")
-        current = from_row
+        current = from_row + 1
         numrows = 0
         still_querying = True
         while still_querying:
@@ -1038,7 +1035,7 @@ class DeviceSearchQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupp
                     still_querying = False
                     break
 
-            from_row = current
+            from_row = current - 1
             if current >= self._total_results:
                 still_querying = False
                 break

--- a/src/cbc_sdk/platform/events.py
+++ b/src/cbc_sdk/platform/events.py
@@ -281,8 +281,13 @@ class EventFacetQuery(FacetQuery):
             args["process_guid"] = q
         return args
 
-    def _perform_query(self):
-        return self.results
+    def _perform_query(self, from_row=0, max_rows=-1):
+        if max_rows > 0:
+            return self.results[from_row:from_row + max_rows]
+        elif from_row > 0:
+            return self.results[from_row:]
+        else:
+            return self.results
 
     def _submit(self):
         args = self._get_query_parameters()

--- a/src/cbc_sdk/platform/processes.py
+++ b/src/cbc_sdk/platform/processes.py
@@ -1028,15 +1028,28 @@ class SummaryQuery(BaseQuery, AsyncQueryMixin, QueryBuilderSupportMixin):
             else:
                 raise ApiError(f"Failed to get Process Tree: {result['exception']}")
 
-    def _perform_query(self):
+    def _perform_query(self, from_row=0, max_rows=-1):
         """
         Iterate over the results of the query.
 
         Required Permissions:
             org.search.events(CREATE, READ)
+
+        Args:
+            from_row (int): Row to start iterating from (default 0).
+            max_rows(int): Number of rows to enumerate (default -1, meaning "all rows").
+
+        Yields:
+            Process.Summary or Process.Tree: The enumerated results.
         """
-        for item in self.results:
+        returned_rows = 0
+        for ndx, item in enumerate(self.results):
+            if ndx < from_row:
+                continue
             yield item
+            returned_rows += 1
+            if 0 < max_rows <= returned_rows:
+                break
 
     @property
     def results(self):

--- a/src/cbc_sdk/platform/vulnerability_assessment.py
+++ b/src/cbc_sdk/platform/vulnerability_assessment.py
@@ -294,9 +294,13 @@ class VulnerabilityOrgSummaryQuery(BaseQuery):
             self._severity = severity
         return self
 
-    def _perform_query(self):
+    def _perform_query(self, from_row=0, max_rows=-1):
         """
         Performs the query and returns the Vulnerability.OrgSummary
+
+        Args:
+            from_row (int): Not used, retained for compatibility.
+            max_rows (int): Not used, retained for compatibility.
 
         Returns:
             Vulnerability.OrgSummary: The vulnerabilty summary for an organization

--- a/src/tests/unit/platform/test_platform_events.py
+++ b/src/tests/unit/platform/test_platform_events.py
@@ -100,7 +100,7 @@ def test_event_query_select_with_where(cbcsdk_mock):
 
     # test .where(process_guid=...)
     events = api.select(Event).where(process_guid=guid)
-    results = [res for res in events._perform_query(numrows=10)]
+    results = [res for res in events._perform_query(max_rows=10)]
     assert len(results) == 10
     first_event = results[0]
     assert first_event.process_guid == guid
@@ -117,7 +117,7 @@ def test_event_query_select_with_where(cbcsdk_mock):
                              EVENT_SEARCH_VALIDATION_RESP)
 
     events = api.select(Event).where('process_guid:J7G6DTLN-006633e3-00000334-00000000-1d677bedfbb1c2e')
-    results = [res for res in events._perform_query(numrows=10)]
+    results = [res for res in events._perform_query(max_rows=10)]
     first_event = results[0]
     assert first_event.process_guid == guid
 
@@ -125,7 +125,7 @@ def test_event_query_select_with_where(cbcsdk_mock):
     assert len(results) == 10
 
     # test ._perform_query(numrows)
-    results = [result for result in events._perform_query(numrows=100)]
+    results = [result for result in events._perform_query(max_rows=100)]
     assert len(results) == 100
     first_result = results[0]
     assert first_result.process_guid == guid

--- a/src/tests/unit/platform/test_vulnerability_assessment.py
+++ b/src/tests/unit/platform/test_vulnerability_assessment.py
@@ -93,8 +93,11 @@ def test_get_vulnerability_summary_per_severity_fail(cbcsdk_mock):
     cbcsdk_mock.mock_request("GET", "/vulnerability/assessment/api/v1/orgs/test/vulnerabilities/summary",
                              GET_VULNERABILITY_SUMMARY_ORG_LEVEL_PER_SEVERITY)
     api = cbcsdk_mock.api
+    query = api.select(Vulnerability.OrgSummary)
     with pytest.raises(ApiError):
-        api.select(Vulnerability.OrgSummary).set_severity('ERROR')
+        query.set_severity('ERROR')
+    with pytest.raises(ApiError):
+        query.set_visibility('BOGUS')
 
 
 def test_get_vulnerability_summary_per_severity_per_vcenter(cbcsdk_mock):
@@ -174,6 +177,13 @@ def test_get_all_vulnerabilities(cbcsdk_mock):
     results = [result for result in query._perform_query()]
     assert len(results) == 2
     assert query._count() == len(results)
+
+
+def test_vulnerability_query_visibility_fail(cb):
+    """Test that setting visibility on vulnerability query to a bogus value returns an error."""
+    query = cb.select(Vulnerability)
+    with pytest.raises(ApiError):
+        query.set_visibility('BOGUS')
 
 
 def test_export_vulnerabilities(cbcsdk_mock):
@@ -295,6 +305,7 @@ def test_vuln_query_with_all_bells_and_whistles(cbcsdk_mock):
         assert crits['highest_risk_score'] == {"value": 10, "operator": "LESS_THAN"}
         assert crits['last_sync_ts'] == {"value": "2020-01-02T03:04:05Z", "operator": "EQUALS"}
         assert crits['name'] == {"value": "test", "operator": "EQUALS"}
+        assert crits['deployment_type'] == {"value": "ENDPOINT", "operator": "EQUALS"}
         assert crits['os_arch'] == {"value": "x86_64", "operator": "EQUALS"}
         assert crits['os_name'] == {"value": "Red Hat Enterprise Linux Server", "operator": "EQUALS"}
         assert crits['os_type'] == {"value": "MAC", "operator": "EQUALS"}
@@ -315,6 +326,7 @@ def test_vuln_query_with_all_bells_and_whistles(cbcsdk_mock):
                                      .set_highest_risk_score(10, 'LESS_THAN') \
                                      .set_last_sync_ts('2020-01-02T03:04:05Z', 'EQUALS') \
                                      .set_name('test', 'EQUALS') \
+                                     .set_deployment_type('ENDPOINT', 'EQUALS') \
                                      .set_os_arch('x86_64', 'EQUALS') \
                                      .set_os_name('Red Hat Enterprise Linux Server', 'EQUALS') \
                                      .set_os_type('MAC', 'EQUALS') \
@@ -356,6 +368,10 @@ def test_vuln_query_with_all_bells_and_whistles_failures(cbcsdk_mock):
     with pytest.raises(ApiError) as ex:
         api.select(Vulnerability).set_name('', 'EQUALS')
     assert ex.value.message == 'Invalid name'
+
+    with pytest.raises(ApiError) as ex:
+        api.select(Vulnerability).set_deployment_type('', 'EQUALS')
+    assert ex.value.message == 'Invalid deployment type'
 
     with pytest.raises(ApiError) as ex:
         api.select(Vulnerability).set_os_arch('', 'EQUALS')


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-5303

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
1. The arguments to `_perform_query` have been normalized across the entire SDK, so the shortcuts in `IterableQueryMixin` will work correctly in all circumstances.
2. In `IterableQueryMixin`, `first()` has been reimplemented so it will send a query with a `rows` parameter of 1.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Note: The arguments to `_perform_query` have been normalized across the entire code, but SDK users shouldn't be using that method directly anyway.

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
All unit tests pass with this fix. The code has been offered to Kyle for testing to see if it meets his needs.  (He reports that it does.)