### PR TITLE
Fix backport datetime fromisoformat dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ validators
 jsonschema
 keyring;platform_system=='Darwin'
 boto3
-backports-datetime-fromisoformat==2.0.1
+backports-datetime-fromisoformat==2.0.1 ; python_version < '3.11'
 
 
 # Dev dependencies

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ install_requires = [
     'jsonschema',
     "keyring;platform_system=='Darwin'",
     'boto3',
-    'backports-datetime-fromisoformat==2.0.1'
 ]
 
 extras_require = {
@@ -44,6 +43,8 @@ extras_require = {
 
 if sys.version_info < (3, 0):
     install_requires.extend(['futures'])
+if sys.version_info < (3, 11):
+    install_requires.extend(['backports-datetime-fromisoformat==2.0.1'])
 
 
 def read(fname):

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -53,8 +53,7 @@ from cbc_sdk.platform.network_threat_metadata import NetworkThreatMetadata
 from cbc_sdk.enterprise_edr.threat_intelligence import Watchlist
 
 if sys.version_info < (3, 11):
-    from backports._datetime_fromisoformat import MonkeyPatch
-    MonkeyPatch.patch_fromisoformat()
+    from backports._datetime_fromisoformat import datetime_fromisoformat
 
 """Alert Models"""
 
@@ -1403,9 +1402,15 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
             etime = kwargs["end"]
             try:
                 if isinstance(stime, str):
-                    stime = datetime.fromisoformat(stime)
+                    if sys.version_info < (3, 11):
+                        stime = datetime_fromisoformat(stime)
+                    else:
+                        stime = datetime.datetime.fromisoformat(stime)
                 if isinstance(etime, str):
-                    etime = datetime.fromisoformat(etime)
+                    if sys.version_info < (3, 11):
+                        etime = datetime_fromisoformat(etime)
+                    else:
+                        etime = datetime.datetime.fromisoformat(etime)
                 if isinstance(stime, datetime.datetime) and isinstance(etime, datetime.datetime):
                     time_filter = {"start": stime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                                    "end": etime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}

--- a/src/cbc_sdk/platform/alerts.py
+++ b/src/cbc_sdk/platform/alerts.py
@@ -34,6 +34,7 @@ Typical usage example::
 
 import time
 import datetime
+import sys
 
 from cbc_sdk.errors import ApiError, ObjectNotFoundError, NonQueryableModel, FunctionalityDecommissioned
 from cbc_sdk.platform import PlatformModel
@@ -51,7 +52,9 @@ from cbc_sdk.platform.jobs import Job
 from cbc_sdk.platform.network_threat_metadata import NetworkThreatMetadata
 from cbc_sdk.enterprise_edr.threat_intelligence import Watchlist
 
-from backports._datetime_fromisoformat import datetime_fromisoformat
+if sys.version_info < (3, 11):
+    from backports._datetime_fromisoformat import MonkeyPatch
+    MonkeyPatch.patch_fromisoformat()
 
 """Alert Models"""
 
@@ -1400,9 +1403,9 @@ class AlertSearchQuery(BaseQuery, QueryBuilderSupportMixin, IterableQueryMixin, 
             etime = kwargs["end"]
             try:
                 if isinstance(stime, str):
-                    stime = datetime_fromisoformat(stime)
+                    stime = datetime.fromisoformat(stime)
                 if isinstance(etime, str):
-                    etime = datetime_fromisoformat(etime)
+                    etime = datetime.fromisoformat(etime)
                 if isinstance(stime, datetime.datetime) and isinstance(etime, datetime.datetime):
                     time_filter = {"start": stime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                                    "end": etime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}

--- a/src/cbc_sdk/platform/audit.py
+++ b/src/cbc_sdk/platform/audit.py
@@ -31,8 +31,7 @@ from cbc_sdk.errors import ApiError
 from cbc_sdk.platform.jobs import Job
 
 if sys.version_info < (3, 11):
-    from backports._datetime_fromisoformat import MonkeyPatch
-    MonkeyPatch.patch_fromisoformat()
+    from backports._datetime_fromisoformat import datetime_fromisoformat
 
 
 """Model Class"""
@@ -175,9 +174,15 @@ class AuditLogQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupportM
             etime = kwargs["end"]
             try:
                 if isinstance(stime, str):
-                    stime = datetime.fromisoformat(stime)
+                    if sys.version_info < (3, 11):
+                        stime = datetime_fromisoformat(stime)
+                    else:
+                        stime = datetime.datetime.fromisoformat(stime)
                 if isinstance(etime, str):
-                    etime = datetime.fromisoformat(etime)
+                    if sys.version_info < (3, 11):
+                        etime = datetime_fromisoformat(etime)
+                    else:
+                        etime = datetime.datetime.fromisoformat(etime)
                 if isinstance(stime, datetime.datetime) and isinstance(etime, datetime.datetime):
                     time_filter = {"start": stime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                                    "end": etime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}

--- a/src/cbc_sdk/platform/audit.py
+++ b/src/cbc_sdk/platform/audit.py
@@ -22,13 +22,17 @@ with their IP to help determine if the User/API key are from an expected source.
 """
 
 import datetime
+import sys
+
 from cbc_sdk.base import (UnrefreshableModel, BaseQuery, QueryBuilder, QueryBuilderSupportMixin,
                           CriteriaBuilderSupportMixin, ExclusionBuilderSupportMixin, IterableQueryMixin,
                           AsyncQueryMixin)
 from cbc_sdk.errors import ApiError
 from cbc_sdk.platform.jobs import Job
 
-from backports._datetime_fromisoformat import datetime_fromisoformat
+if sys.version_info < (3, 11):
+    from backports._datetime_fromisoformat import MonkeyPatch
+    MonkeyPatch.patch_fromisoformat()
 
 
 """Model Class"""
@@ -171,9 +175,9 @@ class AuditLogQuery(BaseQuery, QueryBuilderSupportMixin, CriteriaBuilderSupportM
             etime = kwargs["end"]
             try:
                 if isinstance(stime, str):
-                    stime = datetime_fromisoformat(stime)
+                    stime = datetime.fromisoformat(stime)
                 if isinstance(etime, str):
-                    etime = datetime_fromisoformat(etime)
+                    etime = datetime.fromisoformat(etime)
                 if isinstance(stime, datetime.datetime) and isinstance(etime, datetime.datetime):
                     time_filter = {"start": stime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                                    "end": etime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
#520 

## Pull Request Description
This is an implementation of a conditional `backports._datetime_fromisoformat` depedency based on the python version. The `MonkeyPatch `method is the default usage recommended on https://github.com/movermeyer/backports.datetime_fromisoformat

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Should be transparent to user before and after 3.11, as `backports._datetime_fromisoformat` backports the `datetime.fromisoformat` functionality identically. Would simplify installation process by removing the need of a C compiler on the machine for engineers using python 3.11 or 3.12.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
Only minimal tests done to ensure implementation worked. May need further evaluation.