### PR TITLE
CBAPI-5259: Reimplement AuditLog.get_auditlogs in terms of new API

### DIFF
--- a/src/cbc_sdk/platform/audit.py
+++ b/src/cbc_sdk/platform/audit.py
@@ -98,7 +98,7 @@ class AuditLog(UnrefreshableModel):
         Returns:
             list[AuditLog]: List of objects representing the audit logs, or an empty list if none available.
         """
-        res = cb.get_object(AuditLog.urlobject.format(cb.credentials.org_key) + "/queue")
+        res = cb.get_object(AuditLog.urlobject.format(cb.credentials.org_key) + "/_queue")
         return [AuditLog(cb, -1, data) for data in res.get("results", [])]
 
 

--- a/src/cbc_sdk/platform/audit.py
+++ b/src/cbc_sdk/platform/audit.py
@@ -69,6 +69,9 @@ class AuditLog(UnrefreshableModel):
         """
         Retrieve queued audit logs from the Carbon Black Cloud server.
 
+        Deprecated:
+            This method uses an outdated API. Use ``get_queued_auditlogs()`` instead.
+
         Required Permissions:
             org.audits (READ)
 
@@ -80,6 +83,23 @@ class AuditLog(UnrefreshableModel):
         """
         res = cb.get_object("/integrationServices/v3/auditlogs")
         return res.get("notifications", [])
+
+    @staticmethod
+    def get_queued_auditlogs(cb):
+        """
+        Retrieve queued audit logs from the Carbon Black Cloud server.
+
+        Required Permissions:
+            org.audits (READ)
+
+        Args:
+            cb (BaseAPI): Reference to API object used to communicate with the server.
+
+        Returns:
+            list[AuditLog]: List of objects representing the audit logs, or an empty list if none available.
+        """
+        res = cb.get_object(AuditLog.urlobject.format(cb.credentials.org_key) + "/queue")
+        return [AuditLog(cb, -1, data) for data in res.get("results", [])]
 
 
 """Query Class"""

--- a/src/cbc_sdk/platform/audit.py
+++ b/src/cbc_sdk/platform/audit.py
@@ -189,6 +189,11 @@ class AuditLogQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupportM
         """
         Adds a ``create_time`` value to either criteria or exclusions.
 
+        Examples:
+            >>> query_specify_start_and_end = api.select(AuditLog).
+            ...     add_time_criteria(start="2023-10-20T20:34:07Z", end="2023-10-30T20:34:07Z")
+            >>> query_specify_exclude_range = api.select(AuditLog).add_time_criteria(range='-3d', exclude=True)
+
         Args:
             kwargs (dict): Keyword arguments to this method.
 

--- a/src/cbc_sdk/platform/audit.py
+++ b/src/cbc_sdk/platform/audit.py
@@ -48,7 +48,6 @@ class AuditLog(UnrefreshableModel):
 
         Args:
             cb (BaseAPI): Reference to API object used to communicate with the server.
-            model_unique_id (int): Not used.
             initial_data (dict): Initial data to fill in the audit log record details.
         """
         super(AuditLog, self).__init__(cb, -1, initial_data, force_init=False, full_doc=True)

--- a/src/cbc_sdk/platform/audit.py
+++ b/src/cbc_sdk/platform/audit.py
@@ -42,7 +42,7 @@ class AuditLog(UnrefreshableModel):
     urlobject = "/audit_log/v1/orgs/{0}/logs"
     swagger_meta_file = "platform/models/audit_log.yaml"
 
-    def __init__(self, cb, model_unique_id, initial_data=None):
+    def __init__(self, cb, initial_data=None):
         """
         Creates a new ``AuditLog`` object.
 
@@ -51,7 +51,7 @@ class AuditLog(UnrefreshableModel):
             model_unique_id (int): Not used.
             initial_data (dict): Initial data to fill in the audit log record details.
         """
-        super(AuditLog, self).__init__(cb, model_unique_id, initial_data, force_init=False, full_doc=True)
+        super(AuditLog, self).__init__(cb, -1, initial_data, force_init=False, full_doc=True)
 
     @classmethod
     def _query_implementation(cls, cb, **kwargs):
@@ -99,7 +99,7 @@ class AuditLog(UnrefreshableModel):
             list[AuditLog]: List of objects representing the audit logs, or an empty list if none available.
         """
         res = cb.get_object(AuditLog.urlobject.format(cb.credentials.org_key) + "/_queue")
-        return [AuditLog(cb, -1, data) for data in res.get("results", [])]
+        return [AuditLog(cb, data) for data in res.get("results", [])]
 
 
 """Query Class"""
@@ -349,7 +349,7 @@ class AuditLogQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupportM
 
             results = result.get("results", [])
             for item in results:
-                yield self._doc_class(self._cb, 0, item)
+                yield self._doc_class(self._cb, item)
                 current += 1
                 numrows += 1
 
@@ -377,4 +377,4 @@ class AuditLogQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupportM
         resp = self._cb.post_object(url, body=request)
         result = resp.json()
         results = result.get("results", [])
-        return [self._doc_class(self._cb, 0, item) for item in results]
+        return [self._doc_class(self._cb, item) for item in results]

--- a/src/tests/unit/fixtures/platform/mock_audit.py
+++ b/src/tests/unit/fixtures/platform/mock_audit.py
@@ -105,6 +105,8 @@ AUDIT_SEARCH_RESPONSE = {
             "actor": "DEFGHIJKLM",
             "request_url": None,
             "description": "Connector DEFGHIJKLM logged in successfully",
+            "flagged": False,
+            "verbose": False,
             "create_time": "2024-04-17T19:18:37.480Z"
         },
         {
@@ -113,6 +115,8 @@ AUDIT_SEARCH_RESPONSE = {
             "actor": "BELTALOWDA",
             "request_url": None,
             "description": "Updated report, 'MCRN threat feed'",
+            "flagged": False,
+            "verbose": False,
             "create_time": "2024-04-17T19:13:01.528Z"
         },
         {
@@ -121,6 +125,8 @@ AUDIT_SEARCH_RESPONSE = {
             "actor": "BELTALOWDA",
             "request_url": None,
             "description": "Updated report, 'Reported by DOP'",
+            "flagged": False,
+            "verbose": False,
             "create_time": "2024-04-17T19:13:01.042Z"
         },
         {
@@ -129,6 +135,8 @@ AUDIT_SEARCH_RESPONSE = {
             "actor": "BELTALOWDA",
             "request_url": None,
             "description": "Updated report, 'Reported by Mao-Kwikowski'",
+            "flagged": False,
+            "verbose": False,
             "create_time": "2024-04-17T19:13:00.235Z"
         },
         {
@@ -137,6 +145,8 @@ AUDIT_SEARCH_RESPONSE = {
             "actor": "BELTALOWDA",
             "request_url": None,
             "description": "Updated report, 'Malware SSL Certificate Fingerprint'",
+            "flagged": False,
+            "verbose": False,
             "create_time": "2024-04-17T19:12:59.693Z"
         }
     ]

--- a/src/tests/unit/platform/test_audit.py
+++ b/src/tests/unit/platform/test_audit.py
@@ -44,6 +44,16 @@ def test_get_auditlogs(cbcsdk_mock):
     assert len(result) == 5
 
 
+def test_get_queued_auditlogs(cbcsdk_mock):
+    """Tests the get_queued_auditlogs function."""
+    cbcsdk_mock.mock_request("GET", "/audit_log/v1/orgs/test/logs/_queue", AUDIT_SEARCH_RESPONSE)
+    api = cbcsdk_mock.api
+    result = AuditLog.get_queued_auditlogs(api)
+    assert len(result) == 5
+    for v in result:
+        assert isinstance(v, AuditLog)
+
+
 def test_search_audit_logs_with_all_bells_and_whistles(cbcsdk_mock):
     """Tests the generation and execution of a search request."""
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
<!-- Please link to a jira ticket or github issue. -->
https://jira.carbonblack.local/browse/CBAPI-5259

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Added function `get_queued_auditlogs()` that does what `get_auditlogs()` did, only in terms of actual new `AuditLog` objects.  Older `get_auditlogs()` function has been marked as deprecated.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Unit test covers the new function; test coverage for `audit.py` now stands at 97%.