### PR TITLE
DSER-50836: CB Defense / EEDR: Live Response API, large file transfers (downloads) are failing with 201 Status Code

### DIFF
--- a/src/cbc_sdk/live_response_api.py
+++ b/src/cbc_sdk/live_response_api.py
@@ -211,7 +211,7 @@ class CbLRSessionBase(object):
             object: Contains the data of the file.
         """
         file_id, command_id = self._submit_get_file(file_name)
-        if file_id and command_id:
+        if file_id is not None and command_id is not None:
             if async_mode:
                 return command_id, self._async_submit(lambda arg, kwarg: self._get_raw_file(command_id,
                                                                                             file_id,

--- a/src/tests/unit/fixtures/live_response/mock_command.py
+++ b/src/tests/unit/fixtures/live_response/mock_command.py
@@ -125,7 +125,7 @@ GET_FILE_COMMAND_RESP = {
         "count": 0,
         "file_id": "f0245f97-67dd-42c4-9548-b35dca12f185"
     },
-    "id": 7,
+    "id": 0,
     "name": "get file",
     "result_code": 0,
     "result_desc": "",

--- a/src/tests/unit/test_live_response_api.py
+++ b/src/tests/unit/test_live_response_api.py
@@ -465,7 +465,7 @@ def test_get_file(cbcsdk_mock, connection_mock):
     cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/devices/2468', DEVICE_RESPONSE)
     cbcsdk_mock.mock_request('POST', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands',
                              GET_FILE_COMMAND_RESP)
-    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/7',
+    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/0',
                              GET_FILE_END_RESP)
     cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468', None)
     manager = LiveResponseSessionManager(cbcsdk_mock.api)
@@ -480,7 +480,7 @@ def test_get_file_cancelled(cbcsdk_mock, connection_mock):
     cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/devices/2468', DEVICE_RESPONSE)
     cbcsdk_mock.mock_request('POST', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands',
                              GET_FILE_COMMAND_RESP)
-    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/7',
+    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/0',
                              GET_FILE_CANCELLED_RESP)
     cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468', None)
     manager = LiveResponseSessionManager(cbcsdk_mock.api)
@@ -497,7 +497,7 @@ def test_get_file_cancelled_async(cbcsdk_mock, connection_mock):
     cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/devices/2468', DEVICE_RESPONSE)
     cbcsdk_mock.mock_request('POST', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands',
                              GET_FILE_COMMAND_RESP)
-    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/7',
+    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/0',
                              GET_FILE_CANCELLED_RESP)
     cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468', None)
     manager = LiveResponseSessionManager(cbcsdk_mock.api)
@@ -515,13 +515,13 @@ def test_get_file_async(cbcsdk_mock, connection_mock):
     cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/devices/2468', DEVICE_RESPONSE)
     cbcsdk_mock.mock_request('POST', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands',
                              GET_FILE_COMMAND_RESP)
-    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/7',
+    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/0',
                              GET_FILE_END_RESP)
     cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468', None)
     manager = LiveResponseSessionManager(cbcsdk_mock.api)
     with manager.request_session(2468) as session:
         command_id, _ = session.get_file('c:\\\\test.txt', async_mode=True)
-        assert command_id == 7
+        assert command_id == 0
 
 
 def test_get_raw_file_async(cbcsdk_mock, connection_mock):
@@ -531,13 +531,13 @@ def test_get_raw_file_async(cbcsdk_mock, connection_mock):
     cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/devices/2468', DEVICE_RESPONSE)
     cbcsdk_mock.mock_request('POST', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands',
                              GET_FILE_COMMAND_RESP)
-    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/7',
+    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/0',
                              GET_FILE_END_RESP)
     cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468', None)
     manager = LiveResponseSessionManager(cbcsdk_mock.api)
     with manager.request_session(2468) as session:
         command_id, _ = session.get_raw_file('c:\\\\test.txt', async_mode=True)
-        assert command_id == 7
+        assert command_id == 0
 
 
 def test_command_status(cbcsdk_mock):
@@ -1596,7 +1596,7 @@ def test_get_file_job(cbcsdk_mock, connection_mock):
     cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/devices/2468', DEVICE_RESPONSE)
     cbcsdk_mock.mock_request('POST', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands',
                              GET_FILE_COMMAND_RESP)
-    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/7',
+    cbcsdk_mock.mock_request('GET', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468/commands/0',
                              GET_FILE_END_RESP)
     cbcsdk_mock.mock_request('DELETE', '/appservices/v6/orgs/test/liveresponse/sessions/1:2468', None)
     manager = LiveResponseSessionManager(cbcsdk_mock.api)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
DSER-50836 related to CRE-17921


## Pull Request Description
Fixed bug when command_id=0 then get_raw_file() was always returning NONE

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## How Has This Been Tested?
Test cases updated. 
Tested with standalone script