### PR TITLE
Enforced timeouts for search jobs with zero contacted searchers

### DIFF
--- a/src/cbc_sdk/base.py
+++ b/src/cbc_sdk/base.py
@@ -2339,9 +2339,7 @@ class FacetQuery(BaseQuery, AsyncQueryMixin, QueryBuilderSupportMixin, CriteriaB
         searchers_contacted = result.get("contacted", 0)
         searchers_completed = result.get("completed", 0)
         log.debug("contacted = {}, completed = {}".format(searchers_contacted, searchers_completed))
-        if searchers_contacted == 0:
-            return True
-        if searchers_completed < searchers_contacted:
+        if searchers_contacted == 0 or searchers_completed < searchers_contacted:
             if (time.time() * 1000) - self._submit_time > self._timeout:
                 self._timed_out = True
                 return False

--- a/src/cbc_sdk/endpoint_standard/base.py
+++ b/src/cbc_sdk/endpoint_standard/base.py
@@ -168,10 +168,7 @@ class EnrichedEvent(UnrefreshableModel):
             searchers_contacted = result.get("contacted", 0)
             searchers_completed = result.get("completed", 0)
             log.debug("contacted = {}, completed = {}".format(searchers_contacted, searchers_completed))
-            if searchers_contacted == 0:
-                time.sleep(.5)
-                continue
-            if searchers_completed < searchers_contacted:
+            if searchers_contacted == 0 or searchers_completed < searchers_contacted:
                 if (time.time() * 1000) - submit_time > self._details_timeout:
                     timed_out = True
                     break
@@ -435,9 +432,7 @@ class EnrichedEventQuery(BaseEventQuery):
         searchers_contacted = result.get("contacted", 0)
         searchers_completed = result.get("completed", 0)
         log.debug("contacted = {}, completed = {}".format(searchers_contacted, searchers_completed))
-        if searchers_contacted == 0:
-            return True
-        if searchers_completed < searchers_contacted:
+        if searchers_contacted == 0 or searchers_completed < searchers_contacted:
             if (time.time() * 1000) - self._submit_time > self._timeout:
                 self._timed_out = True
                 return False

--- a/src/cbc_sdk/enterprise_edr/auth_events.py
+++ b/src/cbc_sdk/enterprise_edr/auth_events.py
@@ -185,10 +185,7 @@ class AuthEvent(NewBaseModel):
             completed = result.get("completed", 0)
             log.debug("contacted = {}, completed = {}".format(contacted, completed))
 
-            if contacted == 0:
-                time.sleep(0.5)
-                continue
-            if completed < contacted:
+            if contacted == 0 or completed < contacted:
                 if (time.time() * 1000) - submit_time > timeout:
                     timed_out = True
                     break
@@ -615,9 +612,7 @@ class AuthEventQuery(Query):
         completed = result.get("completed", 0)
         log.debug("contacted = {}, completed = {}".format(contacted, completed))
 
-        if contacted == 0:
-            return True
-        if completed < contacted:
+        if contacted == 0 or completed < contacted:
             if (time.time() * 1000) - self._submit_time > self._timeout:
                 self._timed_out = True
                 return False

--- a/src/cbc_sdk/platform/observations.py
+++ b/src/cbc_sdk/platform/observations.py
@@ -182,10 +182,7 @@ class Observation(NewBaseModel):
             completed = result.get("completed", 0)
             log.debug("contacted = {}, completed = {}".format(contacted, completed))
 
-            if contacted == 0:
-                time.sleep(0.5)
-                continue
-            if completed < contacted:
+            if contacted == 0 or completed < contacted:
                 if (time.time() * 1000) - submit_time > timeout:
                     timed_out = True
                     break
@@ -498,9 +495,7 @@ class ObservationQuery(Query):
         completed = result.get("completed", 0)
         log.debug("contacted = {}, completed = {}".format(contacted, completed))
 
-        if contacted == 0:
-            return True
-        if completed < contacted:
+        if contacted == 0 or completed < contacted:
             if (time.time() * 1000) - self._submit_time > self._timeout:
                 self._timed_out = True
                 return False

--- a/src/cbc_sdk/platform/processes.py
+++ b/src/cbc_sdk/platform/processes.py
@@ -417,10 +417,7 @@ class Process(UnrefreshableModel):
             searchers_contacted = result.get("contacted", 0)
             searchers_completed = result.get("completed", 0)
             log.debug("contacted = {}, completed = {}".format(searchers_contacted, searchers_completed))
-            if searchers_contacted == 0:
-                time.sleep(.5)
-                continue
-            if searchers_completed < searchers_contacted:
+            if searchers_contacted == 0 or searchers_completed < searchers_contacted:
                 if (time.time() * 1000) - submit_time > self._details_timeout:
                     timed_out = True
                     break
@@ -723,9 +720,7 @@ class AsyncProcessQuery(Query):
         searchers_contacted = result.get("contacted", 0)
         searchers_completed = result.get("completed", 0)
         log.debug("contacted = {}, completed = {}".format(searchers_contacted, searchers_completed))
-        if searchers_contacted == 0:
-            return True
-        if searchers_completed < searchers_contacted:
+        if searchers_contacted == 0 or searchers_completed < searchers_contacted:
             if (time.time() * 1000) - self._submit_time > self._timeout:
                 self._timed_out = True
                 return False
@@ -991,9 +986,7 @@ class SummaryQuery(BaseQuery, AsyncQueryMixin, QueryBuilderSupportMixin):
         searchers_contacted = result.get("contacted", 0)
         searchers_completed = result.get("completed", 0)
         log.debug("contacted = {}, completed = {}".format(searchers_contacted, searchers_completed))
-        if searchers_contacted == 0:
-            return True
-        if searchers_completed < searchers_contacted:
+        if searchers_contacted == 0 or searchers_completed < searchers_contacted:
             if (time.time() * 1000) - self._submit_time > self._timeout:
                 self._timed_out = True
                 return False

--- a/src/tests/uat/enriched_events_uat.py
+++ b/src/tests/uat/enriched_events_uat.py
@@ -71,14 +71,11 @@ def wait_till_job_ready(job_id):
         result = get_status_search_job(job_id).json()
         searchers_contacted = result.get("contacted", 0)
         searchers_completed = result.get("completed", 0)
-        if searchers_completed == searchers_contacted:
-            break
-        if searchers_contacted == 0:
-            time.sleep(0.5)
-            continue
-        if searchers_completed < searchers_contacted:
+        if searchers_contacted == 0 or searchers_completed < searchers_contacted:
             if timeout_time < datetime.datetime.now():
                 break
+        else:
+            break
 
         time.sleep(0.5)
 

--- a/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events.py
+++ b/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events.py
@@ -23,6 +23,7 @@ from tests.unit.fixtures.endpoint_standard.mock_enriched_events import (
     POST_ENRICHED_EVENTS_SEARCH_JOB_RESP,
     GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_2,
     GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+    GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED,
     GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_0,
     GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_ZERO_COMP,
     GET_ENRICHED_EVENTS_AGG_JOB_RESULTS_RESP_1,
@@ -132,13 +133,17 @@ def test_enriched_event_details_only(cbcsdk_mock):
     assert results._info["process_pid"][0] == 2000
 
 
-def test_enriched_event_details_timeout(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_ZERO_COMP, id='still-querying'),
+    pytest.param(GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_enriched_event_details_timeout(cbcsdk_mock, search_job_results):
     """Testing EnrichedEvent get_details() timeout handling"""
     cbcsdk_mock.mock_request("POST", "/api/investigate/v2/orgs/test/enriched_events/detail_jobs",
                              POST_ENRICHED_EVENTS_SEARCH_JOB_RESP)
     cbcsdk_mock.mock_request("GET",
                              "/api/investigate/v2/orgs/test/enriched_events/detail_jobs/08ffa932-b633-4107-ba56-8741e929e48b/results",  # noqa: E501
-                             GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_ZERO_COMP)
+                             search_job_results)
 
     api = cbcsdk_mock.api
     event = EnrichedEvent(api, initial_data={'event_id': 'test'})
@@ -296,13 +301,17 @@ def test_enriched_event_timeout(cbcsdk_mock):
     assert query._timeout == 300000
 
 
-def test_enriched_event_timeout_error(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING, id='still-querying'),
+    pytest.param(GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_enriched_event_timeout_error(cbcsdk_mock, search_job_results):
     """Testing that a timeout in EnrichedEvent querying throws a TimeoutError correctly"""
     cbcsdk_mock.mock_request("POST", "/api/investigate/v2/orgs/test/enriched_events/search_jobs",
                              POST_ENRICHED_EVENTS_SEARCH_JOB_RESP)
     cbcsdk_mock.mock_request("GET",
                              "/api/investigate/v2/orgs/test/enriched_events/search_jobs/08ffa932-b633-4107-ba56-8741e929e48b/results?start=0&rows=0",  # noqa: E501
-                             GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING)
+                             search_job_results)
 
     api = cbcsdk_mock.api
     events = api.select(EnrichedEvent).where("event_id:27a278d5150911eb86f1011a55e73b72").timeout(1)

--- a/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events_facet.py
+++ b/src/tests/unit/endpoint_standard/test_endpoint_standard_enriched_events_facet.py
@@ -22,7 +22,8 @@ from tests.unit.fixtures.endpoint_standard.mock_enriched_events_facet import (
     POST_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESP,
     GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_1,
     GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_2,
-    GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING)
+    GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+    GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED)
 
 log = logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG, filename='log.txt')
 
@@ -131,13 +132,17 @@ def test_enriched_event_facet_timeout(cbcsdk_mock):
     assert query._timeout == 300000
 
 
-def test_enriched_event_facet_timeout_error(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING, id='still-querying'),
+    pytest.param(GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_enriched_event_facet_timeout_error(cbcsdk_mock, search_job_results):
     """Testing that a timeout in EnrichedEventQuery throws the right TimeoutError."""
     cbcsdk_mock.mock_request("POST", "/api/investigate/v2/orgs/test/enriched_events/facet_jobs",
                              POST_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESP)
     cbcsdk_mock.mock_request("GET",
                              "/api/investigate/v2/orgs/test/enriched_events/facet_jobs/08ffa932-b633-4107-ba56-8741e929e48b/results",  # noqa: E501
-                             GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING)
+                             search_job_results)
 
     api = cbcsdk_mock.api
     query = api.select(EnrichedEventFacet).where("process_name:some_name").add_facet_field("process_name").timeout(1)

--- a/src/tests/unit/enterprise_edr/test_auth_events.py
+++ b/src/tests/unit/enterprise_edr/test_auth_events.py
@@ -25,15 +25,17 @@ from tests.unit.fixtures.enterprise_edr.mock_auth_events import (
     POST_AUTH_EVENT_SEARCH_JOB_RESP,
     GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP,
     GET_AUTH_EVENT_DETAIL_JOB_RESULTS_RESP,
+    GET_AUTH_EVENT_DETAIL_JOB_RESULTS_RESP_ZERO_CONTACTED,
     GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_ZERO_COMP,
     GET_AUTH_EVENT_SEARCH_JOB_RESULTS_ZERO,
-    GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
     GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_2,
-    GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_0,
+    GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+    GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED,
     POST_AUTH_EVENT_FACET_SEARCH_JOB_RESP,
     GET_AUTH_EVENT_FACET_SEARCH_JOB_RESULTS_RESP_2,
     GET_AUTH_EVENT_FACET_SEARCH_JOB_RESULTS_RESP_1,
     GET_AUTH_EVENT_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+    GET_AUTH_EVENT_FACET_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED,
     GET_AUTH_EVENT_GROUPED_RESULTS_RESP,
     AUTH_EVENT_SEARCH_VALIDATIONS_RESP,
     AUTH_EVENT_SEARCH_SUGGESTIONS_RESP,
@@ -215,7 +217,11 @@ def test_auth_event_details_only(cbcsdk_mock):
     assert results._info["process_pid"][0] == 764
 
 
-def test_auth_event_details_timeout(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_ZERO_COMP, id='still-querying'),
+    pytest.param(GET_AUTH_EVENT_DETAIL_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_auth_event_details_timeout(cbcsdk_mock, search_job_results):
     """Testing AuthEvent get_details() timeout handling"""
     cbcsdk_mock.mock_request(
         "POST",
@@ -225,7 +231,7 @@ def test_auth_event_details_timeout(cbcsdk_mock):
     cbcsdk_mock.mock_request(
         "GET",
         "/api/investigate/v2/orgs/test/auth_events/detail_jobs/62be5c2c-d080-4ce6-b4f3-7c519cc2b41c-sqs/results",  # noqa: E501
-        GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_ZERO_COMP,
+        search_job_results,
     )
 
     api = cbcsdk_mock.api
@@ -433,7 +439,11 @@ def test_auth_event_timeout(cbcsdk_mock):
     assert query._timeout == 300000
 
 
-def test_auth_event_timeout_error(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING, id='still-querying'),
+    pytest.param(GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_auth_event_timeout_error(cbcsdk_mock, search_job_results):
     """Testing that a timeout in AuthEvent querying throws a TimeoutError correctly"""
     cbcsdk_mock.mock_request(
         "GET",
@@ -448,7 +458,7 @@ def test_auth_event_timeout_error(cbcsdk_mock):
     cbcsdk_mock.mock_request(
         "GET",
         "/api/investigate/v2/orgs/test/auth_events/search_jobs/62be5c2c-d080-4ce6-b4f3-7c519cc2b41c-sqs/results",  # noqa: E501
-        GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+        search_job_results,
     )
 
     api = cbcsdk_mock.api
@@ -596,7 +606,7 @@ def test_auth_event_still_querying(cbcsdk_mock):
     cbcsdk_mock.mock_request(
         "GET",
         "/api/investigate/v2/orgs/test/auth_events/search_jobs/62be5c2c-d080-4ce6-b4f3-7c519cc2b41c-sqs/results",  # noqa: E501
-        GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_0,
+        GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED,
     )
     cbcsdk_mock.mock_request(
         "GET",
@@ -767,7 +777,11 @@ def test_auth_event_facet_timeout(cbcsdk_mock):
     assert query._timeout == 300000
 
 
-def test_auth_event_facet_timeout_error(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_AUTH_EVENT_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING, id='still-querying'),
+    pytest.param(GET_AUTH_EVENT_FACET_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_auth_event_facet_timeout_error(cbcsdk_mock, search_job_results):
     """Testing that a timeout in AuthEventQuery throws the right TimeoutError."""
     cbcsdk_mock.mock_request(
         "POST",
@@ -777,7 +791,7 @@ def test_auth_event_facet_timeout_error(cbcsdk_mock):
     cbcsdk_mock.mock_request(
         "GET",
         "/api/investigate/v2/orgs/test/auth_events/facet_jobs/62be5c2c-d080-4ce6-b4f3-7c519cc2b41c-sqs/results",  # noqa: E501
-        GET_AUTH_EVENT_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+        search_job_results,
     )
 
     api = cbcsdk_mock.api

--- a/src/tests/unit/fixtures/endpoint_standard/mock_enriched_events.py
+++ b/src/tests/unit/fixtures/endpoint_standard/mock_enriched_events.py
@@ -137,6 +137,14 @@ GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING = {
     "results": [],
 }
 
+GET_ENRICHED_EVENTS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED = {
+    "num_found": 0,
+    "num_available": 0,
+    "contacted": 0,
+    "completed": 0,
+    "results": [],
+}
+
 GET_ENRICHED_EVENTS_AGG_JOB_RESULTS_RESP_1 = {
     "results": [
         {

--- a/src/tests/unit/fixtures/endpoint_standard/mock_enriched_events_facet.py
+++ b/src/tests/unit/fixtures/endpoint_standard/mock_enriched_events_facet.py
@@ -72,3 +72,11 @@ GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING = {
     'contacted': 34,
     'completed': 0
 }
+
+GET_ENRICHED_EVENTS_FACET_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED = {
+    'ranges': [],
+    'terms': [],
+    'num_found': 0,
+    'contacted': 0,
+    'completed': 0
+}

--- a/src/tests/unit/fixtures/enterprise_edr/mock_auth_events.py
+++ b/src/tests/unit/fixtures/enterprise_edr/mock_auth_events.py
@@ -59,7 +59,7 @@ GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP = {
 }
 
 
-GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_0 = {
+GET_AUTH_EVENT_DETAIL_JOB_RESULTS_RESP_ZERO_CONTACTED = {
     "results": [],
     "num_found": 0,
     "num_available": 0,
@@ -174,6 +174,15 @@ GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING = {
     "num_found": 808,
     "num_available": 1,
     "contacted": 6,
+    "completed": 0,
+    "results": [],
+}
+
+
+GET_AUTH_EVENT_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED = {
+    "num_found": 0,
+    "num_available": 0,
+    "contacted": 0,
     "completed": 0,
     "results": [],
 }
@@ -318,6 +327,15 @@ GET_AUTH_EVENT_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING = {
     "terms": [],
     "num_found": 0,
     "contacted": 34,
+    "completed": 0,
+}
+
+
+GET_AUTH_EVENT_FACET_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED = {
+    "ranges": [],
+    "terms": [],
+    "num_found": 0,
+    "contacted": 0,
     "completed": 0,
 }
 

--- a/src/tests/unit/fixtures/platform/mock_observations.py
+++ b/src/tests/unit/fixtures/platform/mock_observations.py
@@ -225,6 +225,15 @@ GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING = {
 }
 
 
+GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED = {
+    "num_found": 0,
+    "num_available": 0,
+    "contacted": 0,
+    "completed": 0,
+    "results": [],
+}
+
+
 GET_OBSERVATIONS_DETAIL_JOB_RESULTS_RESP = {
     "approximate_unaggregated": 2,
     "completed": 4,
@@ -556,6 +565,15 @@ GET_OBSERVATIONS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING = {
     "terms": [],
     "num_found": 0,
     "contacted": 34,
+    "completed": 0,
+}
+
+
+GET_OBSERVATIONS_FACET_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED = {
+    "ranges": [],
+    "terms": [],
+    "num_found": 0,
+    "contacted": 0,
     "completed": 0,
 }
 

--- a/src/tests/unit/fixtures/platform/mock_process.py
+++ b/src/tests/unit/fixtures/platform/mock_process.py
@@ -2595,6 +2595,11 @@ GET_PROCESS_DETAILS_JOB_STATUS_IN_PROGRESS_RESP = {
     'completed': 8
 }
 
+GET_PROCESS_DETAILS_JOB_STATUS_RESP_ZERO_CONTACTED = {
+    'contacted': 0,
+    'completed': 0
+}
+
 GET_PROCESS_DETAILS_JOB_RESULTS_RESP = {
     'contacted': 16,
     'completed': 16,

--- a/src/tests/unit/platform/test_alertsv7_api.py
+++ b/src/tests/unit/platform/test_alertsv7_api.py
@@ -76,7 +76,8 @@ from tests.unit.fixtures.platform.mock_process import (
 from tests.unit.fixtures.platform.mock_observations import (
     POST_OBSERVATIONS_SEARCH_JOB_RESP,
     GET_OBSERVATIONS_DETAIL_JOB_RESULTS_RESP,
-    GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING
+    GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+    GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED
 )
 
 from tests.unit.fixtures.platform.mock_alert_v6_v7_compatibility import (
@@ -1135,7 +1136,11 @@ def test_get_observations_invalid(cbcsdk_mock):
         alert.get_observations()
 
 
-def test_get_observations_with_timeout(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING, id='still-querying'),
+    pytest.param(GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_get_observations_with_timeout(cbcsdk_mock, search_job_results):
     """Test get_observations method."""
     cbcsdk_mock.mock_request("GET",
                              "/api/alerts/v7/orgs/test/alerts/86123310980efd0b38111eba4bfa5e98aa30b19",
@@ -1148,7 +1153,7 @@ def test_get_observations_with_timeout(cbcsdk_mock):
     cbcsdk_mock.mock_request(
         "GET",
         "/api/investigate/v2/orgs/test/observations/detail_jobs/08ffa932-b633-4107-ba56-8741e929e48b/results",
-        GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING
+        search_job_results
     )
 
     api = cbcsdk_mock.api

--- a/src/tests/unit/platform/test_observations.py
+++ b/src/tests/unit/platform/test_observations.py
@@ -26,6 +26,7 @@ from tests.unit.fixtures.platform.mock_observations import (
     POST_OBSERVATIONS_SEARCH_JOB_RESP,
     GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_2,
     GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+    GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED,
     GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_0,
     GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_COMP,
     GET_OBSERVATIONS_DETAIL_JOB_RESULTS_RESP,
@@ -38,6 +39,7 @@ from tests.unit.fixtures.platform.mock_observations import (
     GET_OBSERVATIONS_FACET_SEARCH_JOB_RESULTS_RESP_1,
     GET_OBSERVATIONS_FACET_SEARCH_JOB_RESULTS_RESP_2,
     GET_OBSERVATIONS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+    GET_OBSERVATIONS_FACET_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED,
     GET_OBSERVATIONS_GROUPED_RESULTS_RESP,
     OBSERVATIONS_SEARCH_VALIDATIONS_RESP,
     OBSERVATIONS_SEARCH_SUGGESTIONS_RESP,
@@ -238,7 +240,11 @@ def test_observations_details_only(cbcsdk_mock):
     assert results._info["process_pid"][0] == 2000
 
 
-def test_observations_details_timeout(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_COMP, id='still-querying'),
+    pytest.param(GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_observations_details_timeout(cbcsdk_mock, search_job_results):
     """Testing Observation get_details() timeout handling"""
     cbcsdk_mock.mock_request(
         "POST",
@@ -248,7 +254,7 @@ def test_observations_details_timeout(cbcsdk_mock):
     cbcsdk_mock.mock_request(
         "GET",
         "/api/investigate/v2/orgs/test/observations/detail_jobs/08ffa932-b633-4107-ba56-8741e929e48b/results",  # noqa: E501
-        GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_COMP,
+        search_job_results,
     )
 
     api = cbcsdk_mock.api
@@ -466,7 +472,11 @@ def test_observations_timeout(cbcsdk_mock):
     assert query._timeout == 300000
 
 
-def test_observations_timeout_error(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING, id='still-querying'),
+    pytest.param(GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_observations_timeout_error(cbcsdk_mock, search_job_results):
     """Testing that a timeout in Observation querying throws a TimeoutError correctly"""
     cbcsdk_mock.mock_request(
         "GET",
@@ -481,7 +491,7 @@ def test_observations_timeout_error(cbcsdk_mock):
     cbcsdk_mock.mock_request(
         "GET",
         "/api/investigate/v2/orgs/test/observations/search_jobs/08ffa932-b633-4107-ba56-8741e929e48b/results",  # noqa: E501
-        GET_OBSERVATIONS_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+        search_job_results,
     )
 
     api = cbcsdk_mock.api
@@ -841,7 +851,11 @@ def test_observation_facet_timeout(cbcsdk_mock):
     assert query._timeout == 300000
 
 
-def test_observation_facet_timeout_error(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_OBSERVATIONS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING, id='still-querying'),
+    pytest.param(GET_OBSERVATIONS_FACET_SEARCH_JOB_RESULTS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_observation_facet_timeout_error(cbcsdk_mock, search_job_results):
     """Testing that a timeout in ObservationQuery throws the right TimeoutError."""
     cbcsdk_mock.mock_request(
         "POST",
@@ -851,7 +865,7 @@ def test_observation_facet_timeout_error(cbcsdk_mock):
     cbcsdk_mock.mock_request(
         "GET",
         "/api/investigate/v2/orgs/test/observations/facet_jobs/08ffa932-b633-4107-ba56-8741e929e48b/results",  # noqa: E501
-        GET_OBSERVATIONS_FACET_SEARCH_JOB_RESULTS_RESP_STILL_QUERYING,
+        search_job_results,
     )
 
     api = cbcsdk_mock.api

--- a/src/tests/unit/platform/test_platform_process.py
+++ b/src/tests/unit/platform/test_platform_process.py
@@ -43,6 +43,7 @@ from tests.unit.fixtures.platform.mock_process import (GET_PROCESS_SUMMARY_RESP,
                                                        GET_PROCESS_SEARCH_PARENT_JOB_RESULTS_RESP,
                                                        POST_PROCESS_DETAILS_JOB_RESP,
                                                        GET_PROCESS_DETAILS_JOB_STATUS_IN_PROGRESS_RESP,
+                                                       GET_PROCESS_DETAILS_JOB_STATUS_RESP_ZERO_CONTACTED,
                                                        GET_PROCESS_DETAILS_JOB_RESULTS_RESP,
                                                        GET_FACET_SEARCH_RESULTS_RESP,
                                                        EXPECTED_PROCESS_FACETS,
@@ -1291,13 +1292,17 @@ def test_process_get_details_async(cbcsdk_mock):
     assert 10222 in results['process_pid']
 
 
-def test_process_get_details_timeout(cbcsdk_mock):
+@pytest.mark.parametrize('search_job_results', [
+    pytest.param(GET_PROCESS_DETAILS_JOB_STATUS_IN_PROGRESS_RESP, id='still-querying'),
+    pytest.param(GET_PROCESS_DETAILS_JOB_STATUS_RESP_ZERO_CONTACTED, id='zero-contacted'),
+])
+def test_process_get_details_timeout(cbcsdk_mock, search_job_results):
     """Test the timeout of a get_details request."""
     cbcsdk_mock.mock_request("POST", "/api/investigate/v2/orgs/test/processes/detail_jobs",
                              POST_PROCESS_DETAILS_JOB_RESP)
     cbcsdk_mock.mock_request("GET",
                              "/api/investigate/v2/orgs/test/processes/detail_jobs/ccc47a52-9a61-4c77-8652-8a03dc187b98/results",  # noqa: E501
-                             GET_PROCESS_DETAILS_JOB_STATUS_IN_PROGRESS_RESP)
+                             search_job_results)
     api = cbcsdk_mock.api
     process = Process(api, '80dab519-3b5f-4502-afad-da87cd58a4c3',
                       {'process_guid': '80dab519-3b5f-4502-afad-da87cd58a4c3'})


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code, linter).
- [x] A self-review of the code has been done.

## What is the ticket or issue number?
N/A

## Pull Request Description
This PR enforces timeouts for search jobs with zero contacted searchers. I encountered an infinite loop when calling `list(cb.select(Process).where(search_string).timeout(15000))` in a new org that didn't yet have data.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?
I verified `list(cb.select(Process).where(search_string).timeout(15000))` now times out after 15 seconds in an org without data.
